### PR TITLE
feat: multiple OpenAI-compatible LLM providers (LLM_PROVIDERS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ OLLAMA_BASE_URL=http://host.docker.internal:11434
 # OPENAI_BASE_URL=http://host.docker.internal:11434/v1
 # OPENAI_API_KEY=ollama
 
+# 複数の OpenAI 互換プロバイダを併用する場合は LLM_PROVIDERS(JSON) を設定。
+# modelId ごとに base_url/キーを振り分ける（詳細は .env.prod.example 参照）。
+# LLM_PROVIDERS=[{"name":"ollama","base_url":"http://host.docker.internal:11434/v1","models":["qwen2.5:7b"]}]
+
 # 既定で利用するモデル（フロントでモデル未選択時に使用）
 DEFAULT_MODEL=qwen2.5:7b
 

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -30,9 +30,29 @@ KC_DB=dev-file
 
 # === LLM 接続（OpenAI 互換）===
 OLLAMA_BASE_URL=http://host.docker.internal:11434
+# --- 単一プロバイダ（後方互換）---
+# OPENAI_BASE_URL / OPENAI_API_KEY を指定すると、その 1 系統だけを使う。
 # OPENAI_BASE_URL=
 # OPENAI_API_KEY=ollama
 DEFAULT_MODEL=qwen2.5:7b
+
+# --- 複数プロバイダ併用（任意）---
+# LLM_PROVIDERS を設定すると modelId ごとに base_url/キーを振り分ける。
+# api_key は api_key_env で環境変数名を参照（秘密は各 *_API_KEY に入れる）。
+# Azure OpenAI は auth_header/api-version が異なるため auth_header と query を指定する。
+# 例（1 行で設定すること）:
+# LLM_PROVIDERS=[
+#   {"name":"sakura","base_url":"https://api.ai.sakura.ad.jp/v1","api_key_env":"SAKURA_API_KEY","models":["gpt-oss-120b","preview/gemma-4-31B-it"]},
+#   {"name":"ollama","base_url":"http://host.docker.internal:11434/v1","models":["qwen2.5:7b","gemma3:27b"]},
+#   {"name":"openai","base_url":"https://api.openai.com/v1","api_key_env":"OPENAI_PROVIDER_API_KEY","models":["gpt-4o-mini"]},
+#   {"name":"gemini","base_url":"https://generativelanguage.googleapis.com/v1beta/openai","api_key_env":"GEMINI_API_KEY","models":["gemini-2.5-flash"]},
+#   {"name":"azure","base_url":"https://<resource>.openai.azure.com/openai/deployments/<deployment>","api_key_env":"AZURE_OPENAI_API_KEY","auth_header":"api-key","auth_prefix":"","query":{"api-version":"2024-10-21"},"models":["<deployment>"]}
+# ]
+LLM_PROVIDERS=
+SAKURA_API_KEY=
+OPENAI_PROVIDER_API_KEY=
+GEMINI_API_KEY=
+AZURE_OPENAI_API_KEY=
 
 # === RAG / 監査 / 各 AI アプリ ===
 EMBED_MODEL=mxbai-embed-large

--- a/backend/app/llm.py
+++ b/backend/app/llm.py
@@ -1,8 +1,9 @@
 """OpenAI 互換 API (/v1/chat/completions, /v1/models) へのプロキシ。
 
-Ollama の OpenAI 互換エンドポイント(http://host:11434/v1)を既定とするが、
-OPENAI_BASE_URL を変えれば vLLM / LM Studio / OpenAI など任意の
-OpenAI 互換サーバに向けられる（ベンダーロックインを避ける）。
+複数の OpenAI 互換プロバイダ（Ollama / さくら / OpenAI / Azure OpenAI / Gemini 等）を
+`LLM_PROVIDERS`(JSON) で登録し、リクエストの modelId からプロバイダを逆引きして
+呼び分ける。`LLM_PROVIDERS` 未設定時は従来どおり単一の `OPENAI_BASE_URL`
+（未指定なら Ollama の /v1）を使う（後方互換）。
 
 源内 Web が要求する「改行区切り JSON (StreamingChunk)」を生成するための
 ヘルパも提供する。
@@ -12,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+from dataclasses import dataclass, field
 from typing import Any, AsyncIterator
 
 import httpx
@@ -28,11 +30,96 @@ DEFAULT_MODEL = os.environ.get("DEFAULT_MODEL", "qwen2.5:7b")
 REQUEST_TIMEOUT = float(os.environ.get("LLM_TIMEOUT", "600"))
 
 
-def _headers() -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {OPENAI_API_KEY}",
-        "Content-Type": "application/json",
-    }
+@dataclass
+class Provider:
+    """OpenAI 互換 API 1 系統ぶんの接続情報。"""
+
+    name: str
+    base_url: str
+    api_key: str | None = None
+    # 認証ヘッダ名と値の接頭辞。既定は `Authorization: Bearer <key>`。
+    # Azure OpenAI は `api-key: <key>`（接頭辞なし）。
+    auth_header: str = "Authorization"
+    auth_prefix: str = "Bearer "
+    # クエリ文字列（Azure の api-version 等）。
+    query: dict[str, str] = field(default_factory=dict)
+    # 明示モデル一覧（空なら /models を照会）。
+    models: list[str] = field(default_factory=list)
+
+    def headers(self) -> dict[str, str]:
+        h = {"Content-Type": "application/json"}
+        if self.api_key:
+            h[self.auth_header] = f"{self.auth_prefix}{self.api_key}"
+        return h
+
+
+def _build_providers() -> tuple[list[Provider], dict[str, Provider]]:
+    """`LLM_PROVIDERS` からプロバイダ一覧と model→provider 索引を作る。
+
+    未設定/空/不正時は従来の単一プロバイダ（OPENAI_BASE_URL）へフォールバック。
+    """
+    providers: list[Provider] = []
+    raw = os.environ.get("LLM_PROVIDERS", "").strip()
+    if raw:
+        try:
+            entries = json.loads(raw)
+            if not isinstance(entries, list):
+                raise ValueError("LLM_PROVIDERS must be a JSON array")
+            for e in entries:
+                if not isinstance(e, dict) or not e.get("base_url"):
+                    continue
+                key = None
+                if e.get("api_key_env"):
+                    key = os.environ.get(str(e["api_key_env"])) or None
+                elif e.get("api_key"):
+                    key = str(e["api_key"]) or None
+                providers.append(
+                    Provider(
+                        name=str(e.get("name") or e["base_url"]),
+                        base_url=str(e["base_url"]).rstrip("/"),
+                        api_key=key,
+                        auth_header=str(e.get("auth_header") or "Authorization"),
+                        auth_prefix=(
+                            e["auth_prefix"]
+                            if e.get("auth_prefix") is not None
+                            else "Bearer "
+                        ),
+                        query={str(k): str(v) for k, v in (e.get("query") or {}).items()},
+                        models=[str(m) for m in (e.get("models") or [])],
+                    )
+                )
+        except (ValueError, TypeError) as exc:  # noqa: BLE001
+            print(f"[llm] LLM_PROVIDERS の解析に失敗、単一プロバイダにフォールバック: {exc}")
+            providers = []
+
+    if not providers:
+        # 後方互換: 単一の OpenAI 互換プロバイダ。
+        providers = [
+            Provider(name="default", base_url=OPENAI_BASE_URL, api_key=OPENAI_API_KEY)
+        ]
+
+    index: dict[str, Provider] = {}
+    for p in providers:
+        for mid in p.models:
+            if mid in index:
+                print(
+                    f"[llm] モデルID重複 '{mid}': '{index[mid].name}' を優先し "
+                    f"'{p.name}' の割当は無視"
+                )
+                continue
+            index[mid] = p
+    return providers, index
+
+
+_PROVIDERS, _MODEL_INDEX = _build_providers()
+# 索引に無いモデル（request 指定・DEFAULT_MODEL）用の既定プロバイダ。
+_DEFAULT_PROVIDER = _PROVIDERS[0]
+
+for _p in _PROVIDERS:
+    print(
+        f"[llm] provider '{_p.name}' base={_p.base_url} "
+        f"auth={'yes' if _p.api_key else 'none'} models={_p.models or '(query /models)'}"
+    )
 
 
 def _resolve_model(model: dict[str, Any] | None) -> str:
@@ -44,6 +131,11 @@ def _resolve_model(model: dict[str, Any] | None) -> str:
 def resolve_model(model: dict[str, Any] | None) -> str:
     """リクエストの model 指定から実際に使うモデル ID を解決する（公開版）。"""
     return _resolve_model(model)
+
+
+def _provider_for(model_id: str) -> Provider:
+    """modelId からプロバイダを逆引き。未登録は既定プロバイダ。"""
+    return _MODEL_INDEX.get(model_id, _DEFAULT_PROVIDER)
 
 
 def _data_url(media_type: str, data: str) -> str:
@@ -119,14 +211,19 @@ async def chat_once(
     messages: list[dict[str, Any]], model: dict[str, Any] | None
 ) -> str:
     """ストリームなしでチャット補完を取得する。"""
+    model_id = _resolve_model(model)
+    provider = _provider_for(model_id)
     payload = {
-        "model": _resolve_model(model),
+        "model": model_id,
         "messages": _to_openai_messages(messages),
         "stream": False,
     }
     async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
         res = await client.post(
-            f"{OPENAI_BASE_URL}/chat/completions", json=payload, headers=_headers()
+            f"{provider.base_url}/chat/completions",
+            json=payload,
+            headers=provider.headers(),
+            params=provider.query or None,
         )
         res.raise_for_status()
         data = res.json()
@@ -142,8 +239,10 @@ async def chat_stream(
     OpenAI 互換の SSE(`data: {...}`) を読み、各行を {"text": "..."} 形式に変換する。
     最後に stopReason を付与した行を流す。
     """
+    model_id = _resolve_model(model)
+    provider = _provider_for(model_id)
     payload = {
-        "model": _resolve_model(model),
+        "model": model_id,
         "messages": _to_openai_messages(messages),
         "stream": True,
     }
@@ -151,9 +250,10 @@ async def chat_stream(
         async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
             async with client.stream(
                 "POST",
-                f"{OPENAI_BASE_URL}/chat/completions",
+                f"{provider.base_url}/chat/completions",
                 json=payload,
-                headers=_headers(),
+                headers=provider.headers(),
+                params=provider.query or None,
             ) as res:
                 if res.status_code != 200:
                     body = (await res.aread()).decode("utf-8", "ignore")
@@ -191,8 +291,8 @@ async def chat_stream(
         yield json.dumps(
             {
                 "text": (
-                    "[ローカル LLM に接続できませんでした] "
-                    f"{OPENAI_BASE_URL} を確認してください: {e}"
+                    "[LLM に接続できませんでした] "
+                    f"provider '{provider.name}' ({provider.base_url}) を確認してください: {e}"
                 ),
                 "stopReason": "error",
             },
@@ -200,12 +300,31 @@ async def chat_stream(
         ) + "\n"
 
 
-async def list_models() -> list[str]:
+async def _list_provider_models(provider: Provider) -> list[str]:
+    """明示 models があればそれを、無ければ provider の /models を照会する。"""
+    if provider.models:
+        return list(provider.models)
     try:
         async with httpx.AsyncClient(timeout=10) as client:
-            res = await client.get(f"{OPENAI_BASE_URL}/models", headers=_headers())
+            res = await client.get(
+                f"{provider.base_url}/models",
+                headers=provider.headers(),
+                params=provider.query or None,
+            )
             res.raise_for_status()
             data = res.json()
         return [m["id"] for m in data.get("data", [])]
     except httpx.HTTPError:
         return []
+
+
+async def list_models() -> list[str]:
+    """全プロバイダのモデルを統合して返す（重複は登録順で除外）。"""
+    seen: set[str] = set()
+    out: list[str] = []
+    for provider in _PROVIDERS:
+        for mid in await _list_provider_models(provider):
+            if mid not in seen:
+                seen.add(mid)
+                out.append(mid)
+    return out

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -48,6 +48,13 @@ services:
       - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-ollama}
       - DEFAULT_MODEL=${DEFAULT_MODEL:-qwen2.5:7b}
+      # 複数 OpenAI 互換プロバイダ併用（JSON）。未設定なら OPENAI_* 単一。
+      - LLM_PROVIDERS=${LLM_PROVIDERS:-}
+      # LLM_PROVIDERS の api_key_env から参照されるプロバイダ別キー
+      - SAKURA_API_KEY=${SAKURA_API_KEY:-}
+      - OPENAI_PROVIDER_API_KEY=${OPENAI_PROVIDER_API_KEY:-}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - AZURE_OPENAI_API_KEY=${AZURE_OPENAI_API_KEY:-}
       - DB_PATH=/data/open-genai.db
       # 監査ログ / チャット履歴分離
       - AUDIT_ENABLED=${AUDIT_ENABLED:-true}

--- a/genai-web/packages/common/src/application/model.ts
+++ b/genai-web/packages/common/src/application/model.ts
@@ -498,6 +498,48 @@ export const modelMetadata: Record<string, ModelMetadata> = {
     displayName: 'Nova Sonic',
   },
 
+  // ==== Open GENAI: さくら AI Engine ====
+  // https://manual.sakura.ad.jp/cloud/ai-engine/02-howto.html
+  // modelId は API の model 名と一致させる（OPENAI_BASE_URL=https://api.ai.sakura.ad.jp/v1）。
+  'gpt-oss-120b': {
+    flags: MODEL_FEATURE.TEXT_DOC,
+    displayName: 'gpt-oss-120b（さくら AI Engine）',
+  },
+  'preview/gemma-4-31B-it': {
+    // マルチモーダル。画像 + ドキュメント添付に対応。
+    flags: MODEL_FEATURE.TEXT_DOC_IMAGE,
+    displayName: 'Gemma 4 31B IT（さくら・画像対応）',
+  },
+
+  // ==== Open GENAI: 他の OpenAI 互換プロバイダ（LLM_PROVIDERS で併用）====
+  // OpenAI
+  'gpt-4o': {
+    flags: MODEL_FEATURE.TEXT_DOC_IMAGE,
+    displayName: 'GPT-4o（OpenAI）',
+  },
+  'gpt-4o-mini': {
+    flags: { ...MODEL_FEATURE.TEXT_DOC_IMAGE, ...MODEL_FEATURE.LIGHT },
+    displayName: 'GPT-4o mini（OpenAI）',
+  },
+  // Google Gemini（OpenAI 互換エンドポイント）
+  'gemini-2.5-flash': {
+    flags: MODEL_FEATURE.TEXT_DOC_IMAGE,
+    displayName: 'Gemini 2.5 Flash（Google）',
+  },
+  'gemini-2.5-pro': {
+    flags: MODEL_FEATURE.TEXT_DOC_IMAGE,
+    displayName: 'Gemini 2.5 Pro（Google）',
+  },
+  // Azure OpenAI（modelId はデプロイ名に一致させる）
+  'gpt-4.1': {
+    flags: MODEL_FEATURE.TEXT_DOC_IMAGE,
+    displayName: 'GPT-4.1（Azure）',
+  },
+  'gpt-4o-azure': {
+    flags: MODEL_FEATURE.TEXT_DOC_IMAGE,
+    displayName: 'GPT-4o（Azure）',
+  },
+
   // ==== Open GENAI: ローカル LLM (Ollama) ====
   // modelId は Ollama のモデル名と一致させる。バックエンドはこの id を
   // そのまま Ollama の model として利用する。

--- a/genai-web/packages/common/src/application/model.ts
+++ b/genai-web/packages/common/src/application/model.ts
@@ -573,6 +573,21 @@ export const modelMetadata: Record<string, ModelMetadata> = {
     flags: MODEL_FEATURE.TEXT_DOC,
     displayName: 'gpt-oss 20B (ローカル)',
   },
+
+  // ==== Open GENAI: ホスト Ollama（Cloud モデル含む）====
+  // modelId は `ollama list` の NAME と一致させる（さくら gpt-oss-120b とは別 ID）。
+  'gpt-oss:120b-cloud': {
+    flags: MODEL_FEATURE.TEXT_DOC,
+    displayName: 'gpt-oss 120B（Ollama Cloud）',
+  },
+  'gemma4:cloud': {
+    flags: MODEL_FEATURE.TEXT_DOC_IMAGE,
+    displayName: 'Gemma 4（Ollama Cloud・画像対応）',
+  },
+  'glm-5.2:cloud': {
+    flags: MODEL_FEATURE.TEXT_DOC,
+    displayName: 'GLM 5.2（Ollama Cloud）',
+  },
 };
 
 export const BEDROCK_TEXT_MODELS = Object.keys(modelMetadata).filter(


### PR DESCRIPTION
## Summary
- 複数の OpenAI 互換プロバイダ（Ollama / OpenAI / Azure OpenAI / Gemini / さくら等）を `LLM_PROVIDERS`(JSON) で登録し、リクエストの `modelId` からプロバイダを逆引きして呼び分けます。
- `backend/app/llm.py` に `Provider` レジストリ・model→provider 索引・柔軟認証（`auth_header` / `auth_prefix` / `query`）を実装。Azure OpenAI（`api-key` ヘッダ + `api-version` クエリ）に対応。
- `list_models` は全プロバイダのモデルを統合。`LLM_PROVIDERS` 未設定時は従来の `OPENAI_*` 単一プロバイダにフォールバック（後方互換）。
- `docker-compose.prod.yml` に `LLM_PROVIDERS` と各 `*_API_KEY` を配線。`.env(.prod).example` に設定例（Azure 含む）を記載。
- モデルメタデータ（表示名 / 機能フラグ）を追加。

## Notes
- 秘密情報は含みません（キーは環境変数参照のみ）。
- フロントのモデル選択（`VITE_APP_MODEL_IDS`）関連は静的 web ビルド側に依存するため本 PR には含めていません。

## Test plan
- [ ] `LLM_PROVIDERS` 未設定で従来動作（単一プロバイダ）に回帰
- [ ] さくら + Azure の2系統を設定し、各 `modelId` が正しいプロバイダへルーティングされる
- [ ] `chat`(非ストリーム/ストリーム) と `list_models` 統合の確認

Made with [Cursor](https://cursor.com)