### PR TITLE
fix: 添付ファイルの拡張子判定を大文字・小文字非依存にする（.PDF 等が弾かれる不具合）

### DIFF
--- a/genai-web/packages/web/src/hooks/useFiles.ts
+++ b/genai-web/packages/web/src/hooks/useFiles.ts
@@ -102,7 +102,10 @@ const useFilesState = create<{
       }
 
       // 許可されたファイルタイプをフィルタリング
-      const mediaFormat = ('.' + uploadedFile.file.name.split('.').pop()) as string;
+      // 拡張子は大文字・小文字を区別せず判定する（例: 役所文書の `.PDF`）
+      const mediaFormat = (
+        '.' + uploadedFile.file.name.split('.').pop()
+      ).toLowerCase();
       const isFileTypeAllowed = accept.includes(mediaFormat);
       if (accept && accept.length === 0) {
         errorMessages.push(`このモデルはファイルに対応していません。`);


### PR DESCRIPTION
## 概要

チャットのファイル添付ダイアログで、**大文字の拡張子（例: `.PDF`）を持つファイルが「許可されていない拡張子です」と拒否される**不具合を修正します。

## 再現手順

1. チャット画面でファイル添付を開く
2. 拡張子が大文字のファイル（例: `R70743423961021230211014304.PDF`）を選択
3. `... は許可されていない拡張子です。利用できる拡張子は .csv, .doc, .docx, .html, .md, .pdf, .txt, .xls, .xlsx, .gif です` と表示され添付できない

## 原因

`packages/web/src/hooks/useFiles.ts` の拡張子判定で、許可リストは小文字（`.pdf` 等）である一方、ファイル名から取り出した拡張子をそのまま比較していました。

```ts
const mediaFormat = ('.' + uploadedFile.file.name.split('.').pop()) as string; // ".PDF"
const isFileTypeAllowed = accept.includes(mediaFormat);                        // accept は小文字のみ → false
```

## 修正

比較前に拡張子を `.toLowerCase()` するようにしました（1行の追加）。`.PDF` / `.PdF` などの大文字混在も許可されるようになります。

## 影響・補足

- 日本の行政文書はファイル名の拡張子が大文字（例: `R7…304.PDF`）のことが多く、実運用で添付できない不具合につながっていました。
- 副作用はありません（小文字ファイルはこれまで通り許可、リスト外の拡張子は引き続き拒否）。
- backend 側の添付テキスト抽出は拡張子を既に小文字化して判定しているため、フロントの判定を通せば PDF/Word/Excel 等の本文抽出まで正常に動作します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)