### PR TITLE
feat(web): アカウントメニューにログイン中ユーザ名を表示する

### DIFF
--- a/genai-web/packages/web/src/components/ui/AccountMenu.tsx
+++ b/genai-web/packages/web/src/components/ui/AccountMenu.tsx
@@ -7,21 +7,25 @@ type Props = {
   className?: string;
   isShowTeamManagementMenu: boolean;
   onClickSignout: () => void;
+  /** ログイン中の表示名（ユーザ名）。未取得時は「アカウント」 */
+  userDisplayName?: string;
 };
 
 export const AccountMenu = (props: Props) => {
-  const { className, isShowTeamManagementMenu, onClickSignout } = props;
+  const { className, isShowTeamManagementMenu, onClickSignout, userDisplayName } = props;
+  const label = userDisplayName?.trim() || 'アカウント';
 
   return (
     <div className={`group relative h-full ${className ?? ''}`}>
       <Menu>
         <MenuButton
-          className={`flex h-full w-fit items-center gap-1 px-2 text-dns-16B-130 hover:bg-solid-gray-50 hover:underline hover:underline-offset-[calc(3/16*1rem)] data-active:bg-solid-gray-50 focus-visible:data-focus:rounded-4 focus-visible:data-focus:bg-yellow-300 focus-visible:data-focus:ring-[calc(6/16*1rem)] focus-visible:data-focus:ring-yellow-300 focus-visible:data-focus:outline-4 focus-visible:data-focus:-outline-offset-4 focus-visible:data-focus:outline-black focus-visible:data-focus:outline-solid focus-visible:data-focus:ring-inset lg:px-4 focus-visible:[&:not(data-focus)]:outline-hidden`}
+          className={`flex h-full w-fit max-w-56 items-center gap-1 px-2 text-dns-16B-130 hover:bg-solid-gray-50 hover:underline hover:underline-offset-[calc(3/16*1rem)] data-active:bg-solid-gray-50 focus-visible:data-focus:rounded-4 focus-visible:data-focus:bg-yellow-300 focus-visible:data-focus:ring-[calc(6/16*1rem)] focus-visible:data-focus:ring-yellow-300 focus-visible:data-focus:outline-4 focus-visible:data-focus:-outline-offset-4 focus-visible:data-focus:outline-black focus-visible:data-focus:outline-solid focus-visible:data-focus:ring-inset lg:px-4 focus-visible:[&:not(data-focus)]:outline-hidden`}
+          title={label}
         >
           {({ active }) => (
             <>
               <AccountIcon isFilled={active} />
-              <span>アカウント</span>
+              <span className='truncate'>{label}</span>
               <ArrowDownIcon className={`mt-0.5 ${active ? 'rotate-180' : ''}`} />
             </>
           )}
@@ -30,6 +34,17 @@ export const AccountMenu = (props: Props) => {
           modal={false}
           className={`absolute top-full right-4 z-30 w-auto min-w-fit rounded-8 border border-solid-gray-420 bg-white py-2 shadow-1 focus:outline-hidden`}
         >
+          {userDisplayName?.trim() && (
+            <div
+              className='px-4 py-2 text-oln-16N-100 text-solid-gray-600 border-b border-solid-gray-420 mb-1'
+              role='presentation'
+            >
+              <p className='text-dns-14N-130 text-solid-gray-600'>ログイン中</p>
+              <p className='truncate font-bold text-solid-gray-800' title={userDisplayName}>
+                {userDisplayName}
+              </p>
+            </div>
+          )}
           {isShowTeamManagementMenu && (
             <MenuItem>
               {({ focus }) => (

--- a/genai-web/packages/web/src/components/ui/Header.tsx
+++ b/genai-web/packages/web/src/components/ui/Header.tsx
@@ -22,6 +22,11 @@ export const Header = (props: Props) => {
   const { data } = useAuth();
   const groups =
     (data?.tokens?.accessToken.payload['cognito:groups'] as unknown as string[] | undefined) ?? [];
+  const userDisplayName =
+    (data?.tokens?.accessToken.payload['username'] as string | undefined) ||
+    (data?.tokens?.idToken.payload['cognito:username'] as string | undefined) ||
+    (data?.tokens?.idToken.payload['email'] as string | undefined) ||
+    '';
 
   const { cache } = useSWRConfig();
 
@@ -58,6 +63,7 @@ export const Header = (props: Props) => {
         <div className='hidden ml-auto md:flex h-full'>
           <AccountMenu
             onClickSignout={onClickSignout}
+            userDisplayName={userDisplayName}
             isShowTeamManagementMenu={
               groups.includes('SystemAdminGroup') || groups.includes('TeamAdminGroup')
             }
@@ -77,6 +83,7 @@ export const Header = (props: Props) => {
           ref={mobileMenuRef}
           onClose={() => mobileMenuRef.current?.close()}
           onClickSignout={onClickSignout}
+          userDisplayName={userDisplayName}
           isShowTeamManagementMenu={
             groups.includes('SystemAdminGroup') || groups.includes('TeamAdminGroup')
           }

--- a/genai-web/packages/web/src/components/ui/mobile-menu/MobileMenu.tsx
+++ b/genai-web/packages/web/src/components/ui/mobile-menu/MobileMenu.tsx
@@ -19,10 +19,13 @@ type Props = ComponentProps<'dialog'> & {
   isShowTeamManagementMenu: boolean;
   onClickSignout: () => void;
   onClose: () => void;
+  /** ログイン中の表示名（ユーザ名）。未取得時は「アカウント」 */
+  userDisplayName?: string;
 };
 
 export const MobileMenu = forwardRef<HTMLDialogElement, Props>((props, ref) => {
-  const { isShowTeamManagementMenu, onClickSignout, onClose, ...rest } = props;
+  const { isShowTeamManagementMenu, onClickSignout, onClose, userDisplayName, ...rest } = props;
+  const accountLabel = userDisplayName?.trim() || 'アカウント';
   const sidebar = isSidebarNavLayout();
   const recommended = useRecommendedNavItems();
   const { exAppOptions } = useExApps();
@@ -110,10 +113,15 @@ export const MobileMenu = forwardRef<HTMLDialogElement, Props>((props, ref) => {
             <Divider />
             <div>
               <MobileMenuSection
-                label='アカウント'
+                label={accountLabel}
                 icon={(isOpen) => <AccountIcon className='shrink-0' isFilled={isOpen} />}
               >
                 <ul>
+                  {userDisplayName?.trim() && (
+                    <li className='px-4 py-2 text-dns-14N-130 text-solid-gray-600'>
+                      ログイン中: <span className='font-bold text-solid-gray-800'>{userDisplayName}</span>
+                    </li>
+                  )}
                   {isShowTeamManagementMenu && (
                     <li>
                       <MobileMenuItemLink label='チーム管理' to='/teams' />


### PR DESCRIPTION
## Summary
- ヘッダーのアカウント表示を固定の「アカウント」から、JWT のユーザ名（なければ email）に差し替える
- デスクトップのドロップダウンとモバイルメニュー双方で、ログイン中の利用者を確認できるようにする

## Test plan
- [ ] ログイン後、ヘッダー右上にユーザ名が表示される
- [ ] アカウントメニューを開くと「ログイン中」に同じ名前が出る
- [ ] モバイルメニューでも同様に表示される
- [ ] ユーザ名未取得時は従来どおり「アカウント」にフォールバックする


Made with [Cursor](https://cursor.com)