### PR TITLE
feat(rag): 埋め込みモデルを env で差し替え可能にし embed サイドカーをオプトイン追加

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -64,9 +64,36 @@ GEMINI_API_KEY=
 AZURE_OPENAI_API_KEY=
 
 # === RAG / 監査 / 各 AI アプリ ===
+# --- 埋め込みモデル（任意の OpenAI 互換サーバに差し替え可能）---
+# 既定は Ollama 上の mxbai-embed-large（1024 次元）。EMBED_BASE_URL 未設定なら
+# OPENAI_BASE_URL / OPENAI_API_KEY を使う（従来挙動）。
+# ※ モデルを変えると次元が変わる。Qdrant コレクションは次元固定のため、モデル変更時は
+#    QDRANT_COLLECTION を別名にし、全件を再インデックスすること（既存と混在不可）。
 EMBED_MODEL=mxbai-embed-large
+EMBED_DIM=1024
+# QDRANT_COLLECTION=open_genai_rag
+# 埋め込みだけ別エンドポイントへ分離する場合に設定（embed サイドカー / 外部の埋め込みAPI）。
+# EMBED_BASE_URL=
+# EMBED_API_KEY=
+# 検索クエリ/文書の prefix はモデル依存。既定は mxbai 互換（クエリのみ英語 prefix・文書なし）。
+# EMBED_QUERY_PREFIX=Represent this sentence for searching relevant passages: 
+# EMBED_DOC_PREFIX=
+#
+# --- 例: ローカル日本語埋め込み ruri-v3-310m を embed サイドカーで使う場合 ---
+#   下記を有効化し、`docker compose --profile embed ...`（または COMPOSE_PROFILES=embed）で起動する。
+# COMPOSE_PROFILES=embed
+# EMBED_BASE_URL=http://embed:80/v1
+# EMBED_API_KEY=-
+# EMBED_MODEL=cl-nagoya/ruri-v3-310m
+# EMBED_DIM=768
+# QDRANT_COLLECTION=open_genai_rag_ruri_v3_310m
+# EMBED_QUERY_PREFIX=検索クエリ: 
+# EMBED_DOC_PREFIX=検索文書: 
+#
 RAG_MODEL=gpt-oss:20b
 RAG_API_KEY=change-me-local-rag-key
+# 起動時のサンプル自動投入。本番でサンプル不要なら false。
+RAG_SEED_SAMPLES=false
 AUDIT_ENABLED=true
 AUDIT_STORE_CONTENT=true
 AUDIT_MAX_CONTENT_CHARS=8000

--- a/README.md
+++ b/README.md
@@ -342,6 +342,51 @@ docker compose -f docker-compose.prod.yml -f docker-compose.verify.yml \
 
 > 複数の公開ホストで同時に SAML を成立させることは、現状の単一 `PUBLIC_URL` 前提ではできません（EntityID/ACS が固定のため）。
 
+### 埋め込みモデルの差し替え / ローカル日本語埋め込み（`embed` サイドカー）
+
+RAG の埋め込みモデルは推論モデルと同様に**差し替え可能**です。既定は Ollama 上の
+`mxbai-embed-large`（1024 次元）で、開発・検証・既定の本番はこのままで動きます（追加設定不要）。
+挙動はすべて `rag-app` の環境変数で制御され、コードは単一パスのままです。
+
+| 環境変数 | 既定 | 役割 |
+| --- | --- | --- |
+| `EMBED_MODEL` | `mxbai-embed-large` | 埋め込みモデル名 |
+| `EMBED_DIM` | `1024` | ベクトル次元（Qdrant コレクション作成時に使用） |
+| `QDRANT_COLLECTION` | `open_genai_rag` | 保存先コレクション |
+| `EMBED_BASE_URL` | 空（=`OPENAI_BASE_URL` にフォールバック） | 埋め込みだけ別の OpenAI 互換エンドポイントへ分離する場合に設定 |
+| `EMBED_API_KEY` | 空（=`OPENAI_API_KEY`） | 上記エンドポイントの API キー |
+| `EMBED_QUERY_PREFIX` / `EMBED_DOC_PREFIX` | mxbai 互換（クエリのみ英語 prefix・文書なし） | モデル依存の検索クエリ/文書 prefix |
+
+> **重要（再インデックス）:** 埋め込みモデルを変えると**ベクトル次元と意味空間が変わります**。
+> Qdrant のコレクションは次元固定のため、既存コレクションへ別モデルのベクトルを混在させられません。
+> モデルを変更する場合は `QDRANT_COLLECTION` を別名にし、`EMBED_DIM` を合わせたうえで**全件を再インデックス**してください。
+
+#### ローカル日本語埋め込み（`ruri-v3` 等）を使う場合
+
+Ollama や TEI(CPU/ORT) が配信できない埋め込みモデル（例: `cl-nagoya/ruri-v3-310m` は
+ModernBERT-Ja・ONNX 非提供）は、同梱の汎用サイドカー `embed`（`sentence-transformers`／CPU）で配信できます。
+このサイドカーは Compose の `profiles: ["embed"]` により**任意起動**で、既定では起動しません。
+本番で日本語埋め込みが必要な場合にのみ有効化します。
+
+```bash
+# .env.prod に以下を設定（.env.prod.example の「ruri-v3-310m を使う場合」の例を参照）
+#   COMPOSE_PROFILES=embed
+#   EMBED_BASE_URL=http://embed:80/v1
+#   EMBED_API_KEY=-
+#   EMBED_MODEL=cl-nagoya/ruri-v3-310m
+#   EMBED_DIM=768
+#   QDRANT_COLLECTION=open_genai_rag_ruri_v3_310m   # 768 次元の別コレクション
+#   EMBED_QUERY_PREFIX=検索クエリ: 
+#   EMBED_DOC_PREFIX=検索文書: 
+
+# embed サイドカーを含めて起動（COMPOSE_PROFILES=embed を .env.prod に入れれば --profile 省略可）
+docker compose -f docker-compose.prod.yml --env-file .env.prod --profile embed up -d --build embed rag-app
+```
+
+- `embed` を起動しない運用では `EMBED_BASE_URL` を外部の埋め込み API に向けても構いません（サイドカー不要）。
+- 開発・検証環境では `embed` は不要です（`docker-compose.yml` / `docker-compose.verify.yml` は既定 mxbai のまま）。
+- 初回起動時にモデルを HuggingFace から取得し `embed_data` ボリュームへキャッシュします（数百 MB〜。閉域では事前取得が必要）。
+
 ## ファイル添付（画像 / ドキュメント）
 
 チャットでは画像とドキュメントを添付できます（モデルの対応機能フラグに応じて添付ボタンが出ます）。

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -182,6 +182,25 @@ services:
       - qdrant_data:/qdrant/storage
     restart: unless-stopped
 
+  # 埋め込み配信サイドカー（sentence-transformers / CPU）。任意の埋め込みモデルを
+  # OpenAI 互換 API で配信する汎用コンテナ。既定 (mxbai を Ollama で配信) では不要のため
+  # profiles で任意起動: `COMPOSE_PROFILES=embed` または `--profile embed` の時のみ起動する。
+  # Ollama 等が配信できない埋め込みモデル（例: ruri-v3=ModernBERT-Ja, ONNX 非提供）を
+  # 使う場合に有効化し、rag-app の EMBED_BASE_URL をこのサービスへ向ける。
+  embed:
+    profiles: ["embed"]
+    build:
+      context: ./embed-app
+      dockerfile: Dockerfile
+    container_name: open-genai-embed
+    environment:
+      - EMBED_MODEL=${EMBED_MODEL:-cl-nagoya/ruri-v3-310m}
+    volumes:
+      - embed_data:/data
+    expose:
+      - "80"
+    restart: unless-stopped
+
   rag-app:
     build:
       context: .
@@ -192,9 +211,22 @@ services:
       - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-ollama}
       - QDRANT_URL=http://qdrant:6333
+      # 埋め込みモデルは差し替え可能。既定は Ollama 上の mxbai-embed-large(1024 次元)。
+      # モデルを変えると次元が変わるため QDRANT_COLLECTION を分け、再インデックスが必要。
+      - QDRANT_COLLECTION=${QDRANT_COLLECTION:-open_genai_rag}
       - EMBED_MODEL=${EMBED_MODEL:-mxbai-embed-large}
+      - EMBED_DIM=${EMBED_DIM:-1024}
+      # 埋め込みだけ別エンドポイント(embed サイドカー等)へ分離する場合に設定。
+      # 未設定(空)なら OPENAI_BASE_URL / OPENAI_API_KEY にフォールバック（従来挙動）。
+      - EMBED_BASE_URL=${EMBED_BASE_URL:-}
+      - EMBED_API_KEY=${EMBED_API_KEY:-}
+      # 検索クエリ/文書の prefix はモデル依存。既定は mxbai 互換（クエリのみ英語 prefix）。
+      - "EMBED_QUERY_PREFIX=${EMBED_QUERY_PREFIX-Represent this sentence for searching relevant passages: }"
+      - "EMBED_DOC_PREFIX=${EMBED_DOC_PREFIX-}"
       - RAG_MODEL=${RAG_MODEL:-gpt-oss:20b}
       - RAG_API_KEY=${RAG_API_KEY:-local-rag-key}
+      # 起動時のサンプル自動投入。false で無効（本番でサンプル不要なら false）。
+      - RAG_SEED_SAMPLES=${RAG_SEED_SAMPLES:-true}
       - INTERNAL_SIGNING_SECRET=${INTERNAL_SIGNING_SECRET:?INTERNAL_SIGNING_SECRET を設定してください}
       - RAG_META_DB_PATH=/data/rag_meta.db
       - URL_REFRESH_INTERVAL=${URL_REFRESH_INTERVAL:-86400}
@@ -204,6 +236,7 @@ services:
       - rag_app_data:/data
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    # embed は profiles で任意起動のため depends_on にしない（埋め込みは呼び出し時のみ必要）。
     depends_on:
       - qdrant
     restart: unless-stopped
@@ -329,6 +362,7 @@ services:
 volumes:
   backend_data:
   qdrant_data:
+  embed_data:
   keycloak_data:
   whisper_cache:
   dify_app_data:

--- a/embed-app/Dockerfile
+++ b/embed-app/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    HF_HOME=/data \
+    SENTENCE_TRANSFORMERS_HOME=/data
+
+COPY requirements.txt ./
+# torch CPU ホイールを使う（GPU 不要・イメージ縮小）
+RUN pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch==2.5.1 \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+EXPOSE 80
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/embed-app/app/main.py
+++ b/embed-app/app/main.py
@@ -1,0 +1,77 @@
+"""OpenAI 互換の埋め込みサイドカー（sentence-transformers）。
+
+任意の sentence-transformers 対応モデルを CPU で配信し、OpenAI 互換の
+`/v1/embeddings` として提供する汎用サイドカー。埋め込みモデルは EMBED_MODEL で
+差し替え可能（本プロジェクトの「どのモデルでも適用可能」という思想に沿う）。
+
+HF Text Embeddings Inference (TEI, CPU/ORT) が配信できないモデル（例: ruri-v3 系＝
+ModernBERT-Ja, ONNX 非提供）の受け皿としても使える。
+
+- POST /v1/embeddings  { "model": ..., "input": str | [str, ...] }
+    -> { "object": "list", "data": [{"object":"embedding","index":i,"embedding":[...]}],
+         "model": ..., "usage": {...} }
+- GET  /health
+
+検索クエリ/文書への prefix（モデル依存: 例 Ruri の「検索クエリ: 」「検索文書: 」）は
+呼び出し側(rag-app)で付与済みのため、ここではそのままエンコードする。
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+from sentence_transformers import SentenceTransformer
+
+MODEL_ID = os.environ.get("EMBED_MODEL", "cl-nagoya/ruri-v3-310m")
+NORMALIZE = os.environ.get("EMBED_NORMALIZE", "true").lower() != "false"
+
+app = FastAPI(title="open-genai embed sidecar")
+_model: SentenceTransformer | None = None
+
+
+def _get_model() -> SentenceTransformer:
+    global _model
+    if _model is None:
+        _model = SentenceTransformer(MODEL_ID, device="cpu")
+    return _model
+
+
+class EmbeddingsRequest(BaseModel):
+    input: str | list[str]
+    model: str | None = None
+
+
+@app.on_event("startup")
+def _warmup() -> None:
+    # 起動時にモデルをロードして初回リクエストのレイテンシを避ける。
+    _get_model()
+
+
+@app.get("/health")
+def health() -> dict[str, Any]:
+    return {"status": "ok", "model": MODEL_ID}
+
+
+@app.post("/v1/embeddings")
+def embeddings(req: EmbeddingsRequest) -> dict[str, Any]:
+    inputs = [req.input] if isinstance(req.input, str) else list(req.input)
+    model = _get_model()
+    vectors = model.encode(
+        inputs,
+        normalize_embeddings=NORMALIZE,
+        convert_to_numpy=True,
+    )
+    data = [
+        {"object": "embedding", "index": i, "embedding": vec.tolist()}
+        for i, vec in enumerate(vectors)
+    ]
+    total_chars = sum(len(t) for t in inputs)
+    return {
+        "object": "list",
+        "data": data,
+        "model": req.model or MODEL_ID,
+        "usage": {"prompt_tokens": total_chars, "total_tokens": total_chars},
+    }

--- a/embed-app/requirements.txt
+++ b/embed-app/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.139.0
+uvicorn[standard]==0.34.0
+sentence-transformers==5.6.1
+transformers==5.14.1
+sentencepiece==0.2.1
+protobuf==5.29.6

--- a/rag-app/app/embeddings.py
+++ b/rag-app/app/embeddings.py
@@ -17,11 +17,22 @@ OPENAI_BASE_URL = (
     os.environ.get("OPENAI_BASE_URL") or f"{OLLAMA_BASE_URL.rstrip('/')}/v1"
 ).rstrip("/")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY") or "ollama"
+# 埋め込みは EMBED_BASE_URL（embed サイドカー等の OpenAI 互換）へ分離できる。
+# 未設定なら OPENAI_BASE_URL / OPENAI_API_KEY にフォールバックし、従来と同じ挙動になる。
+EMBED_BASE_URL = (os.environ.get("EMBED_BASE_URL") or OPENAI_BASE_URL).rstrip("/")
+EMBED_API_KEY = os.environ.get("EMBED_API_KEY") or OPENAI_API_KEY
 EMBED_MODEL = os.environ.get("EMBED_MODEL", "mxbai-embed-large")
 RAG_MODEL = os.environ.get("RAG_MODEL", "gpt-oss:20b")
 
-# mxbai-embed-large は検索クエリ側にこの prefix を付けると精度が上がる
-QUERY_PREFIX = "Represent this sentence for searching relevant passages: "
+# 検索クエリ / 文書に付ける prefix はモデル依存（本プロジェクトは任意の埋め込みモデルを
+# 差し替え可能）。既定は現行 mxbai-embed-large 互換（クエリのみ英語 prefix・文書は無し）で、
+# 既存インデックスを壊さない。ほかのモデルでは env で上書きする。
+#   例) Ruri v3: EMBED_QUERY_PREFIX="検索クエリ: " / EMBED_DOC_PREFIX="検索文書: "
+#   例) prefix 不要なモデル: 両方に空文字を設定
+QUERY_PREFIX = os.environ.get(
+    "EMBED_QUERY_PREFIX", "Represent this sentence for searching relevant passages: "
+)
+DOC_PREFIX = os.environ.get("EMBED_DOC_PREFIX", "")
 
 
 def _headers() -> dict[str, str]:
@@ -31,13 +42,20 @@ def _headers() -> dict[str, str]:
     }
 
 
+def _embed_headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {EMBED_API_KEY}",
+        "Content-Type": "application/json",
+    }
+
+
 async def embed(text: str, *, is_query: bool = False) -> list[float]:
-    prompt = (QUERY_PREFIX + text) if is_query else text
+    prompt = (QUERY_PREFIX + text) if is_query else (DOC_PREFIX + text)
     async with httpx.AsyncClient(timeout=120) as client:
         res = await client.post(
-            f"{OPENAI_BASE_URL}/embeddings",
+            f"{EMBED_BASE_URL}/embeddings",
             json={"model": EMBED_MODEL, "input": prompt},
-            headers=_headers(),
+            headers=_embed_headers(),
         )
         res.raise_for_status()
         data = res.json()


### PR DESCRIPTION
## Summary
PR #8 を「開発・検証・既存本番に無影響のオプトイン」に再設計して取り込みます。埋め込みも推論同様「どのモデルでも差し替え可能」という思想に沿い、ruri を特別扱いせず env 駆動にしました。

- **コンテナはオプトイン**: `embed` サービスを `profiles: ["embed"]` 化。`COMPOSE_PROFILES=embed` / `--profile embed` の時だけ起動。開発・検証は既定 mxbai のまま（サイドカー不要）。
- **コードは env 制御・既定は現行維持**: `rag-app/embeddings.py` に `EMBED_BASE_URL`/`EMBED_API_KEY`（未設定なら `OPENAI_*` にフォールバック）と `EMBED_QUERY_PREFIX`/`EMBED_DOC_PREFIX` を追加。**既定は現行 mxbai 互換（クエリのみ英語 prefix・文書 prefix なし）** で、既存 Qdrant インデックスを壊さない。
- **汎用サイドカー**: `embed-app/` は任意の sentence-transformers モデルを OpenAI 互換 `/v1/embeddings` で配信（Ollama/TEI が扱えない ruri-v3 等の受け皿）。
- **compose 既定を非 ruri に**: `docker-compose.prod.yml` の `EMBED_*`/`QDRANT_COLLECTION`/`RAG_SEED_SAMPLES` を後方互換の既定で追加。
- **ドキュメント**: `.env.prod.example` に env 一覧と ruri 有効化例、README にモデル差し替え手順・**モデル変更時の再インデックス必須（次元固定）** を明記。

### PR #8 からの変更点
- prefix 既定を ruri（日本語）→ **mxbai 互換に戻し**、prefix は env で上書きする方式に（PR #8 は既定挙動を全環境で変えてしまい後方互換を壊していた）。
- prod compose の `EMBED_*` 既定を ruri 前提から**現行 mxbai 前提**に。ruri は `.env.prod` のコメント例として提示。
- `rag-app/app/main.py` の `RAG_SEED_SAMPLES` 追加は **main に既存のため除外**（`QDRANT_COLLECTION`/`EMBED_DIM` も `vectorstore.py` に既存）。

Closes #8

## Test plan
- [x] `docker compose -f docker-compose.prod.yml config`（既定）で `embed` 非起動・rag-app の `EMBED_BASE_URL=""`/`EMBED_MODEL=mxbai-embed-large`/`EMBED_DOC_PREFIX=""`/`QDRANT_COLLECTION=open_genai_rag` を確認
- [x] `COMPOSE_PROFILES=embed` で `embed` サービスが構成に含まれることを確認
- [ ] embed サイドカーが起動し `/health` と `/v1/embeddings` が応答する
- [ ] ruri 設定（別 `QDRANT_COLLECTION`・768 次元）で投入・検索でき、mxbai の既存コレクションと混在しない

Made with [Cursor](https://cursor.com)