### PR TITLE
docs: 本番デプロイ手順を README に追記し、HTTP検証を静的ビルドに整合

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -14,9 +14,9 @@ PUBLIC_URL=https://genai.example.lg.jp
 PROXY_HTTP_PORT=80
 PROXY_HTTPS_PORT=443
 
-# Vite(dev server) に許可させる公開ホスト名（true で全許可、または PUBLIC_URL のホスト）
-# 例: genai.example.lg.jp
-VITE_ALLOWED_HOSTS=genai.example.lg.jp
+# 本番/検証(prod.yml)の web は静的ビルド（Dockerfile.prod + nginx）で配信するため、
+# この VITE_ALLOWED_HOSTS は使用しません（Vite dev server 用。dev の docker-compose.yml のみ）。
+# VITE_ALLOWED_HOSTS=genai.example.lg.jp
 
 # === 認証・鍵（本番では必ず変更）===
 APP_JWT_SECRET=please-change-to-a-long-random-secret
@@ -116,7 +116,8 @@ URL_FETCH_ALLOWED_HOSTS=
 # ============================================================================
 # 併せて必要な「設定ファイル」側の変更（このファイルでは反映されない項目）
 # ============================================================================
-# 1) フロントの API 参照は docker-compose で VITE_APP_*=/api を注入済み。
+# 1) フロントの API 参照は docker-compose.prod.yml の build.args で VITE_APP_*=/api を
+#    ビルド時に静的バンドルへ埋め込み済み（相対 /api）。変更時は web の再ビルドが必要。
 #    ホストで genai-web を直接起動する場合のみ packages/web/.env に設定:
 #      VITE_APP_API_ENDPOINT=/api
 #      VITE_APP_TEAM_ACCESS_CONTROL_API_ENDPOINT=/api

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ Linux + NVIDIA GPU 機（例: **NVIDIA DGX Spark**）でも動作します。
 | `seaweedfs/` | 成果物配信用 S3 互換ストレージ設定 |
 | `scripts/` | 運用スクリプト（契約終了時の完全削除・報告書生成 等） |
 | `docs/` | Open GENAI レイヤのガイド（[ナレッジ API](docs/knowledge-api.md) / [MCP](docs/knowledge-mcp.md) / [Dify 事例](docs/dify-knowledge.md)） |
-| `docker-compose.yml` | proxy + web / backend / … をまとめて起動（HTTP :80 のみ公開） |
-| `docker-compose.prod.yml` | 本番 TLS 構成（proxy :80/:443 のみ公開） |
-| `docker-compose.verify.yml` | 本番スタックの HTTP 検証用オーバーライド（自己署名不要） |
-| `proxy/` | nginx リバースプロキシ設定（`nginx.http.conf` / `nginx.conf`）。成果物ファイル（SeaweedFS）用の別経路は README「成果物ファイル」節を参照 |
+| `docker-compose.yml` | **開発用**。proxy + web(Vite dev server) / backend / … をまとめて起動（HTTP :80 のみ公開、コード変更は無ビルドで即時反映） |
+| `docker-compose.prod.yml` | **本番 TLS 構成**（proxy :80/:443 のみ公開。web は静的ビルド `genai-web/Dockerfile.prod` を nginx で配信） |
+| `docker-compose.verify.yml` | 本番スタックを HTTP で検証／閉域運用するオーバーライド（自己署名不要。web は本番同様の静的ビルド） |
+| `proxy/` | nginx リバースプロキシ設定（開発=`nginx.http.conf` / 本番TLS=`nginx.conf` / 本番HTTP検証=`nginx.verify.conf`）。成果物ファイル（SeaweedFS）用の別経路は README「成果物ファイル」節を参照 |
 
 ## オリジナル源内からの改修内容（クラウド依存 → オープンアーキテクチャ）
 
@@ -256,6 +256,91 @@ docker compose up --build
 - http://localhost:8333/ をブラウザで開くと XML の `AccessDenied` が表示されること（SeaweedFS S3 API の正常応答。**開発時のみホスト公開**。本番は `S3_PUBLIC_ENDPOINT` 経由のリバースプロキシのみ公開）
 - （Dify 連携）[`dify-app/dsl/File Output Test.yml`](dify-app/dsl/File Output Test.yml) をデプロイし、源内 AI アプリから実行して成果物リンクが表示されること
 - http://localhost/kc/ の **Administration Console** に `.env` の `KEYCLOAK_ADMIN` でログインでき、realm **`open-genai`** の Users / Groups が表示されること（利用者アカウント管理用。源内ログイン画面とは別）
+
+## 本番デプロイ
+
+開発環境（`docker compose up`）と本番環境では、**フロントエンド（源内 Web）の配信方式**が異なります。ここでは本番デプロイの前提・初回手順・変更反映の運用をまとめます。
+
+### 開発と本番の違い（配信方式）
+
+| 項目 | 開発（`docker-compose.yml`） | 本番（`docker-compose.prod.yml`） |
+| --- | --- | --- |
+| web の配信 | **Vite dev server**（`Dockerfile.local`, :5173）をバインドマウントで起動 | **静的ビルド**（`Dockerfile.prod` で `npm run web:build` → nginx が `dist` を :80 配信） |
+| フロント変更の反映 | ソース保存で**即時反映**（無ビルド・HMR） | **web イメージの再ビルドが必要**（静的バンドルにビルド時取り込み） |
+| 公開 | proxy が HTTP :80 | proxy が TLS :443 終端（`proxy/nginx.conf`） |
+| API 参照 | `VITE_APP_*` を実行時 env で注入 | `VITE_APP_*` を **build.args でビルド時に埋め込み** |
+
+> backend / 各 exApp（Python）はどちらもイメージ内のコードで動くため、変更時はイメージ再ビルド＋再作成が必要です（下記「変更の反映」参照）。開発で Python 側を即時反映したい場合は各サービスにバインドマウント等を追加してください（既定は web のみ即時反映）。
+
+### 前提
+
+- `.env.prod` を用意（`cp .env.prod.example .env.prod` して編集）。**最低限**、次は本番用に必ず変更します。
+  - `PUBLIC_URL`（例: `https://genai.example.lg.jp`。末尾スラッシュ無し）
+  - `APP_JWT_SECRET` / `INTERNAL_SIGNING_SECRET`（十分長い乱数。例: `openssl rand -hex 32`）
+  - `KEYCLOAK_ADMIN_PASSWORD`（**初回起動前**に設定。詳細は[認証節の「運用開始時」](#運用開始時本番閉域-パスワード変更)）
+  - `S3_*`（`S3_PUBLIC_ENDPOINT` / `S3_ACCESS_KEY` / `S3_SECRET_KEY` 等。詳細は[成果物ファイル節](#成果物ファイルseaweedfs-再ホスト)）
+- TLS 証明書を `proxy/certs/{fullchain.pem,privkey.pem}` に配置（`docker-compose.prod.yml` が `/etc/nginx/certs` にマウント。詳細は [`proxy/certs/README.md`](proxy/certs/README.md)）。
+- Keycloak の SAML クライアント（SP）登録を `PUBLIC_URL` に合わせる（初回 import 前に `keycloak/import/realm-open-genai.json` を編集、または admin コンソールで更新。詳細は[SAML 節](#源内側の設定変更時に必要な作業)）。
+
+### 初回デプロイ（本番 TLS）
+
+```bash
+# 1. 設定と証明書を用意
+cp .env.prod.example .env.prod        # PUBLIC_URL・各シークレット等を編集
+#    proxy/certs/fullchain.pem, privkey.pem を配置
+
+# 2. ビルドして起動（web は静的ビルドされる）
+docker compose -f docker-compose.prod.yml --env-file .env.prod up --build -d
+
+# 3. 状態確認
+docker compose -f docker-compose.prod.yml --env-file .env.prod ps
+```
+
+- 公開 URL（`PUBLIC_URL`）でログイン画面（Keycloak）に遷移すること
+- 初回はフロントのビルドに数分かかります
+- 起動後、初期ユーザー（`admin`/`user`）の無効化・パスワード変更を必ず実施（[運用開始時](#運用開始時本番閉域-パスワード変更)）
+
+### 変更の反映（再デプロイ）
+
+本番はビルド済みイメージで動くため、変更箇所に応じて対象サービスを**再ビルド＋再作成**します。
+
+| 変更した箇所 | 反映コマンド（`-f docker-compose.prod.yml --env-file .env.prod` を付与） |
+| --- | --- |
+| **フロント**（`genai-web/**`。プロンプト・画面・ルーティング等） | `docker compose ... up -d --build web` |
+| **backend**（`backend/**`） | `docker compose ... up -d --build backend` |
+| **各 exApp**（`rag-app/` 等） | `docker compose ... up -d --build <service>` |
+| **proxy 設定**（`proxy/nginx.conf`） | `docker compose ... restart proxy`（設定はマウントのため再起動のみ） |
+| **`.env.prod` の値**（LLM 接続・S3 公開先・`TITLE_MODE` 等） | 対象サービスを `up -d`（再作成で env 再読込。フロント埋め込み値は再ビルド） |
+
+```bash
+# 例: フロントのプロンプト/画面を変更 → web を再ビルドして差し替え
+docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build web
+```
+
+> **注意:** フロントの見た目・文言・プロンプトの変更は、`web` を再ビルドしない限り本番へ反映されません（静的バンドルにビルド時取り込みのため）。開発環境では即時反映されるので、この差に注意してください。
+
+### 閉域・HTTP のみで運用/検証する場合
+
+TLS 終端や自己署名証明書が使えず、ポート 80 のみで公開する環境（閉域検証など）向けに、本番スタックを HTTP で動かすオーバーライドを用意しています。web は本番同様の**静的ビルド**を使い、proxy だけを HTTP・静的上流用の `proxy/nginx.verify.conf` に差し替えます。
+
+```bash
+cp .env.prod.example .env.prod
+#   PUBLIC_URL=http://localhost（またはホスト名）, PROXY_HTTP_PORT=80 等に編集
+docker compose -f docker-compose.prod.yml -f docker-compose.verify.yml \
+  --env-file .env.prod up --build -d
+```
+
+- `PUBLIC_URL` は `http://` で始めること（証明書は不要）
+- ポート 80 が使用中なら `.env.prod` の `PROXY_HTTP_PORT=8080` 等に変更し、`PUBLIC_URL` も合わせる
+
+### 前段にゲートウェイ/別リバースプロキシがある場合（SAML 注意）
+
+`PUBLIC_URL` が SAML の SP EntityID / ACS / SLS と Keycloak の公開ホスト（`KC_HOSTNAME`）の**単一の正**になります。前段に別ホスト名のゲートウェイを置く場合は、次のいずれかにしてください。
+
+- **公開ホストを 1 つに統一**: 利用者に見せるホスト名を `PUBLIC_URL` に設定し、ゲートウェイは `/`・`/api`・`/kc` すべてを **Host ヘッダを保持**して転送する。Keycloak の SAML クライアント（ACS/EntityID）もそのホストで登録する。
+- backend は `X-Forwarded-Proto` / `X-Forwarded-Host` / `X-Forwarded-Port` から公開 URL を組み立てるため、前段プロキシはこれらを正しく付与すること（本リポジトリの `proxy/nginx.conf` は TLS 終端時に `https` / `$host` / `443` を送出）。
+
+> 複数の公開ホストで同時に SAML を成立させることは、現状の単一 `PUBLIC_URL` 前提ではできません（EntityID/ACS が固定のため）。
 
 ## ファイル添付（画像 / ドキュメント）
 

--- a/docker-compose.verify.yml
+++ b/docker-compose.verify.yml
@@ -2,6 +2,8 @@
 #
 # 閉域検証など TLS/自己署名証明書が使えずポート 80 のみ公開できる環境向け。
 # 証明書不要。PUBLIC_URL は http:// で始めること（例: http://localhost）。
+# web は本番同様の静的ビルド（docker-compose.prod.yml の Dockerfile.prod / :80）を
+# そのまま使い、proxy だけを HTTP・静的上流用の nginx.verify.conf に差し替える。
 #
 # 使い方:
 #   cp .env.prod.example .env.prod
@@ -16,4 +18,4 @@ services:
     ports: !override
       - "${PROXY_HTTP_PORT:-80}:80"
     volumes: !override
-      - ./proxy/nginx.http.conf:/etc/nginx/nginx.conf:ro
+      - ./proxy/nginx.verify.conf:/etc/nginx/nginx.conf:ro

--- a/proxy/nginx.verify.conf
+++ b/proxy/nginx.verify.conf
@@ -1,0 +1,78 @@
+# Open GENAI 本番スタックの HTTP 検証/閉域運用用リバースプロキシ（TLS 不要）。
+#
+# docker-compose.prod.yml（静的ビルドの web を nginx で :80 配信）を、TLS/自己署名
+# 証明書を使わずポート 80 のみで検証・閉域運用するための設定。dev 用の
+# proxy/nginx.http.conf（web = Vite dev server:5173）とは web の上流だけが異なる。
+#   /      -> web (静的ビルド nginx):80   ブラウザの SPA
+#   /api/  -> backend:8000 (prefix 除去)  API・SAML SP・ファイル配信
+#   /kc/   -> keycloak:8080 (relative /kc) SAML IdP
+#
+# 本番 TLS 終端は proxy/nginx.conf を使用する。
+
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    sendfile      on;
+    server_tokens off;
+
+    client_max_body_size 64m;
+
+    server {
+        listen 80;
+        listen [::]:80;
+        server_name _;
+
+        resolver 127.0.0.11 valid=30s ipv6=off;
+
+        location /api/ {
+            set $backend_upstream http://backend:8000;
+            rewrite ^/api/(.*)$ /$1 break;
+            proxy_pass $backend_upstream;
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host  $host;
+            proxy_set_header X-Forwarded-Prefix /api;
+            proxy_buffering    off;
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
+        }
+
+        # Keycloak が /kc 無しの SAML URL を返した場合の救済
+        location /realms/ {
+            return 302 $scheme://$host/kc$request_uri;
+        }
+
+        location /kc/ {
+            set $kc_upstream http://keycloak:8080;
+            proxy_pass $kc_upstream;
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host  $host;
+            proxy_set_header X-Forwarded-Port  $server_port;
+            proxy_set_header X-Forwarded-Prefix /kc;
+        }
+
+        # --- フロントエンド（静的ビルド / nginx）---
+        location / {
+            set $web_upstream http://web:80;
+            proxy_pass $web_upstream;
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- README に **「本番デプロイ」節** を新設し、開発（Vite 即時反映）と本番（静的ビルド）の違い・初回デプロイ・変更反映（web 再ビルド）・閉域 HTTP 運用・前段ゲートウェイ時の SAML 注意をまとめました（[PR #18](https://github.com/hirokawaguchi/open-genai/pull/18) の運用面を明文化）。
- あわせて **PR #18 のリグレッションを修正**: prod の web を静的（:80）化した結果、`docker-compose.verify.yml`（prod + HTTP 検証）が dev 共用の `nginx.http.conf`（web:5173）を使っていて壊れていました。HTTP + 静的 web:80 用の `proxy/nginx.verify.conf` を新設して verify に割り当て、整合を取りました（dev の `nginx.http.conf` は Vite:5173 のまま不変）。

## Changes
- `README.md`: 「本番デプロイ」節を追加。構成表の compose/proxy 記述を静的ビルド・`nginx.verify.conf` 反映に更新。
- `proxy/nginx.verify.conf`（新規）: HTTP(80) + フロント上流 `web:80`（静的）。`/api`・`/kc`・`/realms` は `nginx.http.conf` と同一。
- `docker-compose.verify.yml`: proxy のマウントを `nginx.http.conf` → `nginx.verify.conf` に変更。
- `.env.prod.example`: 静的ビルドで未使用の `VITE_ALLOWED_HOSTS` を注記化。`VITE_APP_*` は build.args でビルド時埋め込みである旨を明記。

## Test plan / 検証済み
- [x] `docker compose -f docker-compose.prod.yml config` … web=Dockerfile.prod / expose 80 / proxy=nginx.conf+certs / ports 80,443
- [x] `docker compose -f docker-compose.prod.yml -f docker-compose.verify.yml config` … web=Dockerfile.prod(静的) / proxy=**nginx.verify.conf** / ports 80
- [x] `nginx -t`（`nginx.verify.conf`）成功
- [x] README の文書内アンカーリンクがすべて解決

Made with [Cursor](https://cursor.com)