### PR TITLE
feat: RAG embeddings via OpenAI-compatible sidecar (ruri-v3)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -35,6 +35,9 @@ OLLAMA_BASE_URL=http://host.docker.internal:11434
 DEFAULT_MODEL=qwen2.5:7b
 
 # === RAG / 監査 / 各 AI アプリ ===
+# embed サイドカー（ローカル日本語埋め込み）を起動する場合は embed プロファイルを有効化。
+# 使わない場合は空にし、EMBED_BASE_URL を外部の OpenAI 互換埋め込みへ向ける。
+COMPOSE_PROFILES=embed
 # 埋め込みは embed サイドカー（sentence-transformers / CPU）へ分離。未設定なら OPENAI_BASE_URL にフォールバック。
 EMBED_BASE_URL=http://embed:80/v1
 EMBED_API_KEY=-

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -35,9 +35,17 @@ OLLAMA_BASE_URL=http://host.docker.internal:11434
 DEFAULT_MODEL=qwen2.5:7b
 
 # === RAG / 監査 / 各 AI アプリ ===
-EMBED_MODEL=mxbai-embed-large
+# 埋め込みは embed サイドカー（sentence-transformers / CPU）へ分離。未設定なら OPENAI_BASE_URL にフォールバック。
+EMBED_BASE_URL=http://embed:80/v1
+EMBED_API_KEY=-
+EMBED_MODEL=cl-nagoya/ruri-v3-310m
+EMBED_DIM=768
+# ruri-v3-310m は 768 次元のため、既存 1024 次元とは別コレクションにする
+QDRANT_COLLECTION=open_genai_rag_ruri_v3_310m
 RAG_MODEL=gpt-oss:20b
 RAG_API_KEY=change-me-local-rag-key
+# 起動時のサンプル自動投入。false で無効（本番でサンプル不要なら false）
+RAG_SEED_SAMPLES=false
 AUDIT_ENABLED=true
 AUDIT_STORE_CONTENT=true
 AUDIT_MAX_CONTENT_CHARS=8000

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -182,8 +182,13 @@ services:
     restart: unless-stopped
 
   # 日本語埋め込み（sentence-transformers / ruri-v3-310m, CPU）。rag-app の embeddings 専用。
-  # TEI(CPU/ORT) は ruri（ModernBERT-Ja, ONNX 非提供）を配信できないため OpenAI 互換サイドカーで代替。
+  # 旧 TEI(CPU/ORT) は ruri（ModernBERT-Ja, ONNX 非提供）を配信できないため、この
+  # OpenAI 互換サイドカーで代替している。
+  # profiles により起動を任意化: 有効化しない限り起動しない（EMBED_BASE_URL を
+  # 外部の埋め込みエンドポイントへ向ける運用では不要）。COMPOSE_PROFILES=embed か
+  # `--profile embed` で有効化する。
   embed:
+    profiles: ["embed"]
     build:
       context: ./embed-app
       dockerfile: Dockerfile
@@ -227,9 +232,10 @@ services:
       - rag_app_data:/data
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    # embed は profiles で任意起動のため depends_on にしない（埋め込みは起動時では
+    # なく呼び出し時にのみ必要。embed 無効時は EMBED_BASE_URL を外部へ向ける）。
     depends_on:
       - qdrant
-      - embed
     restart: unless-stopped
 
   # ナレッジ検索 MCP（Dify Agent 向け）。外部公開が必要なら ports を追加する。

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -181,6 +181,21 @@ services:
       - qdrant_data:/qdrant/storage
     restart: unless-stopped
 
+  # 日本語埋め込み（sentence-transformers / ruri-v3-310m, CPU）。rag-app の embeddings 専用。
+  # TEI(CPU/ORT) は ruri（ModernBERT-Ja, ONNX 非提供）を配信できないため OpenAI 互換サイドカーで代替。
+  embed:
+    build:
+      context: ./embed-app
+      dockerfile: Dockerfile
+    container_name: open-genai-embed
+    environment:
+      - EMBED_MODEL=${EMBED_MODEL:-cl-nagoya/ruri-v3-310m}
+    volumes:
+      - embed_data:/data
+    expose:
+      - "80"
+    restart: unless-stopped
+
   rag-app:
     build:
       context: .
@@ -191,9 +206,18 @@ services:
       - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-ollama}
       - QDRANT_URL=http://qdrant:6333
-      - EMBED_MODEL=${EMBED_MODEL:-mxbai-embed-large}
+      - QDRANT_COLLECTION=${QDRANT_COLLECTION:-open_genai_rag_ruri_v3_310m}
+      # 埋め込みは embed サイドカーへ分離。未設定時は OPENAI_BASE_URL にフォールバック。
+      - EMBED_BASE_URL=${EMBED_BASE_URL:-http://embed:80/v1}
+      - EMBED_API_KEY=${EMBED_API_KEY:--}
+      - EMBED_MODEL=${EMBED_MODEL:-cl-nagoya/ruri-v3-310m}
+      - EMBED_DIM=${EMBED_DIM:-768}
+      - "EMBED_QUERY_PREFIX=${EMBED_QUERY_PREFIX:-検索クエリ: }"
+      - "EMBED_DOC_PREFIX=${EMBED_DOC_PREFIX:-検索文書: }"
       - RAG_MODEL=${RAG_MODEL:-gpt-oss:20b}
       - RAG_API_KEY=${RAG_API_KEY:-local-rag-key}
+      # 起動時のサンプル自動投入（false で無効）
+      - RAG_SEED_SAMPLES=${RAG_SEED_SAMPLES:-true}
       - INTERNAL_SIGNING_SECRET=${INTERNAL_SIGNING_SECRET:?INTERNAL_SIGNING_SECRET を設定してください}
       - RAG_META_DB_PATH=/data/rag_meta.db
       - URL_REFRESH_INTERVAL=${URL_REFRESH_INTERVAL:-86400}
@@ -205,6 +229,7 @@ services:
       - "host.docker.internal:host-gateway"
     depends_on:
       - qdrant
+      - embed
     restart: unless-stopped
 
   # ナレッジ検索 MCP（Dify Agent 向け）。外部公開が必要なら ports を追加する。
@@ -333,6 +358,7 @@ volumes:
   web_pkg_types_node_modules:
   web_pkg_cdk_node_modules:
   qdrant_data:
+  embed_data:
   keycloak_data:
   whisper_cache:
   dify_app_data:

--- a/embed-app/Dockerfile
+++ b/embed-app/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    HF_HOME=/data \
+    SENTENCE_TRANSFORMERS_HOME=/data
+
+COPY requirements.txt ./
+# torch CPU ホイールを使う（GPU 不要・イメージ縮小）
+RUN pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch==2.5.1 \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+EXPOSE 80
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/embed-app/app/main.py
+++ b/embed-app/app/main.py
@@ -1,7 +1,8 @@
 """OpenAI 互換の埋め込みサイドカー（sentence-transformers）。
 
-TEI(CPU/ORT) は ruri-v3 系（ModernBERT-Ja, ONNX 非提供）を CPU で配信できないため、
-sentence-transformers で同等の埋め込みを OpenAI 互換 API として提供する。
+HF Text Embeddings Inference (TEI, CPU/ORT) は ruri-v3 系（ModernBERT-Ja, ONNX
+非提供）を CPU で配信できないため、その代替として sentence-transformers で同等の
+埋め込みを OpenAI 互換 API として提供する。
 
 - POST /v1/embeddings  { "model": ..., "input": str | [str, ...] }
     -> { "object": "list", "data": [{"object":"embedding","index":i,"embedding":[...]}],

--- a/embed-app/app/main.py
+++ b/embed-app/app/main.py
@@ -1,0 +1,73 @@
+"""OpenAI 互換の埋め込みサイドカー（sentence-transformers）。
+
+TEI(CPU/ORT) は ruri-v3 系（ModernBERT-Ja, ONNX 非提供）を CPU で配信できないため、
+sentence-transformers で同等の埋め込みを OpenAI 互換 API として提供する。
+
+- POST /v1/embeddings  { "model": ..., "input": str | [str, ...] }
+    -> { "object": "list", "data": [{"object":"embedding","index":i,"embedding":[...]}],
+         "model": ..., "usage": {...} }
+- GET  /health
+
+入力への prefix（Ruri の「検索クエリ: 」「検索文書: 」）は呼び出し側(rag-app)で付与済み。
+ここではそのままエンコードする。
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+from sentence_transformers import SentenceTransformer
+
+MODEL_ID = os.environ.get("EMBED_MODEL", "cl-nagoya/ruri-v3-310m")
+NORMALIZE = os.environ.get("EMBED_NORMALIZE", "true").lower() != "false"
+
+app = FastAPI(title="open-genai embed sidecar")
+_model: SentenceTransformer | None = None
+
+
+def _get_model() -> SentenceTransformer:
+    global _model
+    if _model is None:
+        _model = SentenceTransformer(MODEL_ID, device="cpu")
+    return _model
+
+
+class EmbeddingsRequest(BaseModel):
+    input: str | list[str]
+    model: str | None = None
+
+
+@app.on_event("startup")
+def _warmup() -> None:
+    # 起動時にモデルをロードして初回リクエストのレイテンシを避ける。
+    _get_model()
+
+
+@app.get("/health")
+def health() -> dict[str, Any]:
+    return {"status": "ok", "model": MODEL_ID}
+
+
+@app.post("/v1/embeddings")
+def embeddings(req: EmbeddingsRequest) -> dict[str, Any]:
+    inputs = [req.input] if isinstance(req.input, str) else list(req.input)
+    model = _get_model()
+    vectors = model.encode(
+        inputs,
+        normalize_embeddings=NORMALIZE,
+        convert_to_numpy=True,
+    )
+    data = [
+        {"object": "embedding", "index": i, "embedding": vec.tolist()}
+        for i, vec in enumerate(vectors)
+    ]
+    total_chars = sum(len(t) for t in inputs)
+    return {
+        "object": "list",
+        "data": data,
+        "model": req.model or MODEL_ID,
+        "usage": {"prompt_tokens": total_chars, "total_tokens": total_chars},
+    }

--- a/embed-app/requirements.txt
+++ b/embed-app/requirements.txt
@@ -1,5 +1,6 @@
-fastapi==0.115.6
+fastapi==0.139.0
 uvicorn[standard]==0.34.0
-sentence-transformers==3.3.1
-sentencepiece==0.2.0
-protobuf==5.29.2
+sentence-transformers==5.6.1
+transformers==5.14.1
+sentencepiece==0.2.1
+protobuf==5.29.6

--- a/embed-app/requirements.txt
+++ b/embed-app/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.115.6
+uvicorn[standard]==0.34.0
+sentence-transformers==3.3.1
+sentencepiece==0.2.0
+protobuf==5.29.2

--- a/rag-app/app/embeddings.py
+++ b/rag-app/app/embeddings.py
@@ -17,11 +17,15 @@ OPENAI_BASE_URL = (
     os.environ.get("OPENAI_BASE_URL") or f"{OLLAMA_BASE_URL.rstrip('/')}/v1"
 ).rstrip("/")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY") or "ollama"
+# 埋め込みは EMBED_BASE_URL（TEI 等）へ分離可能。未設定なら OPENAI_BASE_URL を使う。
+EMBED_BASE_URL = (os.environ.get("EMBED_BASE_URL") or OPENAI_BASE_URL).rstrip("/")
+EMBED_API_KEY = os.environ.get("EMBED_API_KEY") or OPENAI_API_KEY
 EMBED_MODEL = os.environ.get("EMBED_MODEL", "mxbai-embed-large")
 RAG_MODEL = os.environ.get("RAG_MODEL", "gpt-oss:20b")
 
-# mxbai-embed-large は検索クエリ側にこの prefix を付けると精度が上がる
-QUERY_PREFIX = "Represent this sentence for searching relevant passages: "
+# 検索クエリ / 文書に付ける prefix。Ruri v3 は「検索クエリ: 」「検索文書: 」を推奨。
+QUERY_PREFIX = os.environ.get("EMBED_QUERY_PREFIX", "検索クエリ: ")
+DOC_PREFIX = os.environ.get("EMBED_DOC_PREFIX", "検索文書: ")
 
 
 def _headers() -> dict[str, str]:
@@ -31,13 +35,20 @@ def _headers() -> dict[str, str]:
     }
 
 
+def _embed_headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {EMBED_API_KEY}",
+        "Content-Type": "application/json",
+    }
+
+
 async def embed(text: str, *, is_query: bool = False) -> list[float]:
-    prompt = (QUERY_PREFIX + text) if is_query else text
+    prompt = (QUERY_PREFIX + text) if is_query else (DOC_PREFIX + text)
     async with httpx.AsyncClient(timeout=120) as client:
         res = await client.post(
-            f"{OPENAI_BASE_URL}/embeddings",
+            f"{EMBED_BASE_URL}/embeddings",
             json={"model": EMBED_MODEL, "input": prompt},
-            headers=_headers(),
+            headers=_embed_headers(),
         )
         res.raise_for_status()
         data = res.json()

--- a/rag-app/app/embeddings.py
+++ b/rag-app/app/embeddings.py
@@ -17,7 +17,7 @@ OPENAI_BASE_URL = (
     os.environ.get("OPENAI_BASE_URL") or f"{OLLAMA_BASE_URL.rstrip('/')}/v1"
 ).rstrip("/")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY") or "ollama"
-# 埋め込みは EMBED_BASE_URL（TEI 等）へ分離可能。未設定なら OPENAI_BASE_URL を使う。
+# 埋め込みは EMBED_BASE_URL（embed サイドカー等の OpenAI 互換）へ分離可能。未設定なら OPENAI_BASE_URL を使う。
 EMBED_BASE_URL = (os.environ.get("EMBED_BASE_URL") or OPENAI_BASE_URL).rstrip("/")
 EMBED_API_KEY = os.environ.get("EMBED_API_KEY") or OPENAI_API_KEY
 EMBED_MODEL = os.environ.get("EMBED_MODEL", "mxbai-embed-large")

--- a/rag-app/app/main.py
+++ b/rag-app/app/main.py
@@ -280,8 +280,10 @@ async def _startup() -> None:
         asyncio.create_task(_url_refresh_loop())
     except Exception as e:  # noqa: BLE001
         print(f"[rag-app] URL 自動更新スケジューラ起動をスキップ: {e}")
+    # RAG_SEED_SAMPLES=false で起動時のサンプル自動投入を無効化できる（本番想定）。
+    seed_samples = os.environ.get("RAG_SEED_SAMPLES", "true").lower() != "false"
     try:
-        if await vectorstore.count() == 0:
+        if seed_samples and await vectorstore.count() == 0:
             # サンプルは共通スコープにタグ付きで投入（タグなしは検索対象外のため）
             tagstore.ensure_tags(DEFAULT_SCOPE, ["サンプル"])
             await ingest_documents(SAMPLE_DOCS, DEFAULT_SCOPE, ["サンプル"])


### PR DESCRIPTION
## Summary
- RAG の埋め込み生成をチャット LLM から分離し、日本語埋め込みモデル `cl-nagoya/ruri-v3-310m` を CPU で配信する専用サイドカーを追加します。
- TEI(CPU/ORT) は ruri（ModernBERT-Ja, ONNX 非提供）を配信できないため、FastAPI + sentence-transformers による OpenAI 互換 `/v1/embeddings` サイドカー（`embed-app/`）で代替。
- `rag-app/app/embeddings.py`: `EMBED_BASE_URL` / `EMBED_API_KEY` / `EMBED_MODEL` と ruri 用の検索クエリ/文書 prefix を設定可能に。未設定なら `OPENAI_BASE_URL` にフォールバック。
- `rag-app/app/main.py`: `RAG_SEED_SAMPLES` で起動時のサンプル自動投入を無効化可能に。
- `docker-compose.prod.yml`: `embed` サービス、rag-app の `EMBED_*` 環境変数、`embed_data` volume を追加。
- `.env.prod.example`: 埋め込みサイドカー設定を記載。

## Test plan
- [ ] embed サイドカーが起動し `/health` と `/v1/embeddings` が応答する
- [ ] rag-app がサイドカー経由で埋め込みを生成し、Qdrant へ投入・検索できる
- [ ] `EMBED_BASE_URL` 未設定時に `OPENAI_BASE_URL` へフォールバックする
- [ ] `RAG_SEED_SAMPLES=false` でサンプル未投入になる

Made with [Cursor](https://cursor.com)