### PR TITLE
feat(usermgmt): 利用者一覧表示

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -294,20 +294,15 @@ AUDIT_SEED: dict[str, Any] = {
 
 # 利用者一括管理(User Management) AI アプリ（管理者限定）
 _USERMGMT_FORM = (
-    '{'
-    '"operation":{"type":"select","title":"操作",'
-    '"desc":"まずドライランで内容を確認し、問題なければ適用してください。",'
-    '"items":[{"title":"ドライラン（変更しない）","value":"dry_run"},'
-    '{"title":"適用（Keycloakに反映）","value":"apply",'
-    '"confirm":"CSVの内容をKeycloakに反映します（利用者の作成・更新・削除を含む）。'
-    '削除は元に戻せません。ドライランで確認済みですか？"}],'
-    '"default_value":"dry_run"},'
-    '"files":{"type":"file","title":"CSVファイル",'
-    '"desc":"見出し: action,username,email,firstName,lastName,name,password,groups,enabled",'
-    '"accept":".csv,.txt","multiple":false},'
-    '"csv_text":{"type":"textarea","title":"CSV（貼り付け・任意）",'
-    '"desc":"ファイルの代わりにCSVを直接貼り付けても可。"}'
-    '}'
+    "{\"operation\":{\"type\":\"select\",\"title\":\"操作\",\"desc\":\"一覧表示、または CSV のドライラン／適用。まずドライランで内容を確認してく"
+    "ださい。\",\"items\":[{\"title\":\"ユーザ一覧（表示のみ）\",\"value\":\"list\"},{\"title\":\"ドライラン（変更しない）\",\"value\":\"dry"
+    "_run\"},{\"title\":\"適用（Keycloakに反映）\",\"value\":\"apply\",\"confirm\":\"CSVの内容をKeycloakに反映します（利用者の作成・"
+    "更新・削除を含む）。削除は元に戻せません。ドライランで確認済みですか？\"}],\"default_value\":\"list\"},\"search\":{\"type\":\"text\",\"ti"
+    "tle\":\"検索（一覧用・任意）\",\"desc\":\"ユーザ一覧時のみ有効。username / email / 氏名の部分一致。\"},\"limit\":{\"type\":\"number"
+    "\",\"title\":\"表示件数（一覧用）\",\"default_value\":200,\"min\":1,\"max\":1000},\"files\":{\"type\":\"file\",\"titl"
+    "e\":\"CSVファイル\",\"desc\":\"見出し: action,username,email,firstName,lastName,name,password,groups,en"
+    "abled（一覧表示時は不要）\",\"accept\":\".csv,.txt\",\"multiple\":false},\"csv_text\":{\"type\":\"textarea\",\"tit"
+    "le\":\"CSV（貼り付け・任意）\",\"desc\":\"ファイルの代わりにCSVを直接貼り付けても可（一覧表示時は不要）。\"}}"
 )
 USERMGMT_SEED: dict[str, Any] = {
     "exAppId": "usermgmt",
@@ -317,28 +312,8 @@ USERMGMT_SEED: dict[str, Any] = {
     "apiKey": RAG_API_KEY,
     "config": "",
     "placeholder": _USERMGMT_FORM,
-    "description": "CSV で利用者アカウントを一括登録/更新/削除します（システム管理者のみ）。",
-    "howToUse": (
-        "## このアプリでできること（管理者）\n\n"
-        "CSV を使って利用者アカウント（Keycloak）を一括で作成・更新・削除します。\n\n"
-        "## CSV の準備\n\n"
-        "1行目に見出し、2行目以降に利用者を記載します。見出し例:\n\n"
-        "```\naction,username,email,name,password,groups,enabled\n"
-        "upsert,yamada,yamada@example.com,山田太郎,Passw0rd!,UserGroup,true\n```\n\n"
-        "- **action**: `create`（新規）/`update`（更新）/`delete`（削除）/`upsert`（無ければ作成・あれば更新／既定）。\n"
-        "- **username**: 必須。ログインID。\n"
-        "- **email / name**: メールアドレス・氏名。\n"
-        "- **password**: 新規作成時の初期パスワード（更新時は変更したい場合のみ）。\n"
-        "- **groups**: 権限グループ（例 `SystemAdminGroup`＝システム管理者）。`;` か `,` 区切り。\n"
-        "- **enabled**: 有効/無効（`true`/`false`）。\n\n"
-        "## 操作手順\n\n"
-        "1. CSV ファイルを添付するか、「CSV（貼り付け）」に直接貼り付けます。\n"
-        "2. 「操作」で「ドライラン」を選んで実行し、**対象と操作内容を必ず確認**します（この時点では変更されません）。\n"
-        "3. 問題なければ「操作」を「適用」にして実行します（確認ダイアログが表示されます）。\n\n"
-        "## 注意\n\n"
-        "- 「適用」は作成・更新・**削除**を伴い、削除は元に戻せません。必ずドライランで確認してください。\n"
-        "- パスワード列を含む CSV の保管・共有には十分注意してください。"
-    ),
+    "description": "利用者一覧の表示、および CSV による一括登録/更新/削除（システム管理者のみ）。",
+    "howToUse": "## このアプリでできること（管理者）\n\nKeycloak 上の利用者アカウントを一覧表示し、CSV で一括作成・更新・削除できます。\n\n## ユーザ一覧\n\n1. 「操作」で「ユーザ一覧（表示のみ）」を選びます（既定）。\n2. 必要なら「検索」と「表示件数」を指定して「実行」します。\n3. username / email / 氏名 / 所属グループ / 有効状態が一覧表示されます（変更はされません）。\n\n## CSV の準備\n\n1行目に見出し、2行目以降に利用者を記載します。見出し例:\n\n```\naction,username,email,name,password,groups,enabled\nupsert,yamada,yamada@example.com,山田太郎,Passw0rd!,UserGroup,true\n```\n\n- **action**: `create`（新規）/`update`（更新）/`delete`（削除）/`upsert`（無ければ作成・あれば更新／既定）。\n- **username**: 必須。ログインID。\n- **email / name**: メールアドレス・氏名。\n- **password**: 新規作成時の初期パスワード（更新時は変更したい場合のみ）。\n- **groups**: 権限グループ（例 `SystemAdminGroup`＝システム管理者）。`;` か `,` 区切り。\n- **enabled**: 有効/無効（`true`/`false`）。\n\n## CSV 操作手順\n\n1. CSV ファイルを添付するか、「CSV（貼り付け）」に直接貼り付けます。\n2. 「操作」で「ドライラン」を選んで実行し、**対象と操作内容を必ず確認**します（この時点では変更されません）。\n3. 問題なければ「操作」を「適用」にして実行します（確認ダイアログが表示されます）。\n\n## 注意\n\n- 「適用」は作成・更新・**削除**を伴い、削除は元に戻せません。必ずドライランで確認してください。\n- パスワード列を含む CSV の保管・共有には十分注意してください。",
     "copyable": False,
     "status": "published",
 }

--- a/usermgmt-app/app/main.py
+++ b/usermgmt-app/app/main.py
@@ -6,7 +6,8 @@
 
 - 利用者アカウントは Keycloak(realm) で管理するため、Keycloak Admin REST API を叩く。
 - exApp 同期プロトコル:
-    リクエスト: { "inputs": { "operation": "dry_run|apply", "csv_text": "...",
+    リクエスト: { "inputs": { "operation": "list|dry_run|apply", "csv_text": "...",
+                              "search": "...",
                               "files": [ {files:[{filename,content(base64)}]} ] } }
     レスポンス: { "outputs": "<Markdown の処理レポート>" }
 - 管理者判定: backend が付与する `x-user-groups` に SystemAdminGroup が必要。
@@ -109,6 +110,110 @@ async def _find_user(client: httpx.AsyncClient, token: str, username: str) -> di
     return users[0] if users else None
 
 
+def _md_cell(value: Any) -> str:
+    """Markdown 表セル用にパイプ・改行を無害化する。"""
+    text = "" if value is None else str(value)
+    return text.replace("|", "\\|").replace("\n", " ").replace("\r", "").strip()
+
+
+async def _user_groups(
+    client: httpx.AsyncClient, token: str, user_id: str
+) -> list[str]:
+    res = await client.get(
+        f"{KEYCLOAK_URL}/admin/realms/{KEYCLOAK_REALM}/users/{user_id}/groups",
+        headers=_auth_headers(token),
+    )
+    res.raise_for_status()
+    names: list[str] = []
+    for g in res.json() or []:
+        name = (g.get("name") or "").strip()
+        if name:
+            names.append(name)
+    return names
+
+
+async def _list_users(inputs: dict[str, Any]) -> str:
+    """Keycloak の利用者一覧を Markdown 表で返す（読み取り専用）。"""
+    search = (inputs.get("search") or "").strip()
+    try:
+        limit = int(inputs.get("limit") or 200)
+    except (TypeError, ValueError):
+        limit = 200
+    limit = max(1, min(limit, 1000))
+
+    page_size = 100
+    users: list[dict[str, Any]] = []
+    try:
+        async with httpx.AsyncClient(timeout=60) as client:
+            token = await _admin_token(client)
+            first = 0
+            while len(users) < limit:
+                params: dict[str, Any] = {
+                    "first": first,
+                    "max": min(page_size, limit - len(users)),
+                }
+                if search:
+                    params["search"] = search
+                res = await client.get(
+                    f"{KEYCLOAK_URL}/admin/realms/{KEYCLOAK_REALM}/users",
+                    params=params,
+                    headers=_auth_headers(token),
+                )
+                res.raise_for_status()
+                batch = res.json() or []
+                if not batch:
+                    break
+                users.extend(batch)
+                if len(batch) < params["max"]:
+                    break
+                first += len(batch)
+
+            rows: list[tuple[str, ...]] = []
+            for u in users:
+                uid = u.get("id") or ""
+                groups = await _user_groups(client, token, uid) if uid else []
+                name = " ".join(
+                    x
+                    for x in [
+                        (u.get("lastName") or "").strip(),
+                        (u.get("firstName") or "").strip(),
+                    ]
+                    if x
+                )
+                rows.append(
+                    (
+                        _md_cell(u.get("username")),
+                        _md_cell(u.get("email")),
+                        _md_cell(name),
+                        _md_cell(",".join(groups) if groups else "-"),
+                        "有効" if u.get("enabled", True) else "無効",
+                        _md_cell(uid[:8] + "…" if len(uid) > 8 else uid),
+                    )
+                )
+    except Exception as e:  # noqa: BLE001
+        return f"[Keycloak への接続/認証に失敗しました] {e}"
+
+    title = "## 利用者一覧"
+    if search:
+        title += f"（検索: `{_md_cell(search)}`）"
+    lines = [
+        title,
+        "",
+        f"件数: **{len(rows)}**" + ("（上限に達しています）" if len(rows) >= limit else ""),
+        "",
+        "| # | username | email | 氏名 | groups | 状態 | id |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    if not rows:
+        lines.append("| - | （該当なし） |  |  |  |  |  |")
+    else:
+        for i, cols in enumerate(rows, 1):
+            lines.append(f"| {i} | " + " | ".join(cols) + " |")
+    lines.append("")
+    lines.append("> 読み取り専用です。作成・更新・削除は CSV のドライラン／適用を使ってください。")
+    return "\n".join(lines)
+
+
 async def _group_id(client: httpx.AsyncClient, token: str, name: str) -> str | None:
     res = await client.get(
         f"{KEYCLOAK_URL}/admin/realms/{KEYCLOAK_REALM}/groups",
@@ -148,6 +253,10 @@ async def _apply_groups(
 
 
 async def _process(inputs: dict[str, Any]) -> str:
+    operation = (inputs.get("operation") or "list").strip().lower()
+    if operation == "list":
+        return await _list_users(inputs)
+
     csv_text = _extract_csv(inputs)
     if not csv_text:
         return "CSV が指定されていません（`csv_text` に貼り付けるか、CSV ファイルを添付してください）。"
@@ -157,7 +266,7 @@ async def _process(inputs: dict[str, Any]) -> str:
         return "CSV から有効な行を読み取れませんでした。見出し行（username 等）を確認してください。"
 
     plans = plan_rows(rows)
-    apply = (inputs.get("operation") or "dry_run").strip().lower() == "apply"
+    apply = operation == "apply"
 
     lines = [
         f"## 利用者一括管理 {'（適用）' if apply else '（ドライラン：変更なし）'}",


### PR DESCRIPTION
## Summary
- 利用者一括管理に「ユーザ一覧（表示のみ）」操作を追加し、Keycloak 上の利用者を Markdown 表で表示
- 検索（username/email/氏名）と表示件数を指定可能
- 既定操作を一覧にし、CSV 操作前に現状確認しやすくする

## Test plan
- [ ] 管理者で利用者一括管理を開き、操作が「ユーザ一覧」になっていること
- [ ] 実行で username / email / 氏名 / groups / 状態が一覧表示されること
- [ ] 検索・件数指定が効くこと
- [ ] ドライラン／適用の CSV 操作が従来どおり動くこと

Made with [Cursor](https://cursor.com)