### PR TITLE
fix(auth): 認証エラー時に壊れたセッションを残さずログインへ戻す

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1113,6 +1113,8 @@ async def auth_acs(request: Request) -> Response:
         audit.record(
             request, action="auth.login", status=401, output_text=f"SAML検証例外: {reason}"
         )
+        # Keycloak 再構成後の古い IdP メタデータ/証明書キャッシュを次回で刷新する
+        auth.reset_settings_cache()
         return RedirectResponse(f"{FRONTEND_URL}/auth-error", status_code=303)
 
     errors = saml_auth.get_errors()
@@ -1122,6 +1124,8 @@ async def auth_acs(request: Request) -> Response:
         audit.record(
             request, action="auth.login", status=401, output_text=f"SAML検証失敗: {reason}"
         )
+        # Keycloak 再構成後の古い IdP メタデータ/証明書キャッシュを次回で刷新する
+        auth.reset_settings_cache()
         return RedirectResponse(f"{FRONTEND_URL}/auth-error", status_code=303)
 
     attrs = saml_auth.get_attributes()

--- a/genai-web/packages/web/src/lib/fetcher.ts
+++ b/genai-web/packages/web/src/lib/fetcher.ts
@@ -1,4 +1,21 @@
-import { getIdToken } from '@/local/localAuth';
+import { clearToken, getIdToken, getToken, login } from '@/local/localAuth';
+
+// 401（認証切れ/不正トークン）を受けたら、壊れたトークンを破棄して
+// 素直にログイン画面へ戻す。多重リダイレクトを避けるためのガード付き。
+let redirectingToLogin = false;
+const handleUnauthorized = (): void => {
+  const path = window.location.pathname;
+  if (path === '/auth-error' || path === '/signed-out') {
+    return;
+  }
+  // トークンを持っていた（＝認証済みのつもりだった）場合のみ再ログインへ誘導
+  if (redirectingToLogin || !getToken()) {
+    return;
+  }
+  redirectingToLogin = true;
+  clearToken();
+  login();
+};
 
 export class ApiError extends Error {
   readonly status: number;
@@ -83,6 +100,9 @@ const createApiClient = (baseURL: string) => {
     });
 
     if (!res.ok) {
+      if (res.status === 401) {
+        handleUnauthorized();
+      }
       const errorData = await parseResponseBody<unknown>(res);
       throw new ApiError(res.status, errorData);
     }
@@ -104,6 +124,9 @@ const createApiClient = (baseURL: string) => {
     });
 
     if (!res.ok) {
+      if (res.status === 401) {
+        handleUnauthorized();
+      }
       const errorData = await parseResponseBody<unknown>(res);
       throw new ApiError(res.status, errorData);
     }

--- a/genai-web/packages/web/src/local/localAuth.ts
+++ b/genai-web/packages/web/src/local/localAuth.ts
@@ -54,6 +54,11 @@ export const captureTokenFromUrl = (): void => {
 
 export const getToken = (): string | null => localStorage.getItem(TOKEN_KEY);
 
+/** localStorage の JWT を破棄する（認証エラー時に壊れたセッションを残さない） */
+export const clearToken = (): void => {
+  localStorage.removeItem(TOKEN_KEY);
+};
+
 export const isAuthenticated = (): boolean => {
   const token = getToken();
   if (!token) {
@@ -75,7 +80,7 @@ export const login = (): void => {
 export const signOut = (): void => {
   // SLO(Keycloak セッション終了) のため、破棄前のトークンを backend に渡す
   const token = getToken();
-  localStorage.removeItem(TOKEN_KEY);
+  clearToken();
   const query = token ? `?token=${encodeURIComponent(token)}` : '';
   window.location.href = `${API_ENDPOINT}/auth/logout${query}`;
 };

--- a/genai-web/packages/web/src/main.tsx
+++ b/genai-web/packages/web/src/main.tsx
@@ -6,7 +6,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { BrowserRouter } from 'react-router';
 import { OnlineStatusProvider } from '@/components/OnlineStatusProvider';
 import { GlobalErrorFallback } from '@/components/ui/GlobalErrorFallback';
-import { captureTokenFromUrl, isAuthenticated, login } from '@/local/localAuth';
+import { captureTokenFromUrl, clearToken, isAuthenticated, login } from '@/local/localAuth';
 
 // ACS からのリダイレクトで付与された #token= を取り込む（描画前に実行）
 captureTokenFromUrl();
@@ -17,6 +17,10 @@ captureTokenFromUrl();
 const AuthGate = ({ children }: { children: ReactNode }) => {
   const path = window.location.pathname;
   if (path === '/signed-out' || path === '/auth-error') {
+    // 認証エラー到達時は壊れたトークンを残さない（セッションを永続化しない）
+    if (path === '/auth-error') {
+      clearToken();
+    }
     return <>{children}</>;
   }
   if (!isAuthenticated()) {

--- a/genai-web/packages/web/src/pages/AuthErrorPage.tsx
+++ b/genai-web/packages/web/src/pages/AuthErrorPage.tsx
@@ -1,8 +1,16 @@
+import { useEffect } from 'react';
 import { PageTitle } from '@/components/PageTitle';
+import { Button } from '@/components/ui/dads/Button';
 import { APP_TITLE } from '@/constants';
+import { clearToken, login } from '@/local/localAuth';
 
 export const AuthErrorPage = () => {
   const PAGE_TITLE = '認証エラー';
+
+  // 壊れたセッションを残さないよう、到達時に古いトークンを破棄する
+  useEffect(() => {
+    clearToken();
+  }, []);
 
   return (
     <>
@@ -12,8 +20,14 @@ export const AuthErrorPage = () => {
           <h1 className='mb-8 text-std-28B-150 lg:text-std-45B-140'>認証エラー</h1>
 
           <p className='text-std-18N-160'>
-            認証に失敗しました。しばらく時間をおいて再度お試しいただき、それでも解消しない場合、管理者にお問い合わせください。
+            認証に失敗しました。下のボタンから再度ログインしてください。解消しない場合は管理者にお問い合わせください。
           </p>
+
+          <div>
+            <Button size='lg' variant='solid-fill' onClick={() => login()}>
+              ログイン画面へ戻る
+            </Button>
+          </div>
         </main>
       </div>
     </>


### PR DESCRIPTION
## 背景
Keycloak を再構成した後などにログインを試みると失敗し、ブラウザのサイトデータを削除するまで回復しない、という報告への対応。

原因は「壊れた状態が自己回復しない」点:
- クライアントの `isAuthenticated()` は署名を検証せず `exp` だけを見るため、鍵変更後の古いトークンでも有効と誤判定
- `/auth-error` はトークンを破棄せず再ログイン導線もない（`/signed-out` にはある）
- `fetcher` は 401 でも例外を投げるだけでログインへ戻さない

結果、古い `open-genai-token`（と Keycloak SSO Cookie）が残り続ける。

## 変更（セッションを永続化せず、素直にログインへ戻す）
- `local/localAuth.ts`: `clearToken()` を追加（`signOut` でも利用）
- `main.tsx`: `/auth-error` 到達時に `clearToken()`
- `pages/AuthErrorPage.tsx`: 到達時にトークン破棄＋「ログイン画面へ戻る」ボタン追加
- `lib/fetcher.ts`: 401 応答時に `clearToken()` + `login()`（多重リダイレクト防止ガード付き。認証ページ上では発火しない）
- `backend/app/main.py`: ACS 失敗時に `auth.reset_settings_cache()` を呼び、Keycloak 再構成後の古い IdP メタデータ/証明書キャッシュを次回で刷新

## Test plan
- [ ] 期限内でも不正な古いトークンで API を叩くと 401 → 自動でログインへ戻ること
- [ ] SAML 失敗で `/auth-error` に来たとき、古いトークンが破棄され「ログイン画面へ戻る」で再ログインできること
- [ ] 正常ログインが従来どおり動くこと
- [ ] Keycloak 再構成後、キャッシュ削除なしでも再ログインが通ること
- [ ] 反映には web コンテナ再起動（Vite 配信）と backend 再ビルドが必要

Made with [Cursor](https://cursor.com)