### PR TITLE
feat(web): 本番 web を静的ビルド配信にして dev/prod 差異を compose で吸収

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -160,23 +160,13 @@ services:
   web:
     build:
       context: ./genai-web
-      dockerfile: Dockerfile.local
+      dockerfile: Dockerfile.prod
+      args:
+        VITE_APP_API_ENDPOINT: /api
+        VITE_APP_TEAM_ACCESS_CONTROL_API_ENDPOINT: /api
     container_name: open-genai-web
     expose:
-      - "5173"
-    environment:
-      - VITE_USE_POLLING=true
-      - VITE_APP_API_ENDPOINT=/api
-      - VITE_APP_TEAM_ACCESS_CONTROL_API_ENDPOINT=/api
-      # proxy 経由の公開ホスト名を Vite に許可させる（例: genai.example.lg.jp）
-      - VITE_ALLOWED_HOSTS=${VITE_ALLOWED_HOSTS:-true}
-    volumes:
-      - ./genai-web:/app
-      - web_node_modules:/app/node_modules
-      - web_pkg_web_node_modules:/app/packages/web/node_modules
-      - web_pkg_common_node_modules:/app/packages/common/node_modules
-      - web_pkg_types_node_modules:/app/packages/types/node_modules
-      - web_pkg_cdk_node_modules:/app/packages/cdk/node_modules
+      - "80"
     depends_on:
       - backend
     restart: unless-stopped
@@ -336,11 +326,6 @@ services:
 
 volumes:
   backend_data:
-  web_node_modules:
-  web_pkg_web_node_modules:
-  web_pkg_common_node_modules:
-  web_pkg_types_node_modules:
-  web_pkg_cdk_node_modules:
   qdrant_data:
   keycloak_data:
   whisper_cache:

--- a/genai-web/Dockerfile.prod
+++ b/genai-web/Dockerfile.prod
@@ -1,0 +1,29 @@
+# Open GENAI: 本番向け静的ビルドを nginx で配信する
+FROM node:22.22.2-bookworm-slim AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY packages/web/package.json packages/web/package.json
+COPY packages/cdk/package.json packages/cdk/package.json
+COPY packages/common/package.json packages/common/package.json
+COPY packages/types/package.json packages/types/package.json
+
+RUN npm install
+
+COPY . .
+
+# ビルド時に埋め込む公開エンドポイント（compose の build.args で上書き可）
+ARG VITE_APP_API_ENDPOINT=/api
+ARG VITE_APP_TEAM_ACCESS_CONTROL_API_ENDPOINT=/api
+ENV VITE_APP_API_ENDPOINT=${VITE_APP_API_ENDPOINT} \
+    VITE_APP_TEAM_ACCESS_CONTROL_API_ENDPOINT=${VITE_APP_TEAM_ACCESS_CONTROL_API_ENDPOINT}
+
+RUN npm run web:build
+
+FROM nginx:1.27-alpine
+
+COPY --from=build /app/packages/web/dist /usr/share/nginx/html
+COPY packages/web/nginx.spa.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80

--- a/genai-web/packages/web/nginx.spa.conf
+++ b/genai-web/packages/web/nginx.spa.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA: 実ファイルがなければ index.html へフォールバック
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # ハッシュ付きアセットは長期キャッシュ
+    location /assets/ {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+}

--- a/genai-web/packages/web/src/features/chat/ChatPage.tsx
+++ b/genai-web/packages/web/src/features/chat/ChatPage.tsx
@@ -42,7 +42,7 @@ export const ChatPage = () => {
     setHasSent,
   } = useChatStore();
 
-  const { pathname, search, state } = useLocation();
+  const { search, state } = useLocation();
   const { usecase, chatId } = useUsecasePath();
   const navigate = useNavigate();
   const { scrollTopAnchorRef, scrollBottomAnchorRef } = useScreen({

--- a/genai-web/packages/web/src/features/generate-image/utils/ensureImagePersistTarget.ts
+++ b/genai-web/packages/web/src/features/generate-image/utils/ensureImagePersistTarget.ts
@@ -45,7 +45,8 @@ export async function ensureImagePersistTarget(params: {
     ],
   });
 
-  const recorded = messages.find((m) => m.messageId === messageId) ?? messages.at(-1);
+  const recorded =
+    messages.find((m) => m.messageId === messageId) ?? messages[messages.length - 1];
   if (!recorded?.messageId) {
     return null;
   }

--- a/genai-web/packages/web/src/routes.tsx
+++ b/genai-web/packages/web/src/routes.tsx
@@ -27,96 +27,59 @@ import { AuthErrorPage } from './pages/AuthErrorPage';
 import { SignedOutPage } from './pages/SignedOutPage';
 
 export const createRoutes = (): RouteObject[] => {
+  const optionalUseCaseRoutes: Array<RouteObject[] | null> = [
+    isUseCaseEnabled('generate')
+      ? [
+          { path: 'generate', element: <GenerateTextPage /> },
+          { path: 'generate/:chatId', element: <GenerateTextPage /> },
+        ]
+      : null,
+    isUseCaseEnabled('translate')
+      ? [
+          { path: 'translate', element: <TranslatePage /> },
+          { path: 'translate/:chatId', element: <TranslatePage /> },
+        ]
+      : null,
+    isUseCaseEnabled('image')
+      ? [
+          { path: 'image', element: <GenerateImagePage /> },
+          { path: 'image/:chatId', element: <GenerateImagePage /> },
+        ]
+      : null,
+    isUseCaseEnabled('diagram')
+      ? [
+          { path: 'diagram', element: <GenerateDiagramPage /> },
+          { path: 'diagram/:chatId', element: <GenerateDiagramPage /> },
+        ]
+      : null,
+  ];
+
+  const children: RouteObject[] = [
+    { index: true, element: <LandingPage /> },
+    { path: 'apps', element: <ExAppsPage /> },
+    { path: 'apps/:teamId/:exAppId', element: <ExAppPage /> },
+    { path: 'chat', element: <ChatPage /> },
+    { path: 'chat/:chatId', element: <ChatPage /> },
+    { path: 'history', element: <ChatHistoryPage /> },
+    ...optionalUseCaseRoutes.flatMap((routes) => routes ?? []),
+    { path: 'transcribe', element: <TranscribePage /> },
+    { path: 'teams', element: <TeamsPage /> },
+    { path: 'teams/create', element: <TeamCreatePage /> },
+    { path: 'teams/:teamId/edit', element: <TeamEditPage /> },
+    { path: 'teams/:teamId/members', element: <TeamMembersPage /> },
+    { path: 'teams/:teamId/members/create', element: <TeamMemberCreatePage /> },
+    { path: 'teams/:teamId/members/:userId/edit', element: <TeamMemberEditPage /> },
+    { path: 'teams/:teamId/apps', element: <TeamAppsPage /> },
+    { path: 'teams/:teamId/apps/create', element: <TeamAppCreatePage /> },
+    { path: 'teams/:teamId/apps/:appId/edit', element: <TeamAppEditPage /> },
+    { path: 'teams/:teamId/apps/:appId/copy', element: <TeamAppCopyPage /> },
+    { path: 'docs/api-request-data-format', element: <ApiRequestDataFormatPage /> },
+    { path: '*', element: <NotFound /> },
+  ];
+
   return [
-    {
-      path: '/signed-out',
-      element: <SignedOutPage />,
-    },
-    {
-      path: '/auth-error',
-      element: <AuthErrorPage />,
-    },
-    {
-      path: '/',
-      element: <Layout />,
-      children: [
-        { index: true, element: <LandingPage /> },
-        {
-          path: 'apps',
-          element: <ExAppsPage />,
-        },
-        { path: 'apps/:teamId/:exAppId', element: <ExAppPage /> },
-        {
-          path: 'chat',
-          element: <ChatPage />,
-        },
-        {
-          path: 'chat/:chatId',
-          element: <ChatPage />,
-        },
-        { path: 'history', element: <ChatHistoryPage /> },
-        isUseCaseEnabled('generate')
-          ? [
-              { path: 'generate', element: <GenerateTextPage /> },
-              { path: 'generate/:chatId', element: <GenerateTextPage /> },
-            ]
-          : null,
-        isUseCaseEnabled('translate')
-          ? [
-              { path: 'translate', element: <TranslatePage /> },
-              { path: 'translate/:chatId', element: <TranslatePage /> },
-            ]
-          : null,
-        isUseCaseEnabled('image')
-          ? [
-              { path: 'image', element: <GenerateImagePage /> },
-              { path: 'image/:chatId', element: <GenerateImagePage /> },
-            ]
-          : null,
-        isUseCaseEnabled('diagram')
-          ? [
-              { path: 'diagram', element: <GenerateDiagramPage /> },
-              { path: 'diagram/:chatId', element: <GenerateDiagramPage /> },
-            ]
-          : null,
-        { path: 'transcribe', element: <TranscribePage /> },
-        { path: 'teams', element: <TeamsPage /> },
-        { path: 'teams/create', element: <TeamCreatePage /> },
-        {
-          path: 'teams/:teamId/edit',
-          element: <TeamEditPage />,
-        },
-        {
-          path: 'teams/:teamId/members',
-          element: <TeamMembersPage />,
-        },
-        {
-          path: 'teams/:teamId/members/create',
-          element: <TeamMemberCreatePage />,
-        },
-        {
-          path: 'teams/:teamId/members/:userId/edit',
-          element: <TeamMemberEditPage />,
-        },
-        {
-          path: 'teams/:teamId/apps',
-          element: <TeamAppsPage />,
-        },
-        {
-          path: 'teams/:teamId/apps/create',
-          element: <TeamAppCreatePage />,
-        },
-        {
-          path: 'teams/:teamId/apps/:appId/edit',
-          element: <TeamAppEditPage />,
-        },
-        {
-          path: 'teams/:teamId/apps/:appId/copy',
-          element: <TeamAppCopyPage />,
-        },
-        { path: 'docs/api-request-data-format', element: <ApiRequestDataFormatPage /> },
-        { path: '*', element: <NotFound /> },
-      ].flatMap((r) => (Array.isArray(r) ? r : r ? [r] : [])),
-    },
-  ].flatMap((r) => (Array.isArray(r) ? r : r ? [r] : []));
+    { path: '/signed-out', element: <SignedOutPage /> },
+    { path: '/auth-error', element: <AuthErrorPage /> },
+    { path: '/', element: <Layout />, children },
+  ];
 };

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -99,14 +99,12 @@ http {
             proxy_set_header X-Forwarded-Prefix /kc;
         }
 
-        # --- フロントエンド（Vite dev server / HMR WebSocket 対応）---
+        # --- フロントエンド（静的ビルド / nginx）---
         location / {
-            set $web_upstream http://web:5173;
+            set $web_upstream http://web:80;
             proxy_pass $web_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host              $host;
-            proxy_set_header Upgrade           $http_upgrade;
-            proxy_set_header Connection        $connection_upgrade;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;


### PR DESCRIPTION
## Summary
- 本番実体（静的ビルド配信）とリポジトリの `docker-compose.prod.yml`（Vite dev server）の乖離を解消し、**開発=Vite / 本番=静的ビルド**を compose の切替だけで表現できるようにします。
- PR #5 のうち **静的ビルド基盤部分のみ** を抽出（SAML 修正は #16、認証エラー導線は #17 で反映済み。UI のユーザ名表示機能は本 PR に含めません）。

## Changes
- `genai-web/Dockerfile.prod`（新規）: multi-stage（`node:22.22.2` で `npm run web:build` → `nginx:1.27-alpine` で `dist` を配信）。公開エンドポイントは build.args で注入。
- `genai-web/packages/web/nginx.spa.conf`（新規）: SPA フォールバック（`try_files ... /index.html`）＋ `/assets` 長期キャッシュ。
- `docker-compose.prod.yml`: web を `Dockerfile.local`(Vite) → `Dockerfile.prod`(静的) へ。`expose` を 5173→80、Vite 用 env / bind mount / node_modules ボリュームを削除。
- `proxy/nginx.conf`: `location /` を `http://web:5173` → `http://web:80` に変更し、静的配信では不要な HMR 用 `Upgrade`/`Connection` ヘッダを除去。
- 静的ビルド（`tsc`）を通すための最小 TS 修正:
  - `ChatPage.tsx`: 未使用 `pathname` を削除（`noUnusedLocals`）。
  - `ensureImagePersistTarget.ts`: `Array.at(-1)`（ES2022）を index 参照へ（`target: ES2020`）。
  - `routes.tsx`: `RouteObject[]` の型不整合を解消（構造を整理）。

## 開発/本番の差異
- 開発: `docker-compose.yml`（Vite dev server + bind mount で無ビルド即時反映）
- 本番: `docker-compose.prod.yml`（`npm run web:build` の静的成果物を nginx 配信）
- 同一コードを配信方式のみで切替。

## Test plan / 検証済み
- [x] `npm run web:build` がグリーン（tsc + vite build 成功）
- [x] `docker build -f genai-web/Dockerfile.prod` 成功
- [x] 生成イメージで `/` = 200(text/html)、`/chat` の SPA フォールバック = 200
- [x] `index.html` が `/assets/*.js`（静的）を参照（`/src/*.tsx` を配信しない）
- [ ] （デプロイ時）HTTPS 公開 URL で SAML ログイン後にアプリへ戻ること

Made with [Cursor](https://cursor.com)