### PR TITLE
fix: genai-webの.env.exampleのVITE_APP_MODEL_IDSデフォルト値の修正とREADMEの'使い方'を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ ollama pull qwen2.5:7b
 cp .env.example .env    # 必要に応じて DEFAULT_MODEL などを編集
 ```
 
+```bash
+cp genai-web/packages/web/.env.example genai-web/packages/web/.env    # 必要に応じて VITE_APP_MODEL_IDS などを編集
+```
+
 利用したいモデルを増やす場合は `genai-web/packages/web/.env` の
 `VITE_APP_MODEL_IDS`（Ollama のモデル名と一致させる）を編集してください。
 モデルの表示名は `genai-web/packages/common/src/application/model.ts` に定義しています。

--- a/genai-web/packages/web/.env.example
+++ b/genai-web/packages/web/.env.example
@@ -8,7 +8,7 @@ VITE_APP_API_ENDPOINT=http://localhost/api
 VITE_APP_TEAM_ACCESS_CONTROL_API_ENDPOINT=http://localhost/api
 
 # --- 利用可能なモデル（Ollama のモデル名と一致させる） ---
-VITE_APP_MODEL_IDS=["gpt-oss:20b","gemma3:27b"]
+VITE_APP_MODEL_IDS=["qwen2.5:7b"]
 VITE_APP_IMAGE_MODEL_IDS=["local-sd"]
 VITE_APP_ENDPOINT_NAMES=[]
 


### PR DESCRIPTION
Issue #2 の 案A) での修正案です。