### PR TITLE
feat(rag): タグ名の Unicode NFC 正規化

### DIFF
--- a/knowledge-mcp/app/main.py
+++ b/knowledge-mcp/app/main.py
@@ -46,11 +46,21 @@ def _resolve_scope(scope: str | None) -> str:
 
 
 def _parse_tags(tags: str | list[str] | None) -> list[str]:
+    import unicodedata
+
+    def _norm(t: str) -> str:
+        return unicodedata.normalize("NFC", str(t)).strip()
+
     if tags is None:
         return []
     if isinstance(tags, list):
-        return [str(t).strip() for t in tags if str(t).strip()]
-    s = str(tags).strip()
+        out: list[str] = []
+        for t in tags:
+            n = _norm(t)
+            if n and n not in out:
+                out.append(n)
+        return out
+    s = _norm(tags)
     if not s:
         return []
     # JSON 配列文字列にも対応
@@ -58,12 +68,17 @@ def _parse_tags(tags: str | list[str] | None) -> list[str]:
         try:
             data = json.loads(s)
             if isinstance(data, list):
-                return [str(t).strip() for t in data if str(t).strip()]
+                return _parse_tags(data)
         except json.JSONDecodeError:
             pass
     for sep in (",", "|", "、", ";"):
         if sep in s:
-            return [p.strip() for p in s.split(sep) if p.strip()]
+            out = []
+            for p in s.split(sep):
+                n = _norm(p)
+                if n and n not in out:
+                    out.append(n)
+            return out
     return [s]
 
 

--- a/rag-app/app/docstore.py
+++ b/rag-app/app/docstore.py
@@ -13,6 +13,11 @@ import time
 import uuid
 from typing import Any
 
+try:  # パッケージとして読み込まれた場合（本番アプリ）
+    from . import textnorm
+except ImportError:  # 単体モジュールとして読み込まれた場合（テスト）
+    import textnorm
+
 DB_PATH = os.environ.get(
     "RAG_META_DB_PATH", os.environ.get("FOLDERS_DB_PATH", "/data/rag_meta.db")
 )
@@ -92,14 +97,10 @@ def _now() -> str:
 
 
 def _tags_json(tags: list[str] | None) -> str:
-    from . import textnorm
-
     return json.dumps(textnorm.normalize_tags(tags), ensure_ascii=False)
 
 
 def _parse_tags(raw: str | None) -> list[str]:
-    from . import textnorm
-
     try:
         v = json.loads(raw or "[]")
         if isinstance(v, list):
@@ -237,8 +238,6 @@ def list_docs(scope: str, tags: list[str] | None = None) -> list[dict[str, Any]]
             """,
             (scope,),
         ).fetchall()
-    from . import textnorm
-
     out: list[dict[str, Any]] = []
     tag_set = set(textnorm.normalize_tags(tags))
     for r in rows:

--- a/rag-app/app/docstore.py
+++ b/rag-app/app/docstore.py
@@ -92,13 +92,19 @@ def _now() -> str:
 
 
 def _tags_json(tags: list[str] | None) -> str:
-    return json.dumps(tags or [], ensure_ascii=False)
+    from . import textnorm
+
+    return json.dumps(textnorm.normalize_tags(tags), ensure_ascii=False)
 
 
 def _parse_tags(raw: str | None) -> list[str]:
+    from . import textnorm
+
     try:
         v = json.loads(raw or "[]")
-        return [str(t) for t in v] if isinstance(v, list) else []
+        if isinstance(v, list):
+            return textnorm.normalize_tags(str(t) for t in v)
+        return []
     except (json.JSONDecodeError, TypeError):
         return []
 
@@ -231,12 +237,17 @@ def list_docs(scope: str, tags: list[str] | None = None) -> list[dict[str, Any]]
             """,
             (scope,),
         ).fetchall()
+    from . import textnorm
+
     out: list[dict[str, Any]] = []
-    tag_set = set(tags or [])
+    tag_set = set(textnorm.normalize_tags(tags))
     for r in rows:
         d = _normalize_doc_row(r)
-        if tag_set and not tag_set.intersection(d["tags"]):
+        doc_tags = set(textnorm.normalize_tags(d.get("tags") or []))
+        if tag_set and not tag_set.intersection(doc_tags):
             continue
+        # 応答も NFC に揃える（LLM がコピーしても照合できる）
+        d["tags"] = sorted(doc_tags) if doc_tags else []
         out.append(d)
     return out
 
@@ -376,15 +387,13 @@ def delete_scope(scope: str) -> int:
 
 
 def set_tags(scope: str, source: str, tags: list[str]) -> bool:
-    import json
-
     doc = get_doc_by_source(scope, source)
     if not doc:
         return False
     with _connect() as conn:
         conn.execute(
             "UPDATE docs SET tags = ?, updated_at = ? WHERE doc_id = ?",
-            (json.dumps(tags or [], ensure_ascii=False), _now(), doc["doc_id"]),
+            (_tags_json(tags), _now(), doc["doc_id"]),
         )
     return True
 

--- a/rag-app/app/main.py
+++ b/rag-app/app/main.py
@@ -239,6 +239,73 @@ async def _migrate_tags_into_registry() -> None:
         print(f"[rag-app] ベクトル/構造化タグ移行警告: {e}")
 
 
+async def _migrate_tag_unicode_nfc() -> None:
+    """タグ名を Unicode NFC に揃える（LLM が NFC で渡しても照合できるようにする）。"""
+    from . import textnorm
+
+    renamed = 0
+    # 1) タグレジストリ
+    try:
+        with tagstore._connect() as conn:  # noqa: SLF001 - 移行専用
+            rows = list(conn.execute("SELECT scope, tag FROM tags"))
+            for scope, tag in rows:
+                nfc = textnorm.normalize_tag(tag)
+                if not nfc or nfc == tag:
+                    continue
+                exists = conn.execute(
+                    "SELECT 1 FROM tags WHERE scope = ? AND tag = ?",
+                    (scope, nfc),
+                ).fetchone()
+                if exists:
+                    conn.execute(
+                        "DELETE FROM tags WHERE scope = ? AND tag = ?",
+                        (scope, tag),
+                    )
+                else:
+                    conn.execute(
+                        "UPDATE tags SET tag = ? WHERE scope = ? AND tag = ?",
+                        (nfc, scope, tag),
+                    )
+                renamed += 1
+                try:
+                    await vectorstore.rename_tag_in_payloads(scope, tag, nfc)
+                except Exception as e:  # noqa: BLE001
+                    print(f"[rag-app] Qdrant タグ NFC 移行警告 ({scope}/{tag}): {e}")
+    except Exception as e:  # noqa: BLE001
+        print(f"[rag-app] タグレジストリ NFC 移行警告: {e}")
+
+    # 2) 構造化 docs.tags JSON
+    try:
+        import json
+
+        with docstore._connect() as conn:  # noqa: SLF001 - 移行専用
+            rows = list(conn.execute("SELECT doc_id, tags FROM docs"))
+            for doc_id, raw in rows:
+                try:
+                    cur = json.loads(raw or "[]")
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                if not isinstance(cur, list):
+                    continue
+                nxt = textnorm.normalize_tags(str(t) for t in cur)
+                if nxt == [str(t).strip() for t in cur if str(t).strip()] and all(
+                    textnorm.normalize_tag(str(t)) == str(t).strip() for t in cur if str(t).strip()
+                ):
+                    continue
+                if json.dumps(nxt, ensure_ascii=False) == (raw or "[]"):
+                    continue
+                conn.execute(
+                    "UPDATE docs SET tags = ? WHERE doc_id = ?",
+                    (json.dumps(nxt, ensure_ascii=False), doc_id),
+                )
+                renamed += 1
+    except Exception as e:  # noqa: BLE001
+        print(f"[rag-app] docs タグ NFC 移行警告: {e}")
+
+    if renamed:
+        print(f"[rag-app] タグ Unicode NFC 移行: {renamed} 件更新")
+
+
 @app.on_event("startup")
 async def _startup() -> None:
     await vectorstore.ensure_collection()
@@ -259,6 +326,10 @@ async def _startup() -> None:
         await _migrate_tags_into_registry()
     except Exception as e:  # noqa: BLE001
         print(f"[rag-app] タグ移行をスキップ: {e}")
+    try:
+        await _migrate_tag_unicode_nfc()
+    except Exception as e:  # noqa: BLE001
+        print(f"[rag-app] タグ NFC 移行をスキップ: {e}")
     # 旧 rag-manage(ADMIN_TEAM scope) → 共有ナレッジ(COMMON) への一度きり移行
     try:
         moved = await vectorstore.reassign_scope(LEGACY_ADMIN_SCOPE, DEFAULT_SCOPE)
@@ -280,8 +351,10 @@ async def _startup() -> None:
         asyncio.create_task(_url_refresh_loop())
     except Exception as e:  # noqa: BLE001
         print(f"[rag-app] URL 自動更新スケジューラ起動をスキップ: {e}")
+    # RAG_SEED_SAMPLES=false で起動時のサンプル自動投入を無効化できる（本番想定）。
+    seed_samples = os.environ.get("RAG_SEED_SAMPLES", "true").lower() != "false"
     try:
-        if await vectorstore.count() == 0:
+        if seed_samples and await vectorstore.count() == 0:
             # サンプルは共通スコープにタグ付きで投入（タグなしは検索対象外のため）
             tagstore.ensure_tags(DEFAULT_SCOPE, ["サンプル"])
             await ingest_documents(SAMPLE_DOCS, DEFAULT_SCOPE, ["サンプル"])
@@ -487,8 +560,19 @@ async def api_list_tags(
     )
     if err:
         return err
-    reg = {r["tag"]: r for r in tagstore.list_tags(resolved)}  # type: ignore[arg-type]
-    used = {r["tag"]: r["chunks"] for r in await vectorstore.list_tags(resolved)}  # type: ignore[arg-type]
+    from . import textnorm
+
+    reg = {
+        textnorm.normalize_tag(r["tag"]): r
+        for r in tagstore.list_tags(resolved)  # type: ignore[arg-type]
+        if textnorm.normalize_tag(r["tag"])
+    }
+    used: dict[str, int] = {}
+    for r in await vectorstore.list_tags(resolved):  # type: ignore[arg-type]
+        name = textnorm.normalize_tag(r["tag"])
+        if not name:
+            continue
+        used[name] = used.get(name, 0) + int(r.get("chunks") or 0)
     names = sorted(set(reg) | set(used))
     tags_out = [
         {"tag": name, "chunks": int(used.get(name, 0))} for name in names
@@ -786,8 +870,10 @@ def _parse_tags(value: Any) -> list[str]:
     """タグ入力を正規化する。
 
     動的フォームの複数選択は配列で届く。手入力は ';' か ',' 区切り文字列。
-    重複を除いて順序を保持する。
+    Unicode NFC + strip、重複を除いて順序を保持する。
     """
+    from . import textnorm
+
     raw: list[str] = []
     if value is None:
         return []
@@ -795,12 +881,7 @@ def _parse_tags(value: Any) -> list[str]:
         raw = [str(v) for v in value]
     else:
         raw = str(value).replace(";", ",").split(",")
-    out: list[str] = []
-    for chunk in raw:
-        t = chunk.strip()
-        if t and t not in out:
-            out.append(t)
-    return out
+    return textnorm.normalize_tags(raw)
 
 
 def _resolve_assign_tags(inputs: dict[str, Any]) -> list[str]:

--- a/rag-app/app/tagstore.py
+++ b/rag-app/app/tagstore.py
@@ -46,11 +46,9 @@ def _now() -> str:
 
 def ensure_tags(scope: str, tags: list[str]) -> list[str]:
     """タグをレジストリに登録（既存は無視）。正規化済みタグ一覧を返す。"""
-    cleaned: list[str] = []
-    for t in tags or []:
-        name = (t or "").strip()
-        if name and name not in cleaned:
-            cleaned.append(name)
+    from . import textnorm
+
+    cleaned = textnorm.normalize_tags(tags)
     if not cleaned:
         return []
     now = _now()
@@ -68,7 +66,9 @@ def ensure_tags(scope: str, tags: list[str]) -> list[str]:
 
 
 def create_tag(scope: str, tag: str) -> str:
-    name = (tag or "").strip()
+    from . import textnorm
+
+    name = textnorm.normalize_tag(tag)
     if not name:
         raise ValueError("タグ名が空です")
     ensure_tags(scope, [name])
@@ -85,8 +85,10 @@ def list_tags(scope: str) -> list[dict[str, Any]]:
 
 
 def rename_tag(scope: str, old: str, new: str) -> None:
-    old_n = (old or "").strip()
-    new_n = (new or "").strip()
+    from . import textnorm
+
+    old_n = textnorm.normalize_tag(old)
+    new_n = textnorm.normalize_tag(new)
     if not old_n or not new_n:
         raise ValueError("タグ名が空です")
     if old_n == new_n:

--- a/rag-app/app/tagstore.py
+++ b/rag-app/app/tagstore.py
@@ -11,6 +11,11 @@ import sqlite3
 import time
 from typing import Any
 
+try:  # パッケージとして読み込まれた場合（本番アプリ）
+    from . import textnorm
+except ImportError:  # 単体モジュールとして読み込まれた場合（テスト）
+    import textnorm
+
 DB_PATH = os.environ.get(
     "RAG_META_DB_PATH", os.environ.get("FOLDERS_DB_PATH", "/data/rag_meta.db")
 )
@@ -46,8 +51,6 @@ def _now() -> str:
 
 def ensure_tags(scope: str, tags: list[str]) -> list[str]:
     """タグをレジストリに登録（既存は無視）。正規化済みタグ一覧を返す。"""
-    from . import textnorm
-
     cleaned = textnorm.normalize_tags(tags)
     if not cleaned:
         return []
@@ -66,8 +69,6 @@ def ensure_tags(scope: str, tags: list[str]) -> list[str]:
 
 
 def create_tag(scope: str, tag: str) -> str:
-    from . import textnorm
-
     name = textnorm.normalize_tag(tag)
     if not name:
         raise ValueError("タグ名が空です")
@@ -85,8 +86,6 @@ def list_tags(scope: str) -> list[dict[str, Any]]:
 
 
 def rename_tag(scope: str, old: str, new: str) -> None:
-    from . import textnorm
-
     old_n = textnorm.normalize_tag(old)
     new_n = textnorm.normalize_tag(new)
     if not old_n or not new_n:

--- a/rag-app/app/textnorm.py
+++ b/rag-app/app/textnorm.py
@@ -1,0 +1,27 @@
+"""テキスト正規化（タグ名の Unicode 統一など）。
+
+LLM / ブラウザは NFC、macOS 由来のファイル名等は NFD になりやすい。
+タグ照合は常に NFC で行う。
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import Iterable
+
+
+def normalize_tag(tag: str | None) -> str:
+    """タグ名を strip + Unicode NFC に正規化する。"""
+    if tag is None:
+        return ""
+    return unicodedata.normalize("NFC", str(tag)).strip()
+
+
+def normalize_tags(tags: Iterable[str] | None) -> list[str]:
+    """タグ一覧を正規化し、空を除いて順序を保ったまま重複除去する。"""
+    out: list[str] = []
+    for t in tags or []:
+        name = normalize_tag(t)
+        if name and name not in out:
+            out.append(name)
+    return out

--- a/rag-app/app/vectorstore.py
+++ b/rag-app/app/vectorstore.py
@@ -72,9 +72,17 @@ def _scope_filter(
     tags 指定時は、その**いずれか**のタグを持つドキュメントに限定する（OR）。
     require_tags=True かつ tags 未指定のときはタグ未付与を除外する。
     """
+    from . import textnorm
+
     must: list[dict[str, Any]] = [{"key": "scope", "match": {"value": scope}}]
     if tags:
-        must.append({"key": "tags", "match": {"any": list(tags)}})
+        # NFD/NFC 混在に備え、正規化形＋生値の両方でマッチさせる
+        tag_any: list[str] = []
+        for t in tags:
+            for form in (t, textnorm.normalize_tag(t)):
+                if form and form not in tag_any:
+                    tag_any.append(form)
+        must.append({"key": "tags", "match": {"any": tag_any}})
     if extra:
         must.extend(extra)
     filt: dict[str, Any] = {"must": must}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,11 @@ for path in (ROOT, SHARED, BACKEND):
 def load_service_module(relative_path: str):
     """サービス配下の app/*.py を import パス衝突なく読み込む。"""
     path = ROOT / relative_path
+    # 同一ディレクトリの兄弟モジュール（例: rag-app/app/textnorm.py）を
+    # パッケージなしのフォールバック import で解決できるようにする。
+    parent = str(path.parent)
+    if parent not in sys.path:
+        sys.path.insert(0, parent)
     module_name = f"testmod_{path.parent.parent.name.replace('-', '_')}_{path.stem}"
     spec = importlib.util.spec_from_file_location(module_name, path)
     if spec is None or spec.loader is None:


### PR DESCRIPTION
## Summary
- タグ名を strip + Unicode NFC で正規化し、照合・登録の不一致を防ぐ
- `rag-app` に `textnorm` を追加し、docstore / tagstore / vectorstore / 起動時移行で適用
- `knowledge-mcp` の tags 入力も同様に NFC 正規化

## Test plan
- [ ] NFD 相当のタグ名で登録したドキュメントが、NFC の同一表記タグ検索でヒットすること
- [ ] 既存タグがある環境で rag-app 起動時に NFC 移行ログが出ても検索が壊れていないこと
- [ ] knowledge-mcp の tags 引数（カンマ区切り / JSON 配列）が従来どおり動くこと


Made with [Cursor](https://cursor.com)