### PR TITLE
fix: SAML ACS のプロキシヘッダ対応と Keycloak 重複属性の許容

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -101,6 +101,9 @@ def get_saml_settings() -> dict[str, Any]:
             "requestedAuthnContext": False,
             # InResponseTo を保存しないため未要求応答を許可
             "rejectUnsolicitedResponsesWithInResponseTo": False,
+            # Keycloak の role_list は Role 属性を Name 重複で送ることがある。
+            # アプリ認可は groups マッパーを使うため、重複 Attribute を許容する。
+            "allowRepeatAttributeName": True,
         },
     }
     _settings_cache = settings

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1043,11 +1043,19 @@ async def _prepare_saml_request(request: Request) -> dict[str, Any]:
     if request.method == "POST":
         raw = await request.form()
         form = {k: v for k, v in raw.items()}
-    host = request.headers.get("host", "localhost:8000")
-    server_port = host.split(":")[1] if ":" in host else (
-        "443" if request.url.scheme == "https" else "80"
-    )
+    # リバースプロキシ配下では request.url.scheme が http のままになるため、
+    # X-Forwarded-* を優先して Recipient 検証用の公開 URL を組み立てる。
     forwarded_proto = request.headers.get("x-forwarded-proto", request.url.scheme)
+    host = request.headers.get("x-forwarded-host") or request.headers.get(
+        "host", "localhost:8000"
+    )
+    forwarded_port = request.headers.get("x-forwarded-port")
+    if forwarded_port:
+        server_port = forwarded_port
+    elif ":" in host:
+        server_port = host.split(":", 1)[1]
+    else:
+        server_port = "443" if forwarded_proto == "https" else "80"
     return {
         "https": "on" if forwarded_proto == "https" else "off",
         "http_host": host,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1102,11 +1102,20 @@ async def auth_login(request: Request) -> Response:
 async def auth_acs(request: Request) -> Response:
     req = await _prepare_saml_request(request)
     saml_auth = auth.build_saml_auth(req)
-    saml_auth.process_response()
-    errors = saml_auth.get_errors()
     relay = req["post_data"].get("RelayState") or FRONTEND_URL
     target = relay if str(relay).startswith("http") else FRONTEND_URL
 
+    try:
+        saml_auth.process_response()
+    except Exception as exc:  # noqa: BLE001 — IdP 応答の検証例外をログイン失敗へ落とす
+        reason = str(exc) or type(exc).__name__
+        print(f"[auth] SAML 検証例外: {reason}")
+        audit.record(
+            request, action="auth.login", status=401, output_text=f"SAML検証例外: {reason}"
+        )
+        return RedirectResponse(f"{FRONTEND_URL}/auth-error", status_code=303)
+
+    errors = saml_auth.get_errors()
     if errors or not saml_auth.is_authenticated():
         reason = saml_auth.get_last_error_reason() or ",".join(errors)
         print(f"[auth] SAML 検証失敗: {reason}")

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -72,6 +72,7 @@ http {
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;
             proxy_set_header X-Forwarded-Host  $host;
+            proxy_set_header X-Forwarded-Port  443;
             proxy_set_header X-Forwarded-Prefix /api;
             # 推論ストリーム(SSE/NDJSON)のためバッファ無効・長時間タイムアウト
             proxy_buffering    off;


### PR DESCRIPTION
## Summary
HTTPS リバースプロキシ配下での Keycloak SAML ログイン失敗を修正する、バックエンドのみの低リスク修正です（PR #5 から SAML 部分だけを切り出し）。

- ACS の Recipient 検証用 URL を組み立てる際、`X-Forwarded-Proto` / `X-Forwarded-Host` / `X-Forwarded-Port` を優先（プロキシ配下で `request.url.scheme` が http のままになる問題に対応）
- ACS の `process_response()` を try/except で包み、IdP 応答の検証例外時に 500 ではなく `/auth-error` へリダイレクト
- Keycloak が `Role` 属性を Name 重複で送るケースを許容（`allowRepeatAttributeName`）。認可は groups マッパーを使用
- proxy に `X-Forwarded-Port 443` を追加

## Notes
- 静的 web ビルド（Dockerfile.prod / nginx SPA）とアカウント名表示は本 PR には含めていません（#5 の残りは別途検討）。
- 反映には backend の再ビルド（+ proxy 設定リロード）が必要です。

## Test plan
- [ ] HTTPS 公開 URL で Keycloak SAML ログインし、ACS 後にアプリへ戻ること
- [ ] 追加ユーザ／admin の双方でログインできること
- [ ] IdP 応答が不正な場合に 500 でなく auth-error へ遷移すること

Made with [Cursor](https://cursor.com)