### PR TITLE
fix: SAML proxy headers and production static web build

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -101,6 +101,9 @@ def get_saml_settings() -> dict[str, Any]:
             "requestedAuthnContext": False,
             # InResponseTo を保存しないため未要求応答を許可
             "rejectUnsolicitedResponsesWithInResponseTo": False,
+            # Keycloak の role_list は Role 属性を Name 重複で送ることがある。
+            # アプリ認可は groups マッパーを使うため、重複 Attribute を許容する。
+            "allowRepeatAttributeName": True,
         },
     }
     _settings_cache = settings

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1053,11 +1053,19 @@ async def _prepare_saml_request(request: Request) -> dict[str, Any]:
     if request.method == "POST":
         raw = await request.form()
         form = {k: v for k, v in raw.items()}
-    host = request.headers.get("host", "localhost:8000")
-    server_port = host.split(":")[1] if ":" in host else (
-        "443" if request.url.scheme == "https" else "80"
-    )
+    # リバースプロキシ配下では request.url.scheme が http のままになるため、
+    # X-Forwarded-* を優先して Recipient 検証用の公開 URL を組み立てる。
     forwarded_proto = request.headers.get("x-forwarded-proto", request.url.scheme)
+    host = request.headers.get("x-forwarded-host") or request.headers.get(
+        "host", "localhost:8000"
+    )
+    forwarded_port = request.headers.get("x-forwarded-port")
+    if forwarded_port:
+        server_port = forwarded_port
+    elif ":" in host:
+        server_port = host.split(":", 1)[1]
+    else:
+        server_port = "443" if forwarded_proto == "https" else "80"
     return {
         "https": "on" if forwarded_proto == "https" else "off",
         "http_host": host,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1112,11 +1112,20 @@ async def auth_login(request: Request) -> Response:
 async def auth_acs(request: Request) -> Response:
     req = await _prepare_saml_request(request)
     saml_auth = auth.build_saml_auth(req)
-    saml_auth.process_response()
-    errors = saml_auth.get_errors()
     relay = req["post_data"].get("RelayState") or FRONTEND_URL
     target = relay if str(relay).startswith("http") else FRONTEND_URL
 
+    try:
+        saml_auth.process_response()
+    except Exception as exc:  # noqa: BLE001 — IdP 応答の検証例外をログイン失敗へ落とす
+        reason = str(exc) or type(exc).__name__
+        print(f"[auth] SAML 検証例外: {reason}")
+        audit.record(
+            request, action="auth.login", status=401, output_text=f"SAML検証例外: {reason}"
+        )
+        return RedirectResponse(f"{FRONTEND_URL}/auth-error", status_code=303)
+
+    errors = saml_auth.get_errors()
     if errors or not saml_auth.is_authenticated():
         reason = saml_auth.get_last_error_reason() or ",".join(errors)
         print(f"[auth] SAML 検証失敗: {reason}")

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -151,23 +151,13 @@ services:
   web:
     build:
       context: ./genai-web
-      dockerfile: Dockerfile.local
+      dockerfile: Dockerfile.prod
+      args:
+        VITE_APP_API_ENDPOINT: /api
+        VITE_APP_TEAM_ACCESS_CONTROL_API_ENDPOINT: /api
     container_name: open-genai-web
     expose:
-      - "5173"
-    environment:
-      - VITE_USE_POLLING=true
-      - VITE_APP_API_ENDPOINT=/api
-      - VITE_APP_TEAM_ACCESS_CONTROL_API_ENDPOINT=/api
-      # proxy 経由の公開ホスト名を Vite に許可させる（例: genai.example.lg.jp）
-      - VITE_ALLOWED_HOSTS=${VITE_ALLOWED_HOSTS:-true}
-    volumes:
-      - ./genai-web:/app
-      - web_node_modules:/app/node_modules
-      - web_pkg_web_node_modules:/app/packages/web/node_modules
-      - web_pkg_common_node_modules:/app/packages/common/node_modules
-      - web_pkg_types_node_modules:/app/packages/types/node_modules
-      - web_pkg_cdk_node_modules:/app/packages/cdk/node_modules
+      - "80"
     depends_on:
       - backend
     restart: unless-stopped

--- a/genai-web/Dockerfile.prod
+++ b/genai-web/Dockerfile.prod
@@ -1,0 +1,29 @@
+# Open GENAI: 本番向け静的ビルドを nginx で配信する
+FROM node:22.22.2-bookworm-slim AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY packages/web/package.json packages/web/package.json
+COPY packages/cdk/package.json packages/cdk/package.json
+COPY packages/common/package.json packages/common/package.json
+COPY packages/types/package.json packages/types/package.json
+
+RUN npm install
+
+COPY . .
+
+# ビルド時に埋め込む公開エンドポイント（compose の build.args で上書き可）
+ARG VITE_APP_API_ENDPOINT=/api
+ARG VITE_APP_TEAM_ACCESS_CONTROL_API_ENDPOINT=/api
+ENV VITE_APP_API_ENDPOINT=${VITE_APP_API_ENDPOINT} \
+    VITE_APP_TEAM_ACCESS_CONTROL_API_ENDPOINT=${VITE_APP_TEAM_ACCESS_CONTROL_API_ENDPOINT}
+
+RUN npm run web:build
+
+FROM nginx:1.27-alpine
+
+COPY --from=build /app/packages/web/dist /usr/share/nginx/html
+COPY packages/web/nginx.spa.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80

--- a/genai-web/packages/web/nginx.spa.conf
+++ b/genai-web/packages/web/nginx.spa.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA: 実ファイルがなければ index.html へフォールバック
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # ハッシュ付きアセットは長期キャッシュ
+    location /assets/ {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+}

--- a/genai-web/packages/web/src/components/ui/AccountMenu.tsx
+++ b/genai-web/packages/web/src/components/ui/AccountMenu.tsx
@@ -7,21 +7,25 @@ type Props = {
   className?: string;
   isShowTeamManagementMenu: boolean;
   onClickSignout: () => void;
+  /** ログイン中の表示名（ユーザ名）。未取得時は「アカウント」 */
+  userDisplayName?: string;
 };
 
 export const AccountMenu = (props: Props) => {
-  const { className, isShowTeamManagementMenu, onClickSignout } = props;
+  const { className, isShowTeamManagementMenu, onClickSignout, userDisplayName } = props;
+  const label = userDisplayName?.trim() || 'アカウント';
 
   return (
     <div className={`group relative h-full ${className ?? ''}`}>
       <Menu>
         <MenuButton
-          className={`flex h-full w-fit items-center gap-1 px-2 text-dns-16B-130 hover:bg-solid-gray-50 hover:underline hover:underline-offset-[calc(3/16*1rem)] data-active:bg-solid-gray-50 focus-visible:data-focus:rounded-4 focus-visible:data-focus:bg-yellow-300 focus-visible:data-focus:ring-[calc(6/16*1rem)] focus-visible:data-focus:ring-yellow-300 focus-visible:data-focus:outline-4 focus-visible:data-focus:-outline-offset-4 focus-visible:data-focus:outline-black focus-visible:data-focus:outline-solid focus-visible:data-focus:ring-inset lg:px-4 focus-visible:[&:not(data-focus)]:outline-hidden`}
+          className={`flex h-full w-fit max-w-56 items-center gap-1 px-2 text-dns-16B-130 hover:bg-solid-gray-50 hover:underline hover:underline-offset-[calc(3/16*1rem)] data-active:bg-solid-gray-50 focus-visible:data-focus:rounded-4 focus-visible:data-focus:bg-yellow-300 focus-visible:data-focus:ring-[calc(6/16*1rem)] focus-visible:data-focus:ring-yellow-300 focus-visible:data-focus:outline-4 focus-visible:data-focus:-outline-offset-4 focus-visible:data-focus:outline-black focus-visible:data-focus:outline-solid focus-visible:data-focus:ring-inset lg:px-4 focus-visible:[&:not(data-focus)]:outline-hidden`}
+          title={label}
         >
           {({ active }) => (
             <>
               <AccountIcon isFilled={active} />
-              <span>アカウント</span>
+              <span className='truncate'>{label}</span>
               <ArrowDownIcon className={`mt-0.5 ${active ? 'rotate-180' : ''}`} />
             </>
           )}
@@ -30,6 +34,17 @@ export const AccountMenu = (props: Props) => {
           modal={false}
           className={`absolute top-full right-4 z-30 w-auto min-w-fit rounded-8 border border-solid-gray-420 bg-white py-2 shadow-1 focus:outline-hidden`}
         >
+          {userDisplayName?.trim() && (
+            <div
+              className='px-4 py-2 text-oln-16N-100 text-solid-gray-600 border-b border-solid-gray-420 mb-1'
+              role='presentation'
+            >
+              <p className='text-dns-14N-130 text-solid-gray-600'>ログイン中</p>
+              <p className='truncate font-bold text-solid-gray-800' title={userDisplayName}>
+                {userDisplayName}
+              </p>
+            </div>
+          )}
           {isShowTeamManagementMenu && (
             <MenuItem>
               {({ focus }) => (

--- a/genai-web/packages/web/src/components/ui/Header.tsx
+++ b/genai-web/packages/web/src/components/ui/Header.tsx
@@ -20,6 +20,11 @@ export const Header = (props: Props) => {
   const { data } = useAuth();
   const groups =
     (data?.tokens?.accessToken.payload['cognito:groups'] as unknown as string[] | undefined) ?? [];
+  const userDisplayName =
+    (data?.tokens?.accessToken.payload['username'] as string | undefined) ||
+    (data?.tokens?.idToken.payload['cognito:username'] as string | undefined) ||
+    (data?.tokens?.idToken.payload['email'] as string | undefined) ||
+    '';
 
   const { cache } = useSWRConfig();
 
@@ -54,6 +59,7 @@ export const Header = (props: Props) => {
         <div className='hidden ml-auto md:flex h-full'>
           <AccountMenu
             onClickSignout={onClickSignout}
+            userDisplayName={userDisplayName}
             isShowTeamManagementMenu={
               groups.includes('SystemAdminGroup') || groups.includes('TeamAdminGroup')
             }
@@ -73,6 +79,7 @@ export const Header = (props: Props) => {
           ref={mobileMenuRef}
           onClose={() => mobileMenuRef.current?.close()}
           onClickSignout={onClickSignout}
+          userDisplayName={userDisplayName}
           isShowTeamManagementMenu={
             groups.includes('SystemAdminGroup') || groups.includes('TeamAdminGroup')
           }

--- a/genai-web/packages/web/src/components/ui/mobile-menu/MobileMenu.tsx
+++ b/genai-web/packages/web/src/components/ui/mobile-menu/MobileMenu.tsx
@@ -9,10 +9,13 @@ type Props = ComponentProps<'dialog'> & {
   isShowTeamManagementMenu: boolean;
   onClickSignout: () => void;
   onClose: () => void;
+  /** ログイン中の表示名（ユーザ名）。未取得時は「アカウント」 */
+  userDisplayName?: string;
 };
 
 export const MobileMenu = forwardRef<HTMLDialogElement, Props>((props, ref) => {
-  const { isShowTeamManagementMenu, onClickSignout, onClose, ...rest } = props;
+  const { isShowTeamManagementMenu, onClickSignout, onClose, userDisplayName, ...rest } = props;
+  const accountLabel = userDisplayName?.trim() || 'アカウント';
 
   return (
     <dialog
@@ -49,10 +52,15 @@ export const MobileMenu = forwardRef<HTMLDialogElement, Props>((props, ref) => {
             <Divider />
             <div>
               <MobileMenuSection
-                label='アカウント'
+                label={accountLabel}
                 icon={(isOpen) => <AccountIcon className='shrink-0' isFilled={isOpen} />}
               >
                 <ul>
+                  {userDisplayName?.trim() && (
+                    <li className='px-4 py-2 text-dns-14N-130 text-solid-gray-600'>
+                      ログイン中: <span className='font-bold text-solid-gray-800'>{userDisplayName}</span>
+                    </li>
+                  )}
                   {isShowTeamManagementMenu && (
                     <li>
                       <MobileMenuItemLink label='チーム管理' to='/teams' />

--- a/genai-web/packages/web/src/features/chat/ChatPage.tsx
+++ b/genai-web/packages/web/src/features/chat/ChatPage.tsx
@@ -42,7 +42,7 @@ export const ChatPage = () => {
     setHasSent,
   } = useChatStore();
 
-  const { pathname, search, state } = useLocation();
+  const { search, state } = useLocation();
   const { usecase, chatId } = useUsecasePath();
   const navigate = useNavigate();
   const { scrollTopAnchorRef, scrollBottomAnchorRef } = useScreen({

--- a/genai-web/packages/web/src/features/generate-image/utils/ensureImagePersistTarget.ts
+++ b/genai-web/packages/web/src/features/generate-image/utils/ensureImagePersistTarget.ts
@@ -45,7 +45,8 @@ export async function ensureImagePersistTarget(params: {
     ],
   });
 
-  const recorded = messages.find((m) => m.messageId === messageId) ?? messages.at(-1);
+  const recorded =
+    messages.find((m) => m.messageId === messageId) ?? messages[messages.length - 1];
   if (!recorded?.messageId) {
     return null;
   }

--- a/genai-web/packages/web/src/routes.tsx
+++ b/genai-web/packages/web/src/routes.tsx
@@ -27,96 +27,59 @@ import { AuthErrorPage } from './pages/AuthErrorPage';
 import { SignedOutPage } from './pages/SignedOutPage';
 
 export const createRoutes = (): RouteObject[] => {
+  const optionalUseCaseRoutes: Array<RouteObject[] | null> = [
+    isUseCaseEnabled('generate')
+      ? [
+          { path: 'generate', element: <GenerateTextPage /> },
+          { path: 'generate/:chatId', element: <GenerateTextPage /> },
+        ]
+      : null,
+    isUseCaseEnabled('translate')
+      ? [
+          { path: 'translate', element: <TranslatePage /> },
+          { path: 'translate/:chatId', element: <TranslatePage /> },
+        ]
+      : null,
+    isUseCaseEnabled('image')
+      ? [
+          { path: 'image', element: <GenerateImagePage /> },
+          { path: 'image/:chatId', element: <GenerateImagePage /> },
+        ]
+      : null,
+    isUseCaseEnabled('diagram')
+      ? [
+          { path: 'diagram', element: <GenerateDiagramPage /> },
+          { path: 'diagram/:chatId', element: <GenerateDiagramPage /> },
+        ]
+      : null,
+  ];
+
+  const children: RouteObject[] = [
+    { index: true, element: <LandingPage /> },
+    { path: 'apps', element: <ExAppsPage /> },
+    { path: 'apps/:teamId/:exAppId', element: <ExAppPage /> },
+    { path: 'chat', element: <ChatPage /> },
+    { path: 'chat/:chatId', element: <ChatPage /> },
+    { path: 'history', element: <ChatHistoryPage /> },
+    ...optionalUseCaseRoutes.flatMap((routes) => routes ?? []),
+    { path: 'transcribe', element: <TranscribePage /> },
+    { path: 'teams', element: <TeamsPage /> },
+    { path: 'teams/create', element: <TeamCreatePage /> },
+    { path: 'teams/:teamId/edit', element: <TeamEditPage /> },
+    { path: 'teams/:teamId/members', element: <TeamMembersPage /> },
+    { path: 'teams/:teamId/members/create', element: <TeamMemberCreatePage /> },
+    { path: 'teams/:teamId/members/:userId/edit', element: <TeamMemberEditPage /> },
+    { path: 'teams/:teamId/apps', element: <TeamAppsPage /> },
+    { path: 'teams/:teamId/apps/create', element: <TeamAppCreatePage /> },
+    { path: 'teams/:teamId/apps/:appId/edit', element: <TeamAppEditPage /> },
+    { path: 'teams/:teamId/apps/:appId/copy', element: <TeamAppCopyPage /> },
+    { path: 'docs/api-request-data-format', element: <ApiRequestDataFormatPage /> },
+    { path: '*', element: <NotFound /> },
+  ];
+
   return [
-    {
-      path: '/signed-out',
-      element: <SignedOutPage />,
-    },
-    {
-      path: '/auth-error',
-      element: <AuthErrorPage />,
-    },
-    {
-      path: '/',
-      element: <Layout />,
-      children: [
-        { index: true, element: <LandingPage /> },
-        {
-          path: 'apps',
-          element: <ExAppsPage />,
-        },
-        { path: 'apps/:teamId/:exAppId', element: <ExAppPage /> },
-        {
-          path: 'chat',
-          element: <ChatPage />,
-        },
-        {
-          path: 'chat/:chatId',
-          element: <ChatPage />,
-        },
-        { path: 'history', element: <ChatHistoryPage /> },
-        isUseCaseEnabled('generate')
-          ? [
-              { path: 'generate', element: <GenerateTextPage /> },
-              { path: 'generate/:chatId', element: <GenerateTextPage /> },
-            ]
-          : null,
-        isUseCaseEnabled('translate')
-          ? [
-              { path: 'translate', element: <TranslatePage /> },
-              { path: 'translate/:chatId', element: <TranslatePage /> },
-            ]
-          : null,
-        isUseCaseEnabled('image')
-          ? [
-              { path: 'image', element: <GenerateImagePage /> },
-              { path: 'image/:chatId', element: <GenerateImagePage /> },
-            ]
-          : null,
-        isUseCaseEnabled('diagram')
-          ? [
-              { path: 'diagram', element: <GenerateDiagramPage /> },
-              { path: 'diagram/:chatId', element: <GenerateDiagramPage /> },
-            ]
-          : null,
-        { path: 'transcribe', element: <TranscribePage /> },
-        { path: 'teams', element: <TeamsPage /> },
-        { path: 'teams/create', element: <TeamCreatePage /> },
-        {
-          path: 'teams/:teamId/edit',
-          element: <TeamEditPage />,
-        },
-        {
-          path: 'teams/:teamId/members',
-          element: <TeamMembersPage />,
-        },
-        {
-          path: 'teams/:teamId/members/create',
-          element: <TeamMemberCreatePage />,
-        },
-        {
-          path: 'teams/:teamId/members/:userId/edit',
-          element: <TeamMemberEditPage />,
-        },
-        {
-          path: 'teams/:teamId/apps',
-          element: <TeamAppsPage />,
-        },
-        {
-          path: 'teams/:teamId/apps/create',
-          element: <TeamAppCreatePage />,
-        },
-        {
-          path: 'teams/:teamId/apps/:appId/edit',
-          element: <TeamAppEditPage />,
-        },
-        {
-          path: 'teams/:teamId/apps/:appId/copy',
-          element: <TeamAppCopyPage />,
-        },
-        { path: 'docs/api-request-data-format', element: <ApiRequestDataFormatPage /> },
-        { path: '*', element: <NotFound /> },
-      ].flatMap((r) => (Array.isArray(r) ? r : r ? [r] : [])),
-    },
-  ].flatMap((r) => (Array.isArray(r) ? r : r ? [r] : []));
+    { path: '/signed-out', element: <SignedOutPage /> },
+    { path: '/auth-error', element: <AuthErrorPage /> },
+    { path: '/', element: <Layout />, children },
+  ];
 };

--- a/genai-web/packages/web/vite.config.ts
+++ b/genai-web/packages/web/vite.config.ts
@@ -3,6 +3,15 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 import { defineConfig } from 'vite';
 
+// 本番はリバースプロキシ配下で稼働するため、外部ホスト名を許可する。
+// VITE_ALLOWED_HOSTS=true で全許可、またはカンマ区切りでホスト名を指定。
+const allowedHosts =
+  process.env.VITE_ALLOWED_HOSTS === 'true'
+    ? true
+    : process.env.VITE_ALLOWED_HOSTS
+      ? process.env.VITE_ALLOWED_HOSTS.split(',')
+      : undefined;
+
 // https://vitejs.dev/config/
 export default defineConfig({
   resolve: {
@@ -16,17 +25,19 @@ export default defineConfig({
   server: {
     host: true,
     port: 5173,
-    // 本番はリバースプロキシ配下で稼働するため、外部ホスト名を許可する。
-    // VITE_ALLOWED_HOSTS=true で全許可、またはカンマ区切りでホスト名を指定。
-    allowedHosts:
-      process.env.VITE_ALLOWED_HOSTS === 'true'
-        ? true
-        : process.env.VITE_ALLOWED_HOSTS
-          ? process.env.VITE_ALLOWED_HOSTS.split(',')
-          : undefined,
+    allowedHosts,
+    fs: {
+      // packages/web/.env 等を Vite が読めるようにモノレポ根まで許可
+      allow: [path.resolve(__dirname, '../..')],
+    },
     watch: {
       usePolling: process.env.VITE_USE_POLLING === 'true',
     },
+  },
+  preview: {
+    host: true,
+    port: 5173,
+    allowedHosts,
   },
   plugins: [
     react(),

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -99,14 +99,12 @@ http {
             proxy_set_header X-Forwarded-Prefix /kc;
         }
 
-        # --- フロントエンド（Vite dev server / HMR WebSocket 対応）---
+        # --- フロントエンド（静的ビルド / nginx）---
         location / {
-            set $web_upstream http://web:5173;
+            set $web_upstream http://web:80;
             proxy_pass $web_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host              $host;
-            proxy_set_header Upgrade           $http_upgrade;
-            proxy_set_header Connection        $connection_upgrade;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -72,6 +72,7 @@ http {
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;
             proxy_set_header X-Forwarded-Host  $host;
+            proxy_set_header X-Forwarded-Port  443;
             proxy_set_header X-Forwarded-Prefix /api;
             # 推論ストリーム(SSE/NDJSON)のためバッファ無効・長時間タイムアウト
             proxy_buffering    off;


### PR DESCRIPTION
## Summary
- HTTPS リバースプロキシ配下で SAML ACS の Recipient 検証が失敗する問題を修正（`X-Forwarded-Host` / `Proto` / `Port` を優先）。
- Keycloak の重複 SAML Attribute で ACS が 500 になる問題を緩和（`allowRepeatAttributeName` + 例外時は auth-error へ）。
- フロントの TypeScript エラーを修正し、本番向け静的ビルド（`Dockerfile.prod` + nginx SPA）で配信できるように変更。

## Test plan
- [ ] HTTPS 公開 URL で Keycloak SAML ログインし、ACS 後にアプリへ戻ること
- [ ] 追加ユーザ／admin の双方でログインできること
- [ ] トップページが `/assets/*.js` の静的配信であること（`/src/*.tsx` を配信しないこと）
- [ ] AI アプリ一覧・利用者一括管理が開けること