### PR TITLE
プロンプト/管理系exAppを専用ページ化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,34 @@
 **推論/埋め込み/画像の各モデルを環境に応じて差し替えられる自由度**、**SAML・認証の堅牢化**が主軸。
 既定値は従来挙動を維持しており、開発・検証・既存本番への影響はない。
 
+### モデル利用制御・入力制限 専用ページ（管理者限定・管理系の第三弾）
+
+- モデル利用制御を専用ページ（`/admin/model-policy`）へ移行。制御の有効/無効、全ユーザー共通の許可モデル、チーム別の追加許可を、利用可能モデルのチェックボックスで直感的に設定できる（一覧にないモデルIDの追加も可能）
+- 入力制限（禁止ワード・機密情報）を専用ページ（`/admin/ngword`）へ移行。有効/無効・大文字小文字の区別・マイナンバー検査のトグル、禁止ワード・正規表現パターンの編集をフォームで行える（正規表現はクライアントでも検証、保存時に確認ダイアログ）
+- 設定保存型のため、読み取りは backend が読み取り専用で直接参照し、書き込みのみ単一ライターの `modelpolicy-app`（`POST /policy`）／`ngword-app`（`POST /rules`）へプロキシ（`backend` は `GET/POST /admin/model-policy`・`GET/POST /admin/ngword` で管理者権限を検証）
+- 旧 exApp 画面（`/apps/:teamId/modelpolicy`・`/apps/:teamId/ngword`）は各専用ページへリダイレクト。`/schema`・`/invoke` は後方互換で維持
+
+### 利用者一括管理 専用ページ（管理者限定・管理系の第二弾）
+
+- 管理者向けの利用者一括管理を汎用 exApp フォームから専用ページ（`/admin/users`）へ移行。「利用者一覧（検索・件数指定）」と「CSV一括処理（ドライラン → 確認ダイアログ → 適用）」をタブで操作でき、ドライラン結果・適用結果を表で確認できる
+- 更新系のため `usermgmt-app` に構造化 REST（`GET /users`、`POST /users/plan`、`POST /users/apply`）を追加。`backend` は `/admin/users`(/plan,/apply) として管理者権限を検証（403）のうえ HMAC 署名付きでプロキシ
+- CSV はファイル読み込み／貼り付けの両対応。password 列を含むため取り扱い注意を明記
+- 旧 exApp 画面（`/apps/:teamId/usermgmt`）は `/admin/users` へリダイレクト。`/invoke`（Markdown 出力）は後方互換で維持
+
+### 監査ログ専用ページ（管理者限定・管理系の第一弾）
+
+- 管理者向けの監査ログ参照を汎用 exApp フォームから専用ページ（`/admin/audit`）へ移行。ユーザーID・アクション種別・キーワード・期間（JST）・表示件数での絞り込み、テーブル表示（日時は JST 表示）、ページング、行ごとの入力/出力全文表示、JSONL エクスポートを 1 画面で操作できる
+- backend の既存 API（`GET /admin/audit-logs`(/export)、`_is_system_admin` で 403 ガード）をそのまま利用。マイクロサービスや backend プロキシの追加は不要
+- 入力・出力の全文はプレーンテキスト（`<pre>`）で表示し、React 既定エスケープで XSS を防止
+- 旧 exApp 画面（`/apps/:teamId/audit`）は `/admin/audit` へリダイレクト。旧 `audit-app` は無改修で維持
+
+### プロンプトテンプレート専用ページ
+
+- 汎用 exApp フォームの縦並び select をやめ、プロンプトテンプレートを専用ページ（`/prompts`）に。一覧の検索・区分バッジ（標準／共有／個人）、変数入力とライブプレビュー、「チャットで開く」までを 1 画面で操作できる
+- `prompt-app` に構造化 REST（`/templates` 一覧・作成・削除、`/templates/{id}/render`）を追加。`backend` は `/prompts/*` として HMAC 署名付きでプロキシ
+- チャットへは `navigate('/chat', { state })` で流し込むため、長文でも URL 長制限を受けない
+- 旧 exApp 画面（`/apps/:teamId/prompt`）は `/prompts` へリダイレクト。`/schema`・`/resolve`・`/invoke` は後方互換で維持
+
 ### 本番配信 / デプロイ
 
 - 本番 web を Vite dev server から**静的ビルド配信（`Dockerfile.prod` + nginx）**に変更し、dev/prod の差異を compose で吸収（#18）

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Linux + NVIDIA GPU 機（例: **NVIDIA DGX Spark**）でも動作します。
 - 改修: `packages/web/vite.config.ts` — コンテナ実行向けに `host`/ポーリング監視を設定
 - 改修: `src/features/exapps/hooks/useGenUApps.ts` — クラウド依存の組み込み「文字起こし」をメニューから除外（ローカル Whisper の AI アプリで代替）
 - 追加: AI アプリ ピン留め（利用者ごと・カテゴリ横断・上限8件）— トップページに「ピン留め」セクションを表示。`open-genai/` 拡張 + `LandingPage`/`ExAppList`/`ExAppListCard` の最小パッチ（[`OPENGENAI_PATCHES.md`](genai-web/OPENGENAI_PATCHES.md) 参照）
+- 追加: プロンプトテンプレート専用ページ（`/prompts`）— 汎用 exApp フォームに代えて、一覧の検索・区分バッジ・変数入力＋ライブプレビュー・「チャットで開く」を 1 画面で操作。`open-genai/prompt-templates/` + `prompt-app` 構造化 REST + backend `/prompts/*` プロキシ。旧 `/apps/:teamId/prompt` は `/prompts` へリダイレクト（[`OPENGENAI_PATCHES.md`](genai-web/OPENGENAI_PATCHES.md) 参照）
 - 改修: `src/features/team-apps/utils/endpointUrl.ts` — AI アプリのエンドポイント URL 検証を `http` も許可（ローカルのコンテナ間通信 `http://dify-app:8004/invoke` 等のため。従来は `https` 必須）
 - 改修: `src/features/teams/components/DialogDeleteTeam.tsx` — チーム削除時に知識ベースも消える旨の警告を追加
 - 改修: 翻訳/ダイアグラム画面の説明文をローカル実態に合わせて修正

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1585,16 +1585,127 @@ async def list_allowed_models(request: Request) -> JSONResponse:
     return JSONResponse(content={"unrestricted": False, "models": sorted(allowed)})
 
 
+# ---------------------------------------------------------------------------
+# 管理者限定サービス（modelpolicy / ngword）への書き込みプロキシ共通ヘルパ
+#
+# 読み取りは backend が読み取り専用で直接参照する。書き込みは各サービスが単一ライター
+# のため、管理者権限を検証（403）のうえ内部署名を付けて転送する。
+# ---------------------------------------------------------------------------
+def _admin_app_url(base_url: str, path: str) -> str:
+    if base_url.endswith("/invoke"):
+        base = base_url[: -len("/invoke")]
+    else:
+        base = base_url.rstrip("/")
+    return base + path
+
+
+def _admin_app_headers(
+    request: Request, forbid_msg: str
+) -> tuple[JSONResponse | None, dict[str, str]]:
+    claims = _claims_from_request(request)
+    if not _is_system_admin(claims):
+        return _forbidden(forbid_msg), {}
+    user_id = _user_id(claims)
+    groups_str = ",".join(claims.get("groups") or [])
+    team_ids = _user_team_ids_str(user_id)
+    teams_hdr = _user_teams_header(user_id)
+    headers = {
+        "x-api-key": RAG_API_KEY,
+        "x-user-id": user_id,
+        "x-user-groups": groups_str,
+        "x-user-tags": team_ids,
+        "x-user-teams": teams_hdr,
+        "x-scope": ADMIN_TEAM_ID,
+        **intauth.signed_headers(user_id, groups_str, ADMIN_TEAM_ID, team_ids),
+        "Content-Type": "application/json",
+    }
+    return None, headers
+
+
+async def _proxy_admin_app(
+    method: str,
+    url: str,
+    headers: dict[str, str],
+    json_body: Any | None,
+    label: str,
+) -> JSONResponse:
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            res = await client.request(method, url, headers=headers, json=json_body)
+    except httpx.HTTPError as e:
+        return JSONResponse(
+            status_code=502, content={"error": f"{label}に接続できませんでした: {e}"}
+        )
+    try:
+        payload = res.json()
+    except ValueError:
+        payload = {"error": f"{label}から不正な応答を受け取りました"}
+    return JSONResponse(status_code=res.status_code, content=payload)
+
+
+def _admin_teams_list() -> list[dict[str, str]]:
+    """設定対象チーム(id+name)の一覧。固定チーム(共通/管理者ツール)は除外。"""
+    try:
+        teams = [
+            t
+            for t in teams_store.list_teams()
+            if t["teamId"] not in (COMMON_TEAM_ID, ADMIN_TEAM_ID)
+        ]
+    except Exception:  # noqa: BLE001
+        teams = []
+    return [{"id": t["teamId"], "name": t["teamName"]} for t in teams]
+
+
 @app.get("/admin/model-policy")
 async def get_model_policy(request: Request) -> JSONResponse:
-    """モデル利用ポリシーの現在値を返す（システム管理者限定・参照のみ）。
+    """モデル利用ポリシーの現在値＋設定に必要な選択肢を返す（システム管理者限定）。
 
-    設定変更は管理者限定 exApp「モデル利用制御」（modelpolicy-app）から行う。
+    書き込みは管理者限定サービス（modelpolicy-app）が担う。backend は読み取り専用で
+    ポリシーを参照し、専用ページ用に利用可能モデルID一覧と設定対象チームも併せて返す。
     """
     claims = _claims_from_request(request)
     if not _is_system_admin(claims):
         return _forbidden("モデル利用ポリシーの閲覧には管理者権限が必要です")
-    return JSONResponse(content=policy.get_policy())
+    return JSONResponse(
+        content={
+            "policy": policy.get_policy(),
+            "availableModels": await _available_models_cached(),
+            "teams": _admin_teams_list(),
+        }
+    )
+
+
+@app.post("/admin/model-policy")
+async def set_model_policy(request: Request) -> JSONResponse:
+    """モデル利用ポリシーを保存する（単一ライターの modelpolicy-app へプロキシ）。"""
+    err, headers = _admin_app_headers(request, "モデル利用ポリシーの変更には管理者権限が必要です")
+    if err:
+        return err
+    body = await request.json()
+    return await _proxy_admin_app(
+        "POST", _admin_app_url(MODELPOLICY_APP_URL, "/policy"), headers, body, "モデル利用制御サービス"
+    )
+
+
+@app.get("/admin/ngword")
+async def get_ngword_rules(request: Request) -> JSONResponse:
+    """入力制限ルールの現在値を返す（システム管理者限定・参照のみ）。"""
+    claims = _claims_from_request(request)
+    if not _is_system_admin(claims):
+        return _forbidden("入力制限ルールの閲覧には管理者権限が必要です")
+    return JSONResponse(content={"rules": ngwords.get_rules()})
+
+
+@app.post("/admin/ngword")
+async def set_ngword_rules(request: Request) -> JSONResponse:
+    """入力制限ルールを保存する（単一ライターの ngword-app へプロキシ）。"""
+    err, headers = _admin_app_headers(request, "入力制限ルールの変更には管理者権限が必要です")
+    if err:
+        return err
+    body = await request.json()
+    return await _proxy_admin_app(
+        "POST", _admin_app_url(NGWORD_APP_URL, "/rules"), headers, body, "入力制限サービス"
+    )
 
 
 @app.get("/admin/audit-logs/export")
@@ -2009,6 +2120,196 @@ async def resolve_exapp_schema(request: Request) -> JSONResponse:
         return JSONResponse(content=res.json())
     except httpx.HTTPError:
         return JSONResponse(content={"placeholder": {}})
+
+
+# ---------------------------------------------------------------------------
+# プロンプトテンプレート専用ページ(/prompts) 用プロキシ
+#
+# 源内の汎用 exApp フォームでは操作が直感的でないため、専用ページを設ける。
+# 認証済み利用者の JWT を検証し、prompt-app の構造化 REST へ HMAC 署名付きで転送する。
+# スコープは共通チーム(COMMON_TEAM_ID)固定（プロンプトは全ユーザー利用可）。
+# ---------------------------------------------------------------------------
+def _prompt_app_url(path: str) -> str:
+    if PROMPT_APP_URL.endswith("/invoke"):
+        base = PROMPT_APP_URL[: -len("/invoke")]
+    else:
+        base = PROMPT_APP_URL.rstrip("/")
+    return base + path
+
+
+def _prompt_headers(request: Request) -> tuple[JSONResponse | None, dict[str, str]]:
+    claims = _claims_from_request(request)
+    user_id = _user_id(claims)
+    if not user_id:
+        return JSONResponse(status_code=401, content={"error": "認証が必要です"}), {}
+    groups_str = ",".join(claims.get("groups") or [])
+    team_ids = _user_team_ids_str(user_id)
+    teams_hdr = _user_teams_header(user_id)
+    headers = {
+        "x-api-key": RAG_API_KEY,
+        "x-user-id": user_id,
+        "x-user-groups": groups_str,
+        "x-user-tags": team_ids,
+        "x-user-teams": teams_hdr,
+        "x-scope": COMMON_TEAM_ID,
+        **intauth.signed_headers(user_id, groups_str, COMMON_TEAM_ID, team_ids),
+        "Content-Type": "application/json",
+    }
+    return None, headers
+
+
+async def _proxy_prompt(
+    method: str, url: str, headers: dict[str, str], json_body: Any | None = None
+) -> JSONResponse:
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            res = await client.request(method, url, headers=headers, json=json_body)
+    except httpx.HTTPError as e:
+        return JSONResponse(
+            status_code=502,
+            content={"error": f"プロンプトテンプレートサービスに接続できませんでした: {e}"},
+        )
+    try:
+        payload = res.json()
+    except ValueError:
+        payload = {"error": "プロンプトテンプレートサービスから不正な応答を受け取りました"}
+    return JSONResponse(status_code=res.status_code, content=payload)
+
+
+@app.get("/prompts/templates")
+async def list_prompt_templates(request: Request) -> JSONResponse:
+    err, headers = _prompt_headers(request)
+    if err:
+        return err
+    return await _proxy_prompt("GET", _prompt_app_url("/templates"), headers)
+
+
+@app.post("/prompts/templates")
+async def create_prompt_template(request: Request) -> JSONResponse:
+    err, headers = _prompt_headers(request)
+    if err:
+        return err
+    body = await request.json()
+    return await _proxy_prompt("POST", _prompt_app_url("/templates"), headers, body)
+
+
+@app.delete("/prompts/templates/{template_id}")
+async def delete_prompt_template(template_id: str, request: Request) -> JSONResponse:
+    err, headers = _prompt_headers(request)
+    if err:
+        return err
+    return await _proxy_prompt(
+        "DELETE", _prompt_app_url(f"/templates/{template_id}"), headers
+    )
+
+
+@app.post("/prompts/templates/{template_id}/render")
+async def render_prompt_template(template_id: str, request: Request) -> JSONResponse:
+    err, headers = _prompt_headers(request)
+    if err:
+        return err
+    body = await request.json()
+    return await _proxy_prompt(
+        "POST", _prompt_app_url(f"/templates/{template_id}/render"), headers, body
+    )
+
+
+# ---------------------------------------------------------------------------
+# 利用者一括管理 専用ページ(/admin/users) 用プロキシ（管理者限定）
+#
+# 汎用 exApp フォーム（Markdown 出力）では一覧・ドライラン・適用の往復がしづらいため、
+# 専用ページから叩く構造化 REST を usermgmt-app へ転送する。backend 側で管理者権限を
+# 検証（403）し、内部署名を付けて転送する。スコープは管理者専用チーム(ADMIN_TEAM_ID)。
+# ---------------------------------------------------------------------------
+def _usermgmt_app_url(path: str) -> str:
+    if USERMGMT_APP_URL.endswith("/invoke"):
+        base = USERMGMT_APP_URL[: -len("/invoke")]
+    else:
+        base = USERMGMT_APP_URL.rstrip("/")
+    return base + path
+
+
+def _usermgmt_headers(request: Request) -> tuple[JSONResponse | None, dict[str, str]]:
+    claims = _claims_from_request(request)
+    if not _is_system_admin(claims):
+        return _forbidden("利用者一括管理には管理者権限が必要です"), {}
+    user_id = _user_id(claims)
+    groups_str = ",".join(claims.get("groups") or [])
+    team_ids = _user_team_ids_str(user_id)
+    teams_hdr = _user_teams_header(user_id)
+    headers = {
+        "x-api-key": RAG_API_KEY,
+        "x-user-id": user_id,
+        "x-user-groups": groups_str,
+        "x-user-tags": team_ids,
+        "x-user-teams": teams_hdr,
+        "x-scope": ADMIN_TEAM_ID,
+        **intauth.signed_headers(user_id, groups_str, ADMIN_TEAM_ID, team_ids),
+        "Content-Type": "application/json",
+    }
+    return None, headers
+
+
+async def _proxy_usermgmt(
+    method: str,
+    url: str,
+    headers: dict[str, str],
+    json_body: Any | None = None,
+    params: dict[str, Any] | None = None,
+) -> JSONResponse:
+    try:
+        # 適用は Keycloak への多数の書き込みを伴うため長めのタイムアウト。
+        async with httpx.AsyncClient(timeout=180) as client:
+            res = await client.request(
+                method, url, headers=headers, json=json_body, params=params
+            )
+    except httpx.HTTPError as e:
+        return JSONResponse(
+            status_code=502,
+            content={"error": f"利用者管理サービスに接続できませんでした: {e}"},
+        )
+    try:
+        payload = res.json()
+    except ValueError:
+        payload = {"error": "利用者管理サービスから不正な応答を受け取りました"}
+    return JSONResponse(status_code=res.status_code, content=payload)
+
+
+@app.get("/admin/users")
+async def list_admin_users(request: Request) -> JSONResponse:
+    err, headers = _usermgmt_headers(request)
+    if err:
+        return err
+    qp = request.query_params
+    params = {
+        "search": qp.get("search") or "",
+        "limit": qp.get("limit") or "200",
+    }
+    return await _proxy_usermgmt(
+        "GET", _usermgmt_app_url("/users"), headers, params=params
+    )
+
+
+@app.post("/admin/users/plan")
+async def plan_admin_users(request: Request) -> JSONResponse:
+    err, headers = _usermgmt_headers(request)
+    if err:
+        return err
+    body = await request.json()
+    return await _proxy_usermgmt(
+        "POST", _usermgmt_app_url("/users/plan"), headers, body
+    )
+
+
+@app.post("/admin/users/apply")
+async def apply_admin_users(request: Request) -> JSONResponse:
+    err, headers = _usermgmt_headers(request)
+    if err:
+        return err
+    body = await request.json()
+    return await _proxy_usermgmt(
+        "POST", _usermgmt_app_url("/users/apply"), headers, body
+    )
 
 
 @app.get("/me/teams")

--- a/backend/app/ngwords.py
+++ b/backend/app/ngwords.py
@@ -105,6 +105,14 @@ def _load() -> tuple[dict[str, Any], list[re.Pattern[str]]]:
     return _cache["rules"], _cache["compiled"]
 
 
+def get_rules() -> dict[str, Any]:
+    """現在のルールを返す（管理画面の表示用・都度読取）。
+
+    書き込みは ngword-app（単一ライター）が担うため、ここでは常に最新を読み取る。
+    """
+    return _read_rules()
+
+
 def check(text: str) -> tuple[bool, str | None]:
     """text が禁止語/機密パターンに該当するか。(blocked, 理由メッセージ)。"""
     if not text:

--- a/genai-web/OPENGENAI_PATCHES.md
+++ b/genai-web/OPENGENAI_PATCHES.md
@@ -40,18 +40,85 @@ upstream のバージョンアップ後は、本ファイルの差分箇所を�
 画像生成サーバ(A1111 互換)が停止しているときは「画像を生成」を一覧・トップから隠す
 （他 exApp の `/health` チェックに準拠）。
 
+### プロンプトテンプレート専用ページ（Open GENAI 拡張）
+
+汎用 exApp フォーム（縦並び select）では操作が直感的でないため、プロンプトテンプレート
+だけは専用ページ（`/prompts`）で「一覧 → 変数入力 → プレビュー → チャットへ」という
+カタログ型 UI を提供する。テンプレートの CRUD・変数置換は `prompt-app` の構造化 REST を
+使い、チャットへは `navigate('/chat', { state })` で流し込む（URL 長制限を受けない）。
+従来の汎用 exApp 画面（`/apps/:teamId/prompt`）は `/prompts` へリダイレクトする。
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `packages/web/src/routes.tsx` | `/prompts` ルート追加、`/apps/:teamId/prompt` → `/prompts` リダイレクト |
+| `packages/web/src/layout/navItems.ts` | おすすめに「プロンプトテンプレート」、`pinnedAppHref` で `prompt` を `/prompts` に振替 |
+
+### 監査ログ専用ページ（Open GENAI 拡張・管理者限定）
+
+管理系の第一弾。汎用 exApp フォーム（Markdown 出力）では詳細確認・全文閲覧・エクスポート
+がしづらいため、監査ログは専用ページ（`/admin/audit`）で「フィルタ → テーブル → 全文 →
+エクスポート」を提供する。backend に既存の管理者限定 REST（`GET /admin/audit-logs`(/export)）が
+あるため、マイクロサービスや backend プロキシの追加は不要で、フロントの専用ページのみで実現。
+入力・出力の全文は `<pre>` にプレーンテキストとして表示（React 既定エスケープで XSS 安全）。
+従来の汎用 exApp 画面（`/apps/:teamId/audit`）は `/admin/audit` へリダイレクトする。
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `packages/web/src/routes.tsx` | `/admin/audit` ルート追加、`/apps/:teamId/audit` → `/admin/audit` リダイレクト |
+| `packages/web/src/layout/navItems.ts` | `pinnedAppHref` で `audit` を `/admin/audit` に振替（管理者限定のためおすすめには非追加） |
+
+### 利用者一括管理 専用ページ（Open GENAI 拡張・管理者限定）
+
+管理系の第二弾。汎用 exApp フォーム（操作 select ＋ Markdown 出力）では一覧・ドライラン・
+適用の往復がしづらいため、専用ページ（`/admin/users`）で「利用者一覧（検索）」と
+「CSV一括処理（ドライラン → 確認ダイアログ → 適用）」をタブで提供する。更新系のため、
+プロンプト同様に `usermgmt-app` へ構造化 REST を追加し、`backend` が管理者権限を検証（403）
+のうえ HMAC 署名付きでプロキシする。従来の汎用 exApp 画面（`/apps/:teamId/usermgmt`）は
+`/admin/users` へリダイレクトする。
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `packages/web/src/routes.tsx` | `/admin/users` ルート追加、`/apps/:teamId/usermgmt` → `/admin/users` リダイレクト |
+| `packages/web/src/layout/navItems.ts` | `pinnedAppHref` で `usermgmt` を `/admin/users` に振替（管理者限定のためおすすめには非追加） |
+
+### モデル利用制御・入力制限 専用ページ（Open GENAI 拡張・管理者限定）
+
+管理系の第三弾。モデル利用制御（`/admin/model-policy`）と入力制限＝禁止ワード（`/admin/ngword`）
+を専用ページ化。いずれも設定保存型のため、**読み取りは backend が読み取り専用で直接参照**し
+（`policy` / `ngwords` モジュール）、**書き込みは単一ライターの各サービスへプロキシ**する
+（`modelpolicy-app` / `ngword-app`）。モデル利用制御は利用可能モデルとチームを
+チェックボックスで選択でき、入力制限は禁止ワード・正規表現・マイナンバー検査などを
+フォームで編集できる（保存時に確認ダイアログ、正規表現はクライアントでも検証）。
+従来の汎用 exApp 画面（`/apps/:teamId/modelpolicy`・`/apps/:teamId/ngword`）はリダイレクトする。
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `packages/web/src/routes.tsx` | `/admin/model-policy`・`/admin/ngword` ルート追加、旧 exApp URL をリダイレクト |
+| `packages/web/src/layout/navItems.ts` | `pinnedAppHref` で `modelpolicy`・`ngword` を各専用ページに振替（管理者限定のためおすすめには非追加） |
+
 ### Open GENAI 専用（upstream 非依存・コンフlict しにくい）
 
 | パス | 内容 |
 |------|------|
 | `packages/web/src/open-genai/app-pins/` | ピン留め API hooks・振り分けユーティリティ・`PinnedAppsSection` |
 | `packages/web/src/open-genai/image-health/` | 画像生成サーバ稼働確認フック `useImageAvailable` |
+| `packages/web/src/open-genai/prompt-templates/` | プロンプトテンプレート専用ページ（`PromptTemplatesPage` ほか） |
+| `packages/web/src/open-genai/admin-audit/` | 監査ログ専用ページ（`AuditLogsPage`・`useAuditLogs`・`types`／管理者限定） |
+| `packages/web/src/open-genai/admin-usermgmt/` | 利用者一括管理 専用ページ（`UserMgmtPage`・`UserCsvSection`・`useUserMgmt`・`types`／管理者限定） |
+| `packages/web/src/open-genai/admin-modelpolicy/` | モデル利用制御 専用ページ（`ModelPolicyPage`・`useModelPolicy`・`types`／管理者限定） |
+| `packages/web/src/open-genai/admin-ngword/` | 入力制限（禁止ワード）専用ページ（`NgWordPage`・`useNgword`・`types`／管理者限定） |
 | `backend/app/teams_store.py` | `user_app_pins` テーブル |
 | `backend/app/image_gen.py` | `is_sd_up()` による SD 稼働確認 |
-| `backend/app/main.py` | `GET/POST/DELETE /my/app-pins`, `GET /image/health` |
+| `backend/app/main.py` | `GET/POST/DELETE /my/app-pins`, `GET /image/health`, `GET/POST/DELETE /prompts/templates`, `POST /prompts/templates/{id}/render`, `GET /admin/users`, `POST /admin/users/plan`, `POST /admin/users/apply`, `GET/POST /admin/model-policy`, `GET/POST /admin/ngword` |
+| `prompt-app/app/main.py` | 構造化 REST（`/templates` 一覧・作成・削除、`/templates/{id}/render`）。`/schema`・`/resolve`・`/invoke` も後方互換で維持 |
+| `usermgmt-app/app/main.py` | 構造化 REST（`GET /users`、`POST /users/plan`、`POST /users/apply`）。`/invoke`（Markdown）も後方互換で維持 |
+| `modelpolicy-app/app/main.py` | 構造化 REST（`POST /policy` 書き込み）。`/schema`・`/invoke` も後方互換で維持（読取は backend が直接参照） |
+| `ngword-app/app/main.py` | 構造化 REST（`POST /rules` 書き込み）。`/schema`・`/invoke` も後方互換で維持（読取は backend が直接参照） |
 
 ## 後方互換
 
 - `pinControl` 未指定時、`ExAppListCard` は従来どおり（源内単体でも動作）
 - `GET /my/app-pins` 失敗時、フロントは `[]` 扱いでピンなし表示にフォールバック
 - `PinnedAppsSection` はピン 0 件・取得失敗時に何も描画しない（トップページに影響なし）
+- プロンプトテンプレートの旧 exApp API（`/schema`・`/resolve`・`/invoke`）は維持するため、
+  ブックマーク・履歴リンク・旧クライアントも従来どおり動作する

--- a/genai-web/packages/web/src/layout/navItems.ts
+++ b/genai-web/packages/web/src/layout/navItems.ts
@@ -7,6 +7,36 @@ import { isUseCaseEnabled } from '@/utils/isUseCaseEnabled';
 /** Open GENAI の文字起こしは Amazon Transcribe ではなく Whisper exApp */
 export const WHISPER_EXAPP_PATH = `/apps/${COMMON_EXAPPS_TEAM_ID}/whisper`;
 
+/** プロンプトテンプレートは汎用 exApp フォームではなく専用ページで提供する */
+export const PROMPT_TEMPLATES_PATH = '/prompts';
+
+/** プロンプトテンプレート exApp の識別子（専用ページへ振り替える対象） */
+export const PROMPT_EXAPP_ID = 'prompt';
+
+/** 監査ログは管理者限定の専用ページで提供する */
+export const AUDIT_ADMIN_PATH = '/admin/audit';
+
+/** 監査ログ exApp の識別子（専用ページへ振り替える対象） */
+export const AUDIT_EXAPP_ID = 'audit';
+
+/** 利用者一括管理は管理者限定の専用ページで提供する */
+export const USERMGMT_ADMIN_PATH = '/admin/users';
+
+/** 利用者一括管理 exApp の識別子（専用ページへ振り替える対象） */
+export const USERMGMT_EXAPP_ID = 'usermgmt';
+
+/** モデル利用制御は管理者限定の専用ページで提供する */
+export const MODELPOLICY_ADMIN_PATH = '/admin/model-policy';
+
+/** モデル利用制御 exApp の識別子（専用ページへ振り替える対象） */
+export const MODELPOLICY_EXAPP_ID = 'modelpolicy';
+
+/** 入力制限（禁止ワード）は管理者限定の専用ページで提供する */
+export const NGWORD_ADMIN_PATH = '/admin/ngword';
+
+/** 入力制限 exApp の識別子（専用ページへ振り替える対象） */
+export const NGWORD_EXAPP_ID = 'ngword';
+
 export type NavLinkItem = {
   label: string;
   to: string;
@@ -64,6 +94,12 @@ export const useRecommendedNavItems = (): NavLinkItem[] => {
       description: '音声ファイルから文字起こし',
     });
 
+    items.push({
+      label: 'プロンプトテンプレート',
+      to: PROMPT_TEMPLATES_PATH,
+      description: '標準／共有テンプレートを選んでチャットへ',
+    });
+
     return items;
   }, [imageAvailable]);
 };
@@ -73,5 +109,26 @@ export const ALL_APPS_NAV_ITEM: NavLinkItem = {
   to: '/apps',
 };
 
-export const pinnedAppHref = (item: PinnedAppItem): string =>
-  item.app.isDefault ? `/${item.app.value}` : `/apps/${item.teamIdKey}/${item.app.value}`;
+export const pinnedAppHref = (item: PinnedAppItem): string => {
+  // プロンプトテンプレートは専用ページへ振り替える（汎用 exApp URL を使わない）
+  if (item.app.value === PROMPT_EXAPP_ID) {
+    return PROMPT_TEMPLATES_PATH;
+  }
+  // 監査ログは管理者限定の専用ページへ振り替える
+  if (item.app.value === AUDIT_EXAPP_ID) {
+    return AUDIT_ADMIN_PATH;
+  }
+  // 利用者一括管理も管理者限定の専用ページへ振り替える
+  if (item.app.value === USERMGMT_EXAPP_ID) {
+    return USERMGMT_ADMIN_PATH;
+  }
+  // モデル利用制御も管理者限定の専用ページへ振り替える
+  if (item.app.value === MODELPOLICY_EXAPP_ID) {
+    return MODELPOLICY_ADMIN_PATH;
+  }
+  // 入力制限（禁止ワード）も管理者限定の専用ページへ振り替える
+  if (item.app.value === NGWORD_EXAPP_ID) {
+    return NGWORD_ADMIN_PATH;
+  }
+  return item.app.isDefault ? `/${item.app.value}` : `/apps/${item.teamIdKey}/${item.app.value}`;
+};

--- a/genai-web/packages/web/src/open-genai/admin-audit/AuditLogsPage.tsx
+++ b/genai-web/packages/web/src/open-genai/admin-audit/AuditLogsPage.tsx
@@ -1,0 +1,410 @@
+import { useMemo, useState } from 'react';
+import { PiBookOpenBold } from 'react-icons/pi';
+import { BreadcrumbsNav } from '@/components/ui/BreadcrumbsNav';
+import { Button } from '@/components/ui/dads/Button';
+import { Disclosure, DisclosureSummary } from '@/components/ui/dads/Disclosure';
+import { Input } from '@/components/ui/dads/Input';
+import { Label } from '@/components/ui/dads/Label';
+import { Select } from '@/components/ui/dads/Select';
+import { SupportText } from '@/components/ui/dads/SupportText';
+import { useTeamAuth } from '@/features/teams/hooks/useTeamAuth';
+import { LayoutBody } from '@/layout/LayoutBody';
+import { PageTitle } from '@/components/PageTitle';
+import { AUDIT_ACTION_OPTIONS, type AuditFilters, type AuditLog } from './types';
+import { useAuditExport, useAuditLogs } from './useAuditLogs';
+
+const DEFAULT_FILTERS: AuditFilters = {
+  userId: '',
+  action: 'all',
+  q: '',
+  fromDate: '',
+  toDate: '',
+  limit: 50,
+};
+
+const LIMIT_OPTIONS = [20, 50, 100, 200, 500];
+
+const actionLabel = (action: string): string =>
+  AUDIT_ACTION_OPTIONS.find((o) => o.value === action)?.title ?? action;
+
+/** epoch ms を JST（UTC+9）の読みやすい文字列にする。 */
+const formatTs = (ts: number): string => {
+  if (!ts) {
+    return '-';
+  }
+  // +9 時間ずらして UTC 表記（toISOString）で読むと JST の壁時計時刻になる。
+  const jst = new Date(ts + 9 * 60 * 60 * 1000);
+  return `${jst.toISOString().replace('T', ' ').slice(0, 19)} JST`;
+};
+
+const excerpt = (text: string | null, max = 60): string => {
+  if (!text) {
+    return '';
+  }
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+};
+
+/**
+ * 監査ログ参照の専用ページ（管理者限定・OpenGENAI 拡張）。
+ * 源内の汎用 exApp フォーム（Markdown 出力）では詳細確認や全文閲覧・エクスポートが
+ * しづらいため、フィルタ→テーブル→全文→エクスポートを専用ページとして提供する。
+ */
+export const AuditLogsPage = () => {
+  const { isSystemAdminGroup } = useTeamAuth();
+
+  // 入力中の下書きと、実際に検索へ反映した条件を分離する。
+  const [draft, setDraft] = useState<AuditFilters>(DEFAULT_FILTERS);
+  const [applied, setApplied] = useState<AuditFilters>(DEFAULT_FILTERS);
+  const [offset, setOffset] = useState(0);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const { items, total, isLoading, forbidden, loadError } = useAuditLogs(applied, offset);
+  const { exportLogs, exporting, exportError } = useAuditExport(applied);
+
+  const page = Math.floor(offset / applied.limit) + 1;
+  const totalPages = Math.max(1, Math.ceil(total / applied.limit));
+  const rangeStart = total === 0 ? 0 : offset + 1;
+  const rangeEnd = Math.min(offset + applied.limit, total);
+
+  const search = () => {
+    setApplied(draft);
+    setOffset(0);
+    setExpandedId(null);
+  };
+
+  const reset = () => {
+    setDraft(DEFAULT_FILTERS);
+    setApplied(DEFAULT_FILTERS);
+    setOffset(0);
+    setExpandedId(null);
+  };
+
+  const gotoPage = (nextOffset: number) => {
+    setOffset(Math.max(0, nextOffset));
+    setExpandedId(null);
+  };
+
+  const header = useMemo(
+    () => (
+      <div className='flex flex-col gap-4'>
+        <BreadcrumbsNav
+          items={[
+            { label: 'ホーム', to: '/' },
+            { label: 'AIアプリ', to: '/apps' },
+            { label: '監査ログ' },
+          ]}
+        />
+        <h1 className='text-std-20B-160 lg:text-std-24B-150'>監査ログ</h1>
+        <p className='text-std-16N-170 text-solid-gray-700'>
+          利用者単位の利用状況・利用内容ログを確認します（管理者限定）。監査ログには入力・出力の本文が含まれる場合があります。取り扱いに注意してください。
+        </p>
+      </div>
+    ),
+    [],
+  );
+
+  if (!isSystemAdminGroup) {
+    return (
+      <LayoutBody>
+        <PageTitle title='監査ログ' />
+        <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-6 p-6 lg:p-8'>
+          {header}
+          <p className='text-dns-16N-130 text-error-1' role='alert'>
+            このページの閲覧には管理者権限が必要です。
+          </p>
+        </div>
+      </LayoutBody>
+    );
+  }
+
+  return (
+    <LayoutBody>
+      <PageTitle title='監査ログ' />
+      <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-6 p-6 lg:p-8'>
+        {header}
+
+        <Disclosure className='rounded-8 border border-solid-gray-420 bg-solid-gray-50 px-4 py-3'>
+          <DisclosureSummary>
+            <span className='flex items-center text-std-16B-150'>
+              <PiBookOpenBold className='mr-2 size-5 flex-none' />
+              使い方（クリックで開閉）
+            </span>
+          </DisclosureSummary>
+          <div className='mt-3 flex flex-col gap-1.5 text-std-16N-170 text-solid-gray-700'>
+            <p>・条件を入力して「検索」を押すと絞り込めます。日付は JST の 0:00〜23:59 で扱います。</p>
+            <p>・各行の「全文」を開くと、入力・出力の本文をそのまま確認できます。</p>
+            <p>・「エクスポート」で、現在の期間（開始日・終了日）の全件を JSONL でダウンロードできます。</p>
+          </div>
+        </Disclosure>
+
+        {/* 絞り込みフォーム */}
+        <div className='grid grid-cols-1 gap-4 rounded-8 border border-solid-gray-300 p-4 sm:grid-cols-2 lg:grid-cols-3'>
+          <div className='flex flex-col gap-1.5'>
+            <Label htmlFor='audit-user' size='sm'>
+              ユーザーID
+            </Label>
+            <Input
+              id='audit-user'
+              blockSize='md'
+              value={draft.userId}
+              onChange={(e) => setDraft({ ...draft, userId: e.target.value })}
+            />
+          </div>
+          <div className='flex flex-col gap-1.5'>
+            <Label htmlFor='audit-action' size='sm'>
+              アクション種別
+            </Label>
+            <Select
+              id='audit-action'
+              blockSize='md'
+              value={draft.action}
+              onChange={(e) => setDraft({ ...draft, action: e.target.value })}
+            >
+              {AUDIT_ACTION_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.title}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <div className='flex flex-col gap-1.5'>
+            <Label htmlFor='audit-q' size='sm'>
+              キーワード（本文）
+            </Label>
+            <Input
+              id='audit-q'
+              blockSize='md'
+              value={draft.q}
+              onChange={(e) => setDraft({ ...draft, q: e.target.value })}
+            />
+          </div>
+          <div className='flex flex-col gap-1.5'>
+            <Label htmlFor='audit-from' size='sm'>
+              開始日（JST）
+            </Label>
+            <Input
+              id='audit-from'
+              type='date'
+              blockSize='md'
+              value={draft.fromDate}
+              onChange={(e) => setDraft({ ...draft, fromDate: e.target.value })}
+            />
+          </div>
+          <div className='flex flex-col gap-1.5'>
+            <Label htmlFor='audit-to' size='sm'>
+              終了日（JST）
+            </Label>
+            <Input
+              id='audit-to'
+              type='date'
+              blockSize='md'
+              value={draft.toDate}
+              onChange={(e) => setDraft({ ...draft, toDate: e.target.value })}
+            />
+          </div>
+          <div className='flex flex-col gap-1.5'>
+            <Label htmlFor='audit-limit' size='sm'>
+              表示件数
+            </Label>
+            <Select
+              id='audit-limit'
+              blockSize='md'
+              value={String(draft.limit)}
+              onChange={(e) => setDraft({ ...draft, limit: Number(e.target.value) })}
+            >
+              {LIMIT_OPTIONS.map((n) => (
+                <option key={n} value={n}>
+                  {n}件
+                </option>
+              ))}
+            </Select>
+          </div>
+        </div>
+
+        <div className='flex flex-wrap items-center gap-3'>
+          <Button type='button' variant='solid-fill' size='md' onClick={search}>
+            検索
+          </Button>
+          <Button type='button' variant='outline' size='md' onClick={reset}>
+            条件をクリア
+          </Button>
+          <Button
+            type='button'
+            variant='outline'
+            size='md'
+            onClick={exportLogs}
+            aria-disabled={exporting || undefined}
+          >
+            {exporting ? 'エクスポート中...' : 'エクスポート（JSONL）'}
+          </Button>
+        </div>
+
+        {exportError && (
+          <p className='text-dns-16N-130 text-error-1' role='alert'>
+            {exportError}
+          </p>
+        )}
+
+        {/* 結果 */}
+        {forbidden ? (
+          <p className='text-dns-16N-130 text-error-1' role='alert'>
+            このページの閲覧には管理者権限が必要です。
+          </p>
+        ) : loadError ? (
+          <p className='text-dns-16N-130 text-error-1' role='alert'>
+            {loadError}
+          </p>
+        ) : (
+          <div className='flex flex-col gap-3'>
+            <div className='flex flex-wrap items-center justify-between gap-2'>
+              <SupportText>
+                {total === 0
+                  ? '該当するログはありません。'
+                  : `全 ${total} 件中 ${rangeStart}〜${rangeEnd} 件を表示`}
+              </SupportText>
+              {isLoading && <SupportText>読み込み中...</SupportText>}
+            </div>
+
+            {items.length > 0 && (
+              <div className='overflow-x-auto rounded-8 border border-solid-gray-300'>
+                <table className='w-full border-collapse text-left text-dns-14N-130'>
+                  <thead className='bg-solid-gray-50 text-solid-gray-700'>
+                    <tr>
+                      <th className='whitespace-nowrap px-3 py-2 font-bold'>日時（JST）</th>
+                      <th className='whitespace-nowrap px-3 py-2 font-bold'>ユーザー</th>
+                      <th className='whitespace-nowrap px-3 py-2 font-bold'>アクション</th>
+                      <th className='whitespace-nowrap px-3 py-2 font-bold'>モデル</th>
+                      <th className='whitespace-nowrap px-3 py-2 font-bold'>入力/出力</th>
+                      <th className='px-3 py-2 font-bold'>内容抜粋</th>
+                      <th className='px-3 py-2 font-bold'>全文</th>
+                    </tr>
+                  </thead>
+                  <tbody className='divide-y divide-solid-gray-300'>
+                    {items.map((log) => (
+                      <AuditRow
+                        key={log.id}
+                        log={log}
+                        expanded={expandedId === log.id}
+                        onToggle={() =>
+                          setExpandedId((cur) => (cur === log.id ? null : log.id))
+                        }
+                      />
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            {total > 0 && (
+              <div className='flex items-center justify-between gap-3'>
+                <Button
+                  type='button'
+                  variant='outline'
+                  size='sm'
+                  onClick={() => gotoPage(offset - applied.limit)}
+                  aria-disabled={offset === 0 || undefined}
+                >
+                  前へ
+                </Button>
+                <span className='text-dns-14N-130 text-solid-gray-700'>
+                  {page} / {totalPages} ページ
+                </span>
+                <Button
+                  type='button'
+                  variant='outline'
+                  size='sm'
+                  onClick={() => gotoPage(offset + applied.limit)}
+                  aria-disabled={rangeEnd >= total || undefined}
+                >
+                  次へ
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </LayoutBody>
+  );
+};
+
+type RowProps = {
+  log: AuditLog;
+  expanded: boolean;
+  onToggle: () => void;
+};
+
+const AuditRow = ({ log, expanded, onToggle }: RowProps) => {
+  const hasContent = !!(log.inputText || log.outputText);
+  return (
+    <>
+      <tr className='align-top text-solid-gray-900'>
+        <td className='whitespace-nowrap px-3 py-2'>{formatTs(log.ts)}</td>
+        <td className='px-3 py-2'>
+          <span className='block max-w-[12rem] truncate' title={log.userEmail || log.userId}>
+            {log.userEmail || log.userId || '-'}
+          </span>
+        </td>
+        <td className='whitespace-nowrap px-3 py-2'>{actionLabel(log.action)}</td>
+        <td className='whitespace-nowrap px-3 py-2'>{log.model || '-'}</td>
+        <td className='whitespace-nowrap px-3 py-2'>
+          {(log.inputChars ?? 0).toLocaleString()} / {(log.outputChars ?? 0).toLocaleString()}
+        </td>
+        <td className='px-3 py-2'>
+          <span className='block max-w-[20rem] text-solid-gray-700'>
+            {excerpt(log.inputText || log.outputText) || '-'}
+          </span>
+        </td>
+        <td className='whitespace-nowrap px-3 py-2'>
+          {hasContent ? (
+            <Button type='button' variant='text' size='sm' onClick={onToggle}>
+              {expanded ? '閉じる' : '全文'}
+            </Button>
+          ) : (
+            <span className='text-solid-gray-500'>-</span>
+          )}
+        </td>
+      </tr>
+      {expanded && hasContent && (
+        <tr>
+          <td colSpan={7} className='bg-solid-gray-50 px-3 py-3'>
+            <div className='flex flex-col gap-4'>
+              {log.inputText && (
+                <div className='flex flex-col gap-1'>
+                  <span className='text-dns-14B-130 text-solid-gray-700'>入力</span>
+                  <pre className='whitespace-pre-wrap break-words rounded-8 border border-solid-gray-300 bg-white p-3 text-dns-14N-130 text-solid-gray-900'>
+                    {log.inputText}
+                  </pre>
+                </div>
+              )}
+              {log.outputText && (
+                <div className='flex flex-col gap-1'>
+                  <span className='text-dns-14B-130 text-solid-gray-700'>出力</span>
+                  <pre className='whitespace-pre-wrap break-words rounded-8 border border-solid-gray-300 bg-white p-3 text-dns-14N-130 text-solid-gray-900'>
+                    {log.outputText}
+                  </pre>
+                </div>
+              )}
+              <dl className='grid grid-cols-2 gap-x-4 gap-y-1 text-dns-14N-130 text-solid-gray-700 sm:grid-cols-3'>
+                <MetaItem label='ユースケース' value={log.usecase} />
+                <MetaItem label='パス' value={log.path} />
+                <MetaItem label='ステータス' value={log.status?.toString()} />
+                <MetaItem label='応答時間(ms)' value={log.latencyMs?.toString()} />
+                <MetaItem label='IP' value={log.ip} />
+                <MetaItem label='チャットID' value={log.chatId} />
+              </dl>
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+};
+
+const MetaItem = ({ label, value }: { label: string; value: string | null | undefined }) => (
+  <div className='flex gap-1'>
+    <dt className='font-bold'>{label}:</dt>
+    <dd className='min-w-0 truncate' title={value ?? undefined}>
+      {value || '-'}
+    </dd>
+  </div>
+);

--- a/genai-web/packages/web/src/open-genai/admin-audit/types.ts
+++ b/genai-web/packages/web/src/open-genai/admin-audit/types.ts
@@ -1,0 +1,55 @@
+// 監査ログ専用ページ（管理者限定・OpenGENAI 拡張）の型。
+// backend `GET /admin/audit-logs` の応答（audit_logs テーブル相当）に対応する。
+
+export type AuditLog = {
+  id: string;
+  ts: number;
+  tsIso: string;
+  userId: string;
+  userEmail: string;
+  userName: string;
+  groups: string;
+  action: string;
+  method: string | null;
+  path: string | null;
+  usecase: string | null;
+  chatId: string | null;
+  teamId: string | null;
+  exAppId: string | null;
+  model: string | null;
+  inputChars: number | null;
+  outputChars: number | null;
+  inputText: string | null;
+  outputText: string | null;
+  status: number | null;
+  latencyMs: number | null;
+  ip: string | null;
+  userAgent: string | null;
+  sessionId: string | null;
+};
+
+export type AuditQueryResult = {
+  total: number;
+  items: AuditLog[];
+  limit: number;
+  offset: number;
+};
+
+/** 絞り込み条件（UI 状態）。日付は YYYY-MM-DD（UTC）。 */
+export type AuditFilters = {
+  userId: string;
+  action: string;
+  q: string;
+  fromDate: string;
+  toDate: string;
+  limit: number;
+};
+
+export const AUDIT_ACTION_OPTIONS: { title: string; value: string }[] = [
+  { title: 'すべて', value: 'all' },
+  { title: 'チャットメッセージ', value: 'chat.message' },
+  { title: '推論ストリーム', value: 'predict.stream' },
+  { title: 'AIアプリ実行', value: 'exapp.invoke' },
+  { title: 'ログイン', value: 'auth.login' },
+  { title: 'APIアクセス', value: 'api.access' },
+];

--- a/genai-web/packages/web/src/open-genai/admin-audit/useAuditLogs.ts
+++ b/genai-web/packages/web/src/open-genai/admin-audit/useAuditLogs.ts
@@ -1,0 +1,92 @@
+import { useCallback, useState } from 'react';
+import useSWR from 'swr';
+import { ApiError, teamApi } from '@/lib/fetcher';
+import type { AuditFilters, AuditQueryResult } from './types';
+
+export const AUDIT_LOGS_KEY = 'admin/audit-logs';
+
+/** YYYY-MM-DD（JST）を epoch ms へ。endOfDay=true なら当日 23:59:59.999（JST）。 */
+const dateToMs = (date: string, endOfDay: boolean): number | undefined => {
+  if (!date) {
+    return undefined;
+  }
+  const suffix = endOfDay ? 'T23:59:59.999+09:00' : 'T00:00:00.000+09:00';
+  const ms = Date.parse(`${date}${suffix}`);
+  return Number.isNaN(ms) ? undefined : ms;
+};
+
+/** フィルタ＋offset を backend のクエリパラメータへ変換する。 */
+const toParams = (
+  filters: AuditFilters,
+  offset: number,
+): Record<string, string | number | undefined> => ({
+  userId: filters.userId.trim() || undefined,
+  action: filters.action && filters.action !== 'all' ? filters.action : undefined,
+  q: filters.q.trim() || undefined,
+  from: dateToMs(filters.fromDate, false),
+  to: dateToMs(filters.toDate, true),
+  limit: filters.limit,
+  offset,
+});
+
+/** 監査ログを取得する（管理者限定 API）。フィルタ／offset が変わると再取得。 */
+export const useAuditLogs = (filters: AuditFilters, offset: number) => {
+  const params = toParams(filters, offset);
+  const { data, error, isLoading, mutate } = useSWR<AuditQueryResult>(
+    [AUDIT_LOGS_KEY, params],
+    ([path, p]: [string, typeof params]) =>
+      teamApi.get<AuditQueryResult>(path, { params: p }).then((res) => res.data),
+    { revalidateOnFocus: false, keepPreviousData: true },
+  );
+
+  const forbidden = error instanceof ApiError && error.status === 403;
+
+  return {
+    result: data,
+    total: data?.total ?? 0,
+    items: data?.items ?? [],
+    isLoading,
+    forbidden,
+    loadError:
+      error && !forbidden
+        ? '監査ログの取得に失敗しました。時間をおいて再度お試しください。'
+        : null,
+    mutate,
+  };
+};
+
+/** 現在の from/to で JSONL をダウンロードする。 */
+export const useAuditExport = (filters: AuditFilters) => {
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+
+  const exportLogs = useCallback(async () => {
+    setExporting(true);
+    setExportError(null);
+    try {
+      const params = {
+        from: dateToMs(filters.fromDate, false),
+        to: dateToMs(filters.toDate, true),
+      };
+      const { blob } = await teamApi.getBlob(`${AUDIT_LOGS_KEY}/export`, { params });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'audit-logs.jsonl';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setExportError(
+        e instanceof ApiError && e.status === 403
+          ? 'エクスポートには管理者権限が必要です。'
+          : 'エクスポートに失敗しました。時間をおいて再度お試しください。',
+      );
+    } finally {
+      setExporting(false);
+    }
+  }, [filters.fromDate, filters.toDate]);
+
+  return { exportLogs, exporting, exportError };
+};

--- a/genai-web/packages/web/src/open-genai/admin-modelpolicy/ModelPolicyPage.tsx
+++ b/genai-web/packages/web/src/open-genai/admin-modelpolicy/ModelPolicyPage.tsx
@@ -1,0 +1,345 @@
+import { useEffect, useMemo, useState } from 'react';
+import { PiBookOpenBold } from 'react-icons/pi';
+import { BreadcrumbsNav } from '@/components/ui/BreadcrumbsNav';
+import {
+  CustomDialog,
+  CustomDialogBody,
+  CustomDialogHeader,
+  CustomDialogPanel,
+} from '@/components/ui/CustomDialog';
+import { Button } from '@/components/ui/dads/Button';
+import { Disclosure, DisclosureSummary } from '@/components/ui/dads/Disclosure';
+import { ErrorText } from '@/components/ui/dads/ErrorText';
+import { Input } from '@/components/ui/dads/Input';
+import { Label } from '@/components/ui/dads/Label';
+import { SupportText } from '@/components/ui/dads/SupportText';
+import { useTeamAuth } from '@/features/teams/hooks/useTeamAuth';
+import { LayoutBody } from '@/layout/LayoutBody';
+import { PageTitle } from '@/components/PageTitle';
+import type { ModelPolicyConfig } from './types';
+import { useModelPolicy, useModelPolicyActions } from './useModelPolicy';
+
+const uniq = (list: string[]): string[] => Array.from(new Set(list.filter(Boolean)));
+
+const toggle = (list: string[], value: string): string[] =>
+  list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+
+export const ModelPolicyPage = () => {
+  const { isSystemAdminGroup } = useTeamAuth();
+  const { config, isLoading, forbidden, loadError, mutate } = useModelPolicy();
+  const { save, submitting, error, setError } = useModelPolicyActions(mutate);
+
+  const header = (
+    <div className='flex flex-col gap-4'>
+      <BreadcrumbsNav
+        items={[
+          { label: 'ホーム', to: '/' },
+          { label: 'AIアプリ', to: '/apps' },
+          { label: 'モデル利用制御' },
+        ]}
+      />
+      <h1 className='text-std-20B-160 lg:text-std-24B-150'>モデル利用制御</h1>
+      <p className='text-std-16N-170 text-solid-gray-700'>
+        利用可能な LLM をチーム単位で管理します（システム管理者のみ）。利用者は所属する各チームの許可モデルの和集合を使えます。
+      </p>
+    </div>
+  );
+
+  if (!isSystemAdminGroup) {
+    return (
+      <LayoutBody>
+        <PageTitle title='モデル利用制御' />
+        <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-6 p-6 lg:p-8'>
+          {header}
+          <p className='text-dns-16N-130 text-error-1' role='alert'>
+            このページの閲覧には管理者権限が必要です。
+          </p>
+        </div>
+      </LayoutBody>
+    );
+  }
+
+  return (
+    <LayoutBody>
+      <PageTitle title='モデル利用制御' />
+      <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-6 p-6 lg:p-8'>
+        {header}
+
+        <Disclosure className='rounded-8 border border-solid-gray-420 bg-solid-gray-50 px-4 py-3'>
+          <DisclosureSummary>
+            <span className='flex items-center text-std-16B-150'>
+              <PiBookOpenBold className='mr-2 size-5 flex-none' />
+              使い方（クリックで開閉）
+            </span>
+          </DisclosureSummary>
+          <div className='mt-3 flex flex-col gap-1.5 text-std-16N-170 text-solid-gray-700'>
+            <p>・「制御」を有効にすると、許可したモデルのみ利用できます（無効の間は全モデル利用可）。</p>
+            <p>・「全ユーザー共通で許可」は全員が使えるモデルです。</p>
+            <p>・「チーム別の追加許可」は各チームに追加で許可するモデルです。</p>
+            <p>・システム管理者は常に全モデルを利用できます。</p>
+          </div>
+        </Disclosure>
+
+        {isLoading ? (
+          <p className='text-std-16N-170 text-solid-gray-600'>読み込み中...</p>
+        ) : forbidden ? (
+          <p className='text-dns-16N-130 text-error-1' role='alert'>
+            このページの閲覧には管理者権限が必要です。
+          </p>
+        ) : loadError || !config ? (
+          <p className='text-dns-16N-130 text-error-1' role='alert'>
+            {loadError ?? 'ポリシーを取得できませんでした。'}
+          </p>
+        ) : (
+          <PolicyEditor
+            config={config}
+            submitting={submitting}
+            error={error}
+            setError={setError}
+            onSave={save}
+          />
+        )}
+      </div>
+    </LayoutBody>
+  );
+};
+
+type EditorProps = {
+  config: ModelPolicyConfig;
+  submitting: boolean;
+  error: string | null;
+  setError: (v: string | null) => void;
+  onSave: (policy: ModelPolicyConfig['policy']) => Promise<boolean>;
+};
+
+const PolicyEditor = ({ config, submitting, error, setError, onSave }: EditorProps) => {
+  const { policy, availableModels, teams } = config;
+
+  const [enabled, setEnabled] = useState(policy.enabled);
+  const [defaultModels, setDefaultModels] = useState<string[]>(policy.default);
+  const [teamModels, setTeamModels] = useState<Record<string, string[]>>(policy.teams ?? {});
+  const [extraModels, setExtraModels] = useState<string[]>([]);
+  const [newModel, setNewModel] = useState('');
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [done, setDone] = useState(false);
+
+  // config が変わった（保存後の再取得含む）ら編集状態を同期する。
+  useEffect(() => {
+    setEnabled(policy.enabled);
+    setDefaultModels(policy.default);
+    setTeamModels(policy.teams ?? {});
+    setExtraModels([]);
+    setDone(false);
+  }, [policy]);
+
+  const modelOptions = useMemo(() => {
+    const configured = [
+      ...availableModels,
+      ...policy.default,
+      ...Object.values(policy.teams ?? {}).flat(),
+      ...extraModels,
+    ];
+    return uniq(configured).sort((a, b) => a.localeCompare(b));
+  }, [availableModels, policy, extraModels]);
+
+  const addModel = () => {
+    const id = newModel.trim();
+    if (id && !modelOptions.includes(id)) {
+      setExtraModels((cur) => [...cur, id]);
+    }
+    setNewModel('');
+  };
+
+  const handleSave = async () => {
+    setConfirmOpen(false);
+    const cleanedTeams: Record<string, string[]> = {};
+    for (const [tid, models] of Object.entries(teamModels)) {
+      if (models.length > 0) {
+        cleanedTeams[tid] = models;
+      }
+    }
+    const ok = await onSave({
+      ...policy,
+      enabled,
+      default: defaultModels,
+      teams: cleanedTeams,
+    });
+    if (ok) {
+      setDone(true);
+    }
+  };
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <fieldset className='flex flex-col gap-2'>
+        <legend className='mb-1 text-std-16B-150'>制御</legend>
+        <label className='flex items-center gap-2 text-std-16N-170 text-solid-gray-900'>
+          <input
+            type='checkbox'
+            className='size-5'
+            checked={enabled}
+            onChange={(e) => {
+              setEnabled(e.target.checked);
+              setError(null);
+            }}
+          />
+          モデル利用制御を有効にする（許可モデルのみ利用可）
+        </label>
+        {!enabled && (
+          <SupportText>無効の間は全ユーザーが全モデルを利用できます。</SupportText>
+        )}
+      </fieldset>
+
+      <div className='flex flex-col gap-2'>
+        <h2 className='text-std-16B-150'>全ユーザー共通で許可するモデル</h2>
+        <ModelCheckboxGroup
+          options={modelOptions}
+          selected={defaultModels}
+          onToggle={(m) => setDefaultModels((cur) => toggle(cur, m))}
+        />
+      </div>
+
+      <div className='flex flex-col gap-3'>
+        <h2 className='text-std-16B-150'>チーム別の追加許可</h2>
+        {teams.length === 0 ? (
+          <SupportText>
+            設定対象のチームがありません。先に「チーム管理」でチームを作成してください。
+          </SupportText>
+        ) : (
+          teams.map((team) => (
+            <Disclosure
+              key={team.id}
+              className='rounded-8 border border-solid-gray-300 px-4 py-3'
+            >
+              <DisclosureSummary>
+                <span className='text-std-16B-150'>
+                  {team.name}
+                  <span className='ml-2 text-dns-14N-130 text-solid-gray-600'>
+                    （{(teamModels[team.id] ?? []).length} モデル許可）
+                  </span>
+                </span>
+              </DisclosureSummary>
+              <div className='mt-3'>
+                <ModelCheckboxGroup
+                  options={modelOptions}
+                  selected={teamModels[team.id] ?? []}
+                  onToggle={(m) =>
+                    setTeamModels((cur) => ({
+                      ...cur,
+                      [team.id]: toggle(cur[team.id] ?? [], m),
+                    }))
+                  }
+                />
+              </div>
+            </Disclosure>
+          ))
+        )}
+      </div>
+
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='extra-model' size='sm'>
+          一覧にないモデルIDを追加
+        </Label>
+        <SupportText>
+          利用可能モデル一覧を取得できない場合などに、モデルIDを直接追加できます。
+        </SupportText>
+        <div className='flex gap-2'>
+          <Input
+            id='extra-model'
+            blockSize='md'
+            value={newModel}
+            onChange={(e) => setNewModel(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addModel();
+              }
+            }}
+            className='flex-1'
+          />
+          <Button type='button' variant='outline' size='md' onClick={addModel}>
+            追加
+          </Button>
+        </div>
+      </div>
+
+      {error && <ErrorText>＊{error}</ErrorText>}
+      {done && (
+        <p className='text-dns-16N-130 text-green-900' role='status'>
+          ポリシーを保存しました。
+        </p>
+      )}
+
+      <div>
+        <Button
+          type='button'
+          variant='solid-fill'
+          size='md'
+          onClick={() => setConfirmOpen(true)}
+          aria-disabled={submitting || undefined}
+        >
+          {submitting ? '保存中...' : '設定を保存'}
+        </Button>
+      </div>
+
+      <CustomDialog isOpen={confirmOpen} onClose={() => setConfirmOpen(false)}>
+        <CustomDialogPanel>
+          <CustomDialogHeader hasClose onClose={() => setConfirmOpen(false)}>
+            モデル利用ポリシーを保存
+          </CustomDialogHeader>
+          <CustomDialogBody>
+            <p className='text-std-16N-170 text-solid-gray-800'>
+              モデル利用ポリシーを上書き保存します。よろしいですか？
+            </p>
+            <div className='mt-6 flex justify-end gap-3'>
+              <Button type='button' variant='outline' size='md' onClick={() => setConfirmOpen(false)}>
+                キャンセル
+              </Button>
+              <Button
+                type='button'
+                variant='solid-fill'
+                size='md'
+                onClick={handleSave}
+                aria-disabled={submitting || undefined}
+              >
+                {submitting ? '保存中...' : '保存する'}
+              </Button>
+            </div>
+          </CustomDialogBody>
+        </CustomDialogPanel>
+      </CustomDialog>
+    </div>
+  );
+};
+
+type GroupProps = {
+  options: string[];
+  selected: string[];
+  onToggle: (model: string) => void;
+};
+
+const ModelCheckboxGroup = ({ options, selected, onToggle }: GroupProps) => {
+  if (options.length === 0) {
+    return <SupportText>選択できるモデルがありません。下の欄からモデルIDを追加してください。</SupportText>;
+  }
+  return (
+    <div className='grid grid-cols-1 gap-1.5 sm:grid-cols-2 lg:grid-cols-3'>
+      {options.map((model) => (
+        <label
+          key={model}
+          className='flex items-center gap-2 text-std-16N-170 text-solid-gray-900'
+        >
+          <input
+            type='checkbox'
+            className='size-5 flex-none'
+            checked={selected.includes(model)}
+            onChange={() => onToggle(model)}
+          />
+          <span className='truncate' title={model}>
+            {model}
+          </span>
+        </label>
+      ))}
+    </div>
+  );
+};

--- a/genai-web/packages/web/src/open-genai/admin-modelpolicy/types.ts
+++ b/genai-web/packages/web/src/open-genai/admin-modelpolicy/types.ts
@@ -1,0 +1,21 @@
+// モデル利用制御 専用ページ（管理者限定・OpenGENAI 拡張）の型。
+// backend `GET/POST /admin/model-policy` の応答に対応する（modelpolicy-app 由来）。
+
+export type ModelPolicy = {
+  enabled: boolean;
+  default: string[];
+  teams: Record<string, string[]>;
+  /** 旧グループ別許可（後方互換・表示/保持のみ）。 */
+  groups?: Record<string, string[]>;
+};
+
+export type PolicyTeam = {
+  id: string;
+  name: string;
+};
+
+export type ModelPolicyConfig = {
+  policy: ModelPolicy;
+  availableModels: string[];
+  teams: PolicyTeam[];
+};

--- a/genai-web/packages/web/src/open-genai/admin-modelpolicy/useModelPolicy.ts
+++ b/genai-web/packages/web/src/open-genai/admin-modelpolicy/useModelPolicy.ts
@@ -1,0 +1,64 @@
+import { useCallback, useState } from 'react';
+import useSWR from 'swr';
+import { ApiError, teamApi } from '@/lib/fetcher';
+import type { ModelPolicy, ModelPolicyConfig } from './types';
+
+export const MODEL_POLICY_KEY = 'admin/model-policy';
+
+const errorMessage = (e: unknown, fallback: string): string => {
+  if (e instanceof ApiError) {
+    const data = e.data as { error?: string } | undefined;
+    if (data?.error) {
+      return data.error;
+    }
+  }
+  return fallback;
+};
+
+/** モデル利用ポリシーの現在値＋利用可能モデル＋対象チームを取得する（管理者限定）。 */
+export const useModelPolicy = () => {
+  const { data, error, isLoading, mutate } = useSWR<ModelPolicyConfig>(
+    MODEL_POLICY_KEY,
+    (key: string) => teamApi.get<ModelPolicyConfig>(key).then((res) => res.data),
+    { revalidateOnFocus: false },
+  );
+
+  const forbidden = error instanceof ApiError && error.status === 403;
+
+  return {
+    config: data,
+    isLoading,
+    forbidden,
+    loadError:
+      error && !forbidden
+        ? 'モデル利用ポリシーの取得に失敗しました。時間をおいて再度お試しください。'
+        : null,
+    mutate,
+  };
+};
+
+/** ポリシーを保存する（modelpolicy-app へプロキシ）。 */
+export const useModelPolicyActions = (mutate: () => Promise<unknown>) => {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const save = useCallback(
+    async (policy: ModelPolicy): Promise<boolean> => {
+      setSubmitting(true);
+      setError(null);
+      try {
+        await teamApi.post(MODEL_POLICY_KEY, { policy });
+        await mutate();
+        return true;
+      } catch (e) {
+        setError(errorMessage(e, 'ポリシーの保存に失敗しました。'));
+        return false;
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [mutate],
+  );
+
+  return { save, submitting, error, setError };
+};

--- a/genai-web/packages/web/src/open-genai/admin-ngword/NgWordPage.tsx
+++ b/genai-web/packages/web/src/open-genai/admin-ngword/NgWordPage.tsx
@@ -1,0 +1,289 @@
+import { useEffect, useState } from 'react';
+import { PiBookOpenBold } from 'react-icons/pi';
+import { BreadcrumbsNav } from '@/components/ui/BreadcrumbsNav';
+import {
+  CustomDialog,
+  CustomDialogBody,
+  CustomDialogHeader,
+  CustomDialogPanel,
+} from '@/components/ui/CustomDialog';
+import { Button } from '@/components/ui/dads/Button';
+import { Disclosure, DisclosureSummary } from '@/components/ui/dads/Disclosure';
+import { ErrorText } from '@/components/ui/dads/ErrorText';
+import { Label } from '@/components/ui/dads/Label';
+import { SupportText } from '@/components/ui/dads/SupportText';
+import { Textarea } from '@/components/ui/dads/Textarea';
+import { useTeamAuth } from '@/features/teams/hooks/useTeamAuth';
+import { LayoutBody } from '@/layout/LayoutBody';
+import { PageTitle } from '@/components/PageTitle';
+import type { NgWordRules } from './types';
+import { useNgword, useNgwordActions } from './useNgword';
+
+const toLines = (text: string): string[] =>
+  text
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+/** 各行の正規表現を検証し、不正なものがあれば最初の行を返す。 */
+const findInvalidPattern = (text: string): string | null => {
+  for (const line of toLines(text)) {
+    try {
+      new RegExp(line);
+    } catch {
+      return line;
+    }
+  }
+  return null;
+};
+
+export const NgWordPage = () => {
+  const { isSystemAdminGroup } = useTeamAuth();
+  const { rules, isLoading, forbidden, loadError, mutate } = useNgword();
+  const { save, submitting, error, setError } = useNgwordActions(mutate);
+
+  const header = (
+    <div className='flex flex-col gap-4'>
+      <BreadcrumbsNav
+        items={[
+          { label: 'ホーム', to: '/' },
+          { label: 'AIアプリ', to: '/apps' },
+          { label: '入力制限（禁止ワード）' },
+        ]}
+      />
+      <h1 className='text-std-20B-160 lg:text-std-24B-150'>入力制限（禁止ワード・機密情報）</h1>
+      <p className='text-std-16N-170 text-solid-gray-700'>
+        チャット・AIアプリの入力に対する禁止ワード・機密情報の制限を設定します（システム管理者のみ）。有効時、推論前に入力を検査し該当時はブロックします。
+      </p>
+    </div>
+  );
+
+  if (!isSystemAdminGroup) {
+    return (
+      <LayoutBody>
+        <PageTitle title='入力制限（禁止ワード）' />
+        <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-6 p-6 lg:p-8'>
+          {header}
+          <p className='text-dns-16N-130 text-error-1' role='alert'>
+            このページの閲覧には管理者権限が必要です。
+          </p>
+        </div>
+      </LayoutBody>
+    );
+  }
+
+  return (
+    <LayoutBody>
+      <PageTitle title='入力制限（禁止ワード）' />
+      <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-6 p-6 lg:p-8'>
+        {header}
+
+        <Disclosure className='rounded-8 border border-solid-gray-420 bg-solid-gray-50 px-4 py-3'>
+          <DisclosureSummary>
+            <span className='flex items-center text-std-16B-150'>
+              <PiBookOpenBold className='mr-2 size-5 flex-none' />
+              使い方（クリックで開閉）
+            </span>
+          </DisclosureSummary>
+          <div className='mt-3 flex flex-col gap-1.5 text-std-16N-170 text-solid-gray-700'>
+            <p>・「入力制限」を有効にすると、禁止ワード・機密情報を含む入力をブロックします。</p>
+            <p>・禁止ワードは1行に1語、機密情報パターンは1行に1つの正規表現で入力します。</p>
+            <p>・マイナンバー検査は検査用数字が一致する12桁のみブロックします（単なる12桁数字では止めません）。</p>
+            <p>・システム管理者による管理系アプリの実行は本制限の対象外です。</p>
+          </div>
+        </Disclosure>
+
+        {isLoading ? (
+          <p className='text-std-16N-170 text-solid-gray-600'>読み込み中...</p>
+        ) : forbidden ? (
+          <p className='text-dns-16N-130 text-error-1' role='alert'>
+            このページの閲覧には管理者権限が必要です。
+          </p>
+        ) : loadError || !rules ? (
+          <p className='text-dns-16N-130 text-error-1' role='alert'>
+            {loadError ?? 'ルールを取得できませんでした。'}
+          </p>
+        ) : (
+          <RulesEditor
+            rules={rules}
+            submitting={submitting}
+            error={error}
+            setError={setError}
+            onSave={save}
+          />
+        )}
+      </div>
+    </LayoutBody>
+  );
+};
+
+type EditorProps = {
+  rules: NgWordRules;
+  submitting: boolean;
+  error: string | null;
+  setError: (v: string | null) => void;
+  onSave: (rules: NgWordRules) => Promise<boolean>;
+};
+
+const RulesEditor = ({ rules, submitting, error, setError, onSave }: EditorProps) => {
+  const [enabled, setEnabled] = useState(rules.enabled);
+  const [caseSensitive, setCaseSensitive] = useState(rules.case_sensitive);
+  const [checkMynumber, setCheckMynumber] = useState(rules.check_mynumber);
+  const [words, setWords] = useState((rules.words ?? []).join('\n'));
+  const [patterns, setPatterns] = useState((rules.patterns ?? []).join('\n'));
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    setEnabled(rules.enabled);
+    setCaseSensitive(rules.case_sensitive);
+    setCheckMynumber(rules.check_mynumber);
+    setWords((rules.words ?? []).join('\n'));
+    setPatterns((rules.patterns ?? []).join('\n'));
+    setDone(false);
+  }, [rules]);
+
+  const openConfirm = () => {
+    setLocalError(null);
+    setDone(false);
+    const invalid = findInvalidPattern(patterns);
+    if (invalid) {
+      setLocalError(`正規表現が不正です: ${invalid}`);
+      return;
+    }
+    setConfirmOpen(true);
+  };
+
+  const handleSave = async () => {
+    setConfirmOpen(false);
+    const ok = await onSave({
+      enabled,
+      case_sensitive: caseSensitive,
+      check_mynumber: checkMynumber,
+      words: toLines(words),
+      patterns: toLines(patterns),
+    });
+    if (ok) {
+      setDone(true);
+    }
+  };
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <fieldset className='flex flex-col gap-2'>
+        <legend className='mb-1 text-std-16B-150'>制御</legend>
+        <label className='flex items-center gap-2 text-std-16N-170 text-solid-gray-900'>
+          <input
+            type='checkbox'
+            className='size-5'
+            checked={enabled}
+            onChange={(e) => {
+              setEnabled(e.target.checked);
+              setError(null);
+            }}
+          />
+          入力制限を有効にする（禁止ワード・機密情報を含む入力をブロック）
+        </label>
+        {!enabled && <SupportText>無効の間は入力を制限しません。</SupportText>}
+      </fieldset>
+
+      <fieldset className='flex flex-col gap-2'>
+        <legend className='mb-1 text-std-16B-150'>検査オプション</legend>
+        <label className='flex items-center gap-2 text-std-16N-170 text-solid-gray-900'>
+          <input
+            type='checkbox'
+            className='size-5'
+            checked={caseSensitive}
+            onChange={(e) => setCaseSensitive(e.target.checked)}
+          />
+          禁止ワードの大文字小文字を区別する
+        </label>
+        <label className='flex items-center gap-2 text-std-16N-170 text-solid-gray-900'>
+          <input
+            type='checkbox'
+            className='size-5'
+            checked={checkMynumber}
+            onChange={(e) => setCheckMynumber(e.target.checked)}
+          />
+          マイナンバー検査を行う（検査用数字が一致する12桁のみ）
+        </label>
+      </fieldset>
+
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='ng-words' size='sm'>
+          禁止ワード（1行に1語）
+        </Label>
+        <SupportText>入力に含まれるとブロックする語を改行区切りで指定します。</SupportText>
+        <Textarea
+          id='ng-words'
+          rows={6}
+          value={words}
+          onChange={(e) => setWords(e.target.value)}
+        />
+      </div>
+
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='ng-patterns' size='sm'>
+          機密情報パターン（1行に1正規表現）
+        </Label>
+        <SupportText>
+          任意の正規表現。マイナンバーは上の専用検査を使ってください（{'\\d{12}'} 単体は専用検査へ委譲されます）。
+        </SupportText>
+        <Textarea
+          id='ng-patterns'
+          rows={6}
+          value={patterns}
+          onChange={(e) => setPatterns(e.target.value)}
+          className='font-mono'
+        />
+      </div>
+
+      {(localError || error) && <ErrorText>＊{localError ?? error}</ErrorText>}
+      {done && (
+        <p className='text-dns-16N-130 text-green-900' role='status'>
+          入力制限ルールを保存しました。
+        </p>
+      )}
+
+      <div>
+        <Button
+          type='button'
+          variant='solid-fill'
+          size='md'
+          onClick={openConfirm}
+          aria-disabled={submitting || undefined}
+        >
+          {submitting ? '保存中...' : '設定を保存'}
+        </Button>
+      </div>
+
+      <CustomDialog isOpen={confirmOpen} onClose={() => setConfirmOpen(false)}>
+        <CustomDialogPanel>
+          <CustomDialogHeader hasClose onClose={() => setConfirmOpen(false)}>
+            入力制限ルールを保存
+          </CustomDialogHeader>
+          <CustomDialogBody>
+            <p className='text-std-16N-170 text-solid-gray-800'>
+              入力制限ルールを上書き保存します。よろしいですか？
+            </p>
+            <div className='mt-6 flex justify-end gap-3'>
+              <Button type='button' variant='outline' size='md' onClick={() => setConfirmOpen(false)}>
+                キャンセル
+              </Button>
+              <Button
+                type='button'
+                variant='solid-fill'
+                size='md'
+                onClick={handleSave}
+                aria-disabled={submitting || undefined}
+              >
+                {submitting ? '保存中...' : '保存する'}
+              </Button>
+            </div>
+          </CustomDialogBody>
+        </CustomDialogPanel>
+      </CustomDialog>
+    </div>
+  );
+};

--- a/genai-web/packages/web/src/open-genai/admin-ngword/types.ts
+++ b/genai-web/packages/web/src/open-genai/admin-ngword/types.ts
@@ -1,0 +1,14 @@
+// 入力制限（禁止ワード・機密情報）専用ページ（管理者限定・OpenGENAI 拡張）の型。
+// backend `GET/POST /admin/ngword` の応答に対応する（ngword-app 由来）。
+
+export type NgWordRules = {
+  enabled: boolean;
+  case_sensitive: boolean;
+  check_mynumber: boolean;
+  words: string[];
+  patterns: string[];
+};
+
+export type NgWordConfig = {
+  rules: NgWordRules;
+};

--- a/genai-web/packages/web/src/open-genai/admin-ngword/useNgword.ts
+++ b/genai-web/packages/web/src/open-genai/admin-ngword/useNgword.ts
@@ -1,0 +1,64 @@
+import { useCallback, useState } from 'react';
+import useSWR from 'swr';
+import { ApiError, teamApi } from '@/lib/fetcher';
+import type { NgWordConfig, NgWordRules } from './types';
+
+export const NGWORD_KEY = 'admin/ngword';
+
+const errorMessage = (e: unknown, fallback: string): string => {
+  if (e instanceof ApiError) {
+    const data = e.data as { error?: string } | undefined;
+    if (data?.error) {
+      return data.error;
+    }
+  }
+  return fallback;
+};
+
+/** 入力制限ルールの現在値を取得する（管理者限定）。 */
+export const useNgword = () => {
+  const { data, error, isLoading, mutate } = useSWR<NgWordConfig>(
+    NGWORD_KEY,
+    (key: string) => teamApi.get<NgWordConfig>(key).then((res) => res.data),
+    { revalidateOnFocus: false },
+  );
+
+  const forbidden = error instanceof ApiError && error.status === 403;
+
+  return {
+    rules: data?.rules,
+    isLoading,
+    forbidden,
+    loadError:
+      error && !forbidden
+        ? '入力制限ルールの取得に失敗しました。時間をおいて再度お試しください。'
+        : null,
+    mutate,
+  };
+};
+
+/** ルールを保存する（ngword-app へプロキシ）。 */
+export const useNgwordActions = (mutate: () => Promise<unknown>) => {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const save = useCallback(
+    async (rules: NgWordRules): Promise<boolean> => {
+      setSubmitting(true);
+      setError(null);
+      try {
+        await teamApi.post(NGWORD_KEY, { rules });
+        await mutate();
+        return true;
+      } catch (e) {
+        setError(errorMessage(e, 'ルールの保存に失敗しました。'));
+        return false;
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [mutate],
+  );
+
+  return { save, submitting, error, setError };
+};

--- a/genai-web/packages/web/src/open-genai/admin-usermgmt/UserCsvSection.tsx
+++ b/genai-web/packages/web/src/open-genai/admin-usermgmt/UserCsvSection.tsx
@@ -1,0 +1,244 @@
+import { useRef, useState } from 'react';
+import {
+  CustomDialog,
+  CustomDialogBody,
+  CustomDialogHeader,
+  CustomDialogPanel,
+} from '@/components/ui/CustomDialog';
+import { Button } from '@/components/ui/dads/Button';
+import { ErrorText } from '@/components/ui/dads/ErrorText';
+import { Label } from '@/components/ui/dads/Label';
+import { SupportText } from '@/components/ui/dads/SupportText';
+import { Textarea } from '@/components/ui/dads/Textarea';
+import { useUserMgmtActions } from './useUserMgmt';
+import type { ApplyResult, PlanRow } from './types';
+
+const ACTION_LABEL: Record<string, string> = {
+  create: '作成',
+  update: '更新',
+  delete: '削除',
+  upsert: '作成/更新',
+};
+
+const actionLabel = (action: string): string => ACTION_LABEL[action] ?? action;
+
+const CSV_SAMPLE = `action,username,email,name,password,groups,enabled
+upsert,yamada,yamada@example.com,山田太郎,Passw0rd!,UserGroup,true`;
+
+type Props = {
+  onApplied: () => void;
+};
+
+/** 「CSV一括処理」: 貼り付け／ファイルからドライラン→適用（確認ダイアログ）まで。 */
+export const UserCsvSection = ({ onApplied }: Props) => {
+  const { plan, apply, submitting, error, setError } = useUserMgmtActions();
+  const [csvText, setCsvText] = useState('');
+  const [planRows, setPlanRows] = useState<PlanRow[] | null>(null);
+  const [applyResults, setApplyResults] = useState<ApplyResult[] | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const resetOutputs = () => {
+    setPlanRows(null);
+    setApplyResults(null);
+  };
+
+  const handleFile = async (file: File | undefined) => {
+    if (!file) {
+      return;
+    }
+    const text = await file.text();
+    setCsvText(text);
+    resetOutputs();
+    setError(null);
+  };
+
+  const handleDryRun = async () => {
+    resetOutputs();
+    const res = await plan(csvText);
+    if (res) {
+      setPlanRows(res.rows);
+    }
+  };
+
+  const handleApply = async () => {
+    setConfirmOpen(false);
+    setApplyResults(null);
+    const res = await apply(csvText);
+    if (res) {
+      setApplyResults(res.results);
+      setPlanRows(null);
+      onApplied();
+    }
+  };
+
+  const planErrorCount = planRows?.filter((r) => r.error).length ?? 0;
+
+  return (
+    <div className='flex flex-col gap-5'>
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='csv-text' size='sm'>
+          CSV（貼り付け）
+        </Label>
+        <SupportText>
+          見出し: action, username, email, firstName, lastName, name, password, groups, enabled。
+          action は create / update / delete / upsert（既定 upsert）。
+        </SupportText>
+        <Textarea
+          id='csv-text'
+          rows={8}
+          value={csvText}
+          placeholder={CSV_SAMPLE}
+          onChange={(e) => {
+            setCsvText(e.target.value);
+            resetOutputs();
+          }}
+          className='font-mono'
+        />
+      </div>
+
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='csv-file' size='sm'>
+          CSV ファイル（貼り付けの代わりに読み込み）
+        </Label>
+        <input
+          id='csv-file'
+          ref={fileRef}
+          type='file'
+          accept='.csv,.txt'
+          onChange={(e) => handleFile(e.target.files?.[0])}
+          className='text-std-16N-170 text-solid-gray-800'
+        />
+      </div>
+
+      {error && <ErrorText>＊{error}</ErrorText>}
+
+      <div className='flex flex-wrap items-center gap-3'>
+        <Button
+          type='button'
+          variant='outline'
+          size='md'
+          onClick={handleDryRun}
+          aria-disabled={submitting || !csvText.trim() || undefined}
+        >
+          {submitting ? '処理中...' : 'ドライラン（変更しない）'}
+        </Button>
+        <Button
+          type='button'
+          variant='solid-fill'
+          size='md'
+          onClick={() => setConfirmOpen(true)}
+          aria-disabled={submitting || !csvText.trim() || undefined}
+        >
+          適用（Keycloak に反映）
+        </Button>
+      </div>
+
+      {planRows && (
+        <div className='flex flex-col gap-2'>
+          <h3 className='text-std-16B-150'>ドライラン結果（変更なし）</h3>
+          <SupportText>
+            {planRows.length} 件中、エラー {planErrorCount} 件。問題なければ「適用」を実行してください。
+          </SupportText>
+          <ResultTable
+            headers={['#', 'username', '操作', 'groups', '判定']}
+            rows={planRows.map((r, i) => [
+              String(i + 1),
+              r.username || '-',
+              actionLabel(r.action),
+              r.groups.join(', ') || '-',
+              r.error ? `エラー: ${r.error}` : '実行予定',
+            ])}
+            errorRow={(i) => !!planRows[i].error}
+          />
+        </div>
+      )}
+
+      {applyResults && (
+        <div className='flex flex-col gap-2'>
+          <h3 className='text-std-16B-150'>適用結果</h3>
+          <ResultTable
+            headers={['#', 'username', '操作', '結果', '備考']}
+            rows={applyResults.map((r, i) => [
+              String(i + 1),
+              r.username || '-',
+              actionLabel(r.action),
+              r.result,
+              r.note || '-',
+            ])}
+            errorRow={(i) => applyResults[i].result === 'エラー'}
+          />
+        </div>
+      )}
+
+      <CustomDialog isOpen={confirmOpen} onClose={() => setConfirmOpen(false)}>
+        <CustomDialogPanel>
+          <CustomDialogHeader hasClose onClose={() => setConfirmOpen(false)}>
+            CSV を Keycloak に反映
+          </CustomDialogHeader>
+          <CustomDialogBody>
+            <p className='text-std-16N-170 text-solid-gray-800'>
+              CSV の内容を Keycloak に反映します（利用者の作成・更新・削除を含む）。削除は元に戻せません。ドライランで確認済みですか？
+            </p>
+            <div className='mt-6 flex justify-end gap-3'>
+              <Button
+                type='button'
+                variant='outline'
+                size='md'
+                onClick={() => setConfirmOpen(false)}
+              >
+                キャンセル
+              </Button>
+              <Button
+                type='button'
+                variant='solid-fill'
+                size='md'
+                onClick={handleApply}
+                aria-disabled={submitting || undefined}
+              >
+                {submitting ? '適用中...' : '適用する'}
+              </Button>
+            </div>
+          </CustomDialogBody>
+        </CustomDialogPanel>
+      </CustomDialog>
+    </div>
+  );
+};
+
+type TableProps = {
+  headers: string[];
+  rows: string[][];
+  errorRow?: (index: number) => boolean;
+};
+
+const ResultTable = ({ headers, rows, errorRow }: TableProps) => (
+  <div className='overflow-x-auto rounded-8 border border-solid-gray-300'>
+    <table className='w-full border-collapse text-left text-dns-14N-130'>
+      <thead className='bg-solid-gray-50 text-solid-gray-700'>
+        <tr>
+          {headers.map((h) => (
+            <th key={h} className='whitespace-nowrap px-3 py-2 font-bold'>
+              {h}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody className='divide-y divide-solid-gray-300'>
+        {rows.map((cols, i) => (
+          <tr
+            // 行の並びは固定でインデックスが安定するため index キーで十分。
+            key={i}
+            className={errorRow?.(i) ? 'text-error-1' : 'text-solid-gray-900'}
+          >
+            {cols.map((c, j) => (
+              <td key={j} className='px-3 py-2 align-top'>
+                {c}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);

--- a/genai-web/packages/web/src/open-genai/admin-usermgmt/UserMgmtPage.tsx
+++ b/genai-web/packages/web/src/open-genai/admin-usermgmt/UserMgmtPage.tsx
@@ -1,0 +1,226 @@
+import { useMemo, useState } from 'react';
+import { PiBookOpenBold } from 'react-icons/pi';
+import { BreadcrumbsNav } from '@/components/ui/BreadcrumbsNav';
+import { Button } from '@/components/ui/dads/Button';
+import { Disclosure, DisclosureSummary } from '@/components/ui/dads/Disclosure';
+import { Input } from '@/components/ui/dads/Input';
+import { Label } from '@/components/ui/dads/Label';
+import { Select } from '@/components/ui/dads/Select';
+import { SupportText } from '@/components/ui/dads/SupportText';
+import { useTeamAuth } from '@/features/teams/hooks/useTeamAuth';
+import { LayoutBody } from '@/layout/LayoutBody';
+import { PageTitle } from '@/components/PageTitle';
+import { UserCsvSection } from './UserCsvSection';
+import { useUsers } from './useUserMgmt';
+
+type Mode = 'list' | 'csv';
+
+const MODES: { id: Mode; label: string }[] = [
+  { id: 'list', label: '利用者一覧' },
+  { id: 'csv', label: 'CSV一括処理' },
+];
+
+const LIMIT_OPTIONS = [50, 100, 200, 500, 1000];
+
+/**
+ * 利用者一括管理 専用ページ（管理者限定・OpenGENAI 拡張）。
+ * 源内の汎用 exApp フォーム（操作 select ＋ Markdown 出力）では一覧・ドライラン・適用の
+ * 往復がしづらいため、一覧と CSV 一括処理を専用ページとして提供する。
+ */
+export const UserMgmtPage = () => {
+  const { isSystemAdminGroup } = useTeamAuth();
+  const [mode, setMode] = useState<Mode>('list');
+
+  const header = useMemo(
+    () => (
+      <div className='flex flex-col gap-4'>
+        <BreadcrumbsNav
+          items={[
+            { label: 'ホーム', to: '/' },
+            { label: 'AIアプリ', to: '/apps' },
+            { label: '利用者一括管理' },
+          ]}
+        />
+        <h1 className='text-std-20B-160 lg:text-std-24B-150'>利用者一括管理</h1>
+        <p className='text-std-16N-170 text-solid-gray-700'>
+          利用者アカウント（Keycloak）の一覧表示と、CSV による一括登録・更新・削除ができます（システム管理者のみ）。
+        </p>
+      </div>
+    ),
+    [],
+  );
+
+  if (!isSystemAdminGroup) {
+    return (
+      <LayoutBody>
+        <PageTitle title='利用者一括管理' />
+        <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-6 p-6 lg:p-8'>
+          {header}
+          <p className='text-dns-16N-130 text-error-1' role='alert'>
+            このページの閲覧には管理者権限が必要です。
+          </p>
+        </div>
+      </LayoutBody>
+    );
+  }
+
+  return (
+    <LayoutBody>
+      <PageTitle title='利用者一括管理' />
+      <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-6 p-6 lg:p-8'>
+        {header}
+
+        <Disclosure className='rounded-8 border border-solid-gray-420 bg-solid-gray-50 px-4 py-3'>
+          <DisclosureSummary>
+            <span className='flex items-center text-std-16B-150'>
+              <PiBookOpenBold className='mr-2 size-5 flex-none' />
+              使い方（クリックで開閉）
+            </span>
+          </DisclosureSummary>
+          <div className='mt-3 flex flex-col gap-1.5 text-std-16N-170 text-solid-gray-700'>
+            <p>・「利用者一覧」で現在のアカウントを検索・確認できます（変更はされません）。</p>
+            <p>・「CSV一括処理」でCSVを貼り付け／読み込み、まず「ドライラン」で内容を確認します。</p>
+            <p>・問題なければ「適用」で Keycloak に反映します（作成・更新・削除。削除は元に戻せません）。</p>
+            <p>・password 列を含む CSV の保管・共有には十分注意してください。</p>
+          </div>
+        </Disclosure>
+
+        <div role='tablist' aria-label='操作' className='flex gap-1 border-b border-solid-gray-300'>
+          {MODES.map((m) => {
+            const isActive = m.id === mode;
+            return (
+              <button
+                key={m.id}
+                type='button'
+                role='tab'
+                aria-selected={isActive}
+                onClick={() => setMode(m.id)}
+                className={`-mb-px border-b-2 px-4 py-2 text-oln-16B-100 transition-colors focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-black ${
+                  isActive
+                    ? 'border-blue-900 text-blue-900'
+                    : 'border-transparent text-solid-gray-600 hover:text-solid-gray-900'
+                }`}
+              >
+                {m.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {mode === 'list' ? <UserListSection /> : <UserCsvSection onApplied={() => setMode('list')} />}
+      </div>
+    </LayoutBody>
+  );
+};
+
+/** 「利用者一覧」: 検索・件数指定で Keycloak の利用者を表示（読み取り専用）。 */
+const UserListSection = () => {
+  const [draftSearch, setDraftSearch] = useState('');
+  const [search, setSearch] = useState('');
+  const [limit, setLimit] = useState(200);
+
+  const { users, count, limitReached, isLoading, forbidden, loadError, mutate } = useUsers(
+    search,
+    limit,
+  );
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <div className='flex flex-wrap items-end gap-3'>
+        <div className='flex min-w-60 flex-1 flex-col gap-1.5'>
+          <Label htmlFor='user-search' size='sm'>
+            検索（username / email / 氏名の部分一致）
+          </Label>
+          <Input
+            id='user-search'
+            blockSize='md'
+            value={draftSearch}
+            onChange={(e) => setDraftSearch(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                setSearch(draftSearch);
+              }
+            }}
+          />
+        </div>
+        <div className='flex flex-col gap-1.5'>
+          <Label htmlFor='user-limit' size='sm'>
+            表示件数
+          </Label>
+          <Select
+            id='user-limit'
+            blockSize='md'
+            value={String(limit)}
+            onChange={(e) => setLimit(Number(e.target.value))}
+          >
+            {LIMIT_OPTIONS.map((n) => (
+              <option key={n} value={n}>
+                {n}件
+              </option>
+            ))}
+          </Select>
+        </div>
+        <Button type='button' variant='solid-fill' size='md' onClick={() => setSearch(draftSearch)}>
+          検索
+        </Button>
+        <Button type='button' variant='outline' size='md' onClick={() => mutate()}>
+          再読み込み
+        </Button>
+      </div>
+
+      {forbidden ? (
+        <p className='text-dns-16N-130 text-error-1' role='alert'>
+          このページの閲覧には管理者権限が必要です。
+        </p>
+      ) : loadError ? (
+        <p className='text-dns-16N-130 text-error-1' role='alert'>
+          {loadError}
+        </p>
+      ) : (
+        <>
+          <div className='flex flex-wrap items-center justify-between gap-2'>
+            <SupportText>
+              {count === 0
+                ? '該当する利用者はいません。'
+                : `${count} 件を表示${limitReached ? '（上限に達しています）' : ''}`}
+            </SupportText>
+            {isLoading && <SupportText>読み込み中...</SupportText>}
+          </div>
+
+          {users.length > 0 && (
+            <div className='overflow-x-auto rounded-8 border border-solid-gray-300'>
+              <table className='w-full border-collapse text-left text-dns-14N-130'>
+                <thead className='bg-solid-gray-50 text-solid-gray-700'>
+                  <tr>
+                    <th className='px-3 py-2 font-bold'>username</th>
+                    <th className='px-3 py-2 font-bold'>email</th>
+                    <th className='px-3 py-2 font-bold'>氏名</th>
+                    <th className='px-3 py-2 font-bold'>groups</th>
+                    <th className='whitespace-nowrap px-3 py-2 font-bold'>状態</th>
+                  </tr>
+                </thead>
+                <tbody className='divide-y divide-solid-gray-300'>
+                  {users.map((u) => (
+                    <tr key={u.id || u.username} className='align-top text-solid-gray-900'>
+                      <td className='px-3 py-2'>{u.username || '-'}</td>
+                      <td className='px-3 py-2'>{u.email || '-'}</td>
+                      <td className='px-3 py-2'>{u.name || '-'}</td>
+                      <td className='px-3 py-2'>{u.groups.length > 0 ? u.groups.join(', ') : '-'}</td>
+                      <td className='whitespace-nowrap px-3 py-2'>
+                        {u.enabled ? (
+                          '有効'
+                        ) : (
+                          <span className='text-solid-gray-500'>無効</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};

--- a/genai-web/packages/web/src/open-genai/admin-usermgmt/types.ts
+++ b/genai-web/packages/web/src/open-genai/admin-usermgmt/types.ts
@@ -1,0 +1,43 @@
+// 利用者一括管理 専用ページ（管理者限定・OpenGENAI 拡張）の型。
+// backend `/admin/users`(/plan,/apply) の応答に対応する（usermgmt-app 由来）。
+
+export type ManagedUser = {
+  id: string;
+  username: string;
+  email: string;
+  name: string;
+  groups: string[];
+  enabled: boolean;
+};
+
+export type UsersResponse = {
+  users: ManagedUser[];
+  count: number;
+  limitReached: boolean;
+};
+
+/** CSV 各行のドライラン結果（Keycloak へは未反映）。 */
+export type PlanRow = {
+  username: string;
+  action: string;
+  groups: string[];
+  error: string | null;
+};
+
+export type PlanResponse = {
+  rows: PlanRow[];
+  count: number;
+};
+
+/** 適用（Keycloak 反映）後の各行の結果。 */
+export type ApplyResult = {
+  username: string;
+  action: string;
+  result: string;
+  note: string;
+};
+
+export type ApplyResponse = {
+  results: ApplyResult[];
+  count: number;
+};

--- a/genai-web/packages/web/src/open-genai/admin-usermgmt/useUserMgmt.ts
+++ b/genai-web/packages/web/src/open-genai/admin-usermgmt/useUserMgmt.ts
@@ -1,0 +1,78 @@
+import { useCallback, useState } from 'react';
+import useSWR from 'swr';
+import { ApiError, teamApi } from '@/lib/fetcher';
+import type { ApplyResponse, PlanResponse, UsersResponse } from './types';
+
+export const ADMIN_USERS_KEY = 'admin/users';
+
+const errorMessage = (e: unknown, fallback: string): string => {
+  if (e instanceof ApiError) {
+    const data = e.data as { error?: string } | undefined;
+    if (data?.error) {
+      return data.error;
+    }
+  }
+  return fallback;
+};
+
+/** Keycloak の利用者一覧を取得する（管理者限定）。search/limit が変わると再取得。 */
+export const useUsers = (search: string, limit: number) => {
+  const params = { search: search.trim() || undefined, limit };
+  const { data, error, isLoading, mutate } = useSWR<UsersResponse>(
+    [ADMIN_USERS_KEY, params],
+    ([path, p]: [string, typeof params]) =>
+      teamApi.get<UsersResponse>(path, { params: p }).then((res) => res.data),
+    { revalidateOnFocus: false, keepPreviousData: true },
+  );
+
+  const forbidden = error instanceof ApiError && error.status === 403;
+
+  return {
+    users: data?.users ?? [],
+    count: data?.count ?? 0,
+    limitReached: data?.limitReached ?? false,
+    isLoading,
+    forbidden,
+    loadError:
+      error && !forbidden
+        ? '利用者一覧の取得に失敗しました。時間をおいて再度お試しください。'
+        : null,
+    mutate,
+  };
+};
+
+/** CSV のドライラン（変更なし）と適用（Keycloak 反映）。 */
+export const useUserMgmtActions = () => {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const plan = useCallback(async (csvText: string): Promise<PlanResponse | null> => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await teamApi.post<PlanResponse>('admin/users/plan', { csv_text: csvText });
+      return res.data ?? null;
+    } catch (e) {
+      setError(errorMessage(e, 'ドライランに失敗しました。'));
+      return null;
+    } finally {
+      setSubmitting(false);
+    }
+  }, []);
+
+  const apply = useCallback(async (csvText: string): Promise<ApplyResponse | null> => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await teamApi.post<ApplyResponse>('admin/users/apply', { csv_text: csvText });
+      return res.data ?? null;
+    } catch (e) {
+      setError(errorMessage(e, '適用に失敗しました。'));
+      return null;
+    } finally {
+      setSubmitting(false);
+    }
+  }, []);
+
+  return { plan, apply, submitting, error, setError };
+};

--- a/genai-web/packages/web/src/open-genai/prompt-templates/PromptCreateSection.tsx
+++ b/genai-web/packages/web/src/open-genai/prompt-templates/PromptCreateSection.tsx
@@ -1,0 +1,173 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/dads/Button';
+import { ErrorText } from '@/components/ui/dads/ErrorText';
+import { Input } from '@/components/ui/dads/Input';
+import { Label } from '@/components/ui/dads/Label';
+import { Select } from '@/components/ui/dads/Select';
+import { SupportText } from '@/components/ui/dads/SupportText';
+import { Textarea } from '@/components/ui/dads/Textarea';
+import { extractVariables } from './templateVars';
+import type { CreateTemplateInput, PromptShare, PromptTarget, PromptTeam } from './types';
+
+type Props = {
+  teams: PromptTeam[];
+  canCreateStandard: boolean;
+  submitting: boolean;
+  error: string | null;
+  onSubmit: (input: CreateTemplateInput) => Promise<boolean>;
+};
+
+/** 「作成」: 個人／チーム共有／全体公開／標準のテンプレートを追加する。 */
+export const PromptCreateSection = ({
+  teams,
+  canCreateStandard,
+  submitting,
+  error,
+  onSubmit,
+}: Props) => {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [target, setTarget] = useState<PromptTarget>('content');
+  const [share, setShare] = useState<PromptShare>('personal');
+  const [shareTeam, setShareTeam] = useState('');
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  const variables = extractVariables(body);
+
+  const handleSubmit = async () => {
+    setLocalError(null);
+    setDone(false);
+    if (!title.trim() || !body.trim()) {
+      setLocalError('タイトルと本文を入力してください。');
+      return;
+    }
+    if (share === 'team' && !shareTeam) {
+      setLocalError('共有先チームを選択してください。');
+      return;
+    }
+    const ok = await onSubmit({
+      title: title.trim(),
+      body,
+      target,
+      share,
+      share_team: share === 'team' ? shareTeam : undefined,
+    });
+    if (ok) {
+      setTitle('');
+      setBody('');
+      setTarget('content');
+      setShare('personal');
+      setShareTeam('');
+      setDone(true);
+    }
+  };
+
+  return (
+    <div className='flex max-w-3xl flex-col gap-5'>
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='create-title' size='sm'>
+          タイトル
+        </Label>
+        <Input
+          id='create-title'
+          blockSize='md'
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+      </div>
+
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='create-body' size='sm'>
+          本文
+        </Label>
+        <SupportText>{'{{メモ}} のように {{ }} で変数を埋め込めます。'}</SupportText>
+        <Textarea
+          id='create-body'
+          rows={8}
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+        />
+        {variables.length > 0 && (
+          <SupportText>変数: {variables.map((v) => `{{${v}}}`).join(', ')}</SupportText>
+        )}
+      </div>
+
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='create-target' size='sm'>
+          挿入先
+        </Label>
+        <Select
+          id='create-target'
+          blockSize='md'
+          value={target}
+          onChange={(e) => setTarget(e.target.value as PromptTarget)}
+        >
+          <option value='content'>入力欄（チャット本文）</option>
+          <option value='system'>システムプロンプト</option>
+        </Select>
+      </div>
+
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='create-share' size='sm'>
+          共有範囲
+        </Label>
+        <Select
+          id='create-share'
+          blockSize='md'
+          value={share}
+          onChange={(e) => setShare(e.target.value as PromptShare)}
+        >
+          <option value='personal'>個人（自分のみ）</option>
+          <option value='team'>チームで共有</option>
+          <option value='public'>全体公開</option>
+          {canCreateStandard && <option value='standard'>標準（管理者のみ）</option>}
+        </Select>
+      </div>
+
+      {share === 'team' && (
+        <div className='flex flex-col gap-1.5'>
+          <Label htmlFor='create-share-team' size='sm'>
+            共有先チーム
+          </Label>
+          {teams.length === 0 ? (
+            <SupportText>所属しているチームがありません。</SupportText>
+          ) : (
+            <Select
+              id='create-share-team'
+              blockSize='md'
+              value={shareTeam}
+              onChange={(e) => setShareTeam(e.target.value)}
+            >
+              <option value=''>選択してください</option>
+              {teams.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </Select>
+          )}
+        </div>
+      )}
+
+      {(localError || error) && <ErrorText>＊{localError ?? error}</ErrorText>}
+      {done && (
+        <p className='text-dns-16N-130 text-green-900' role='status'>
+          テンプレートを作成しました。「使う」「管理」から確認できます。
+        </p>
+      )}
+
+      <div>
+        <Button
+          type='button'
+          variant='solid-fill'
+          size='md'
+          onClick={handleSubmit}
+          aria-disabled={submitting || undefined}
+        >
+          {submitting ? '作成中...' : 'テンプレートを作成'}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/genai-web/packages/web/src/open-genai/prompt-templates/PromptManageSection.tsx
+++ b/genai-web/packages/web/src/open-genai/prompt-templates/PromptManageSection.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import {
+  CustomDialog,
+  CustomDialogBody,
+  CustomDialogHeader,
+  CustomDialogPanel,
+} from '@/components/ui/CustomDialog';
+import { Button } from '@/components/ui/dads/Button';
+import { ErrorText } from '@/components/ui/dads/ErrorText';
+import { SupportText } from '@/components/ui/dads/SupportText';
+import { TemplateKindChip } from './TemplateKindChip';
+import type { PromptTemplate } from './types';
+
+type Props = {
+  templates: PromptTemplate[];
+  submitting: boolean;
+  error: string | null;
+  onDelete: (id: string) => Promise<boolean>;
+};
+
+/** 「管理」: 自分が削除できるテンプレートを一覧し、確認のうえ削除する。 */
+export const PromptManageSection = ({ templates, submitting, error, onDelete }: Props) => {
+  const [target, setTarget] = useState<PromptTemplate | null>(null);
+
+  const handleConfirm = async () => {
+    if (!target) {
+      return;
+    }
+    const ok = await onDelete(target.id);
+    if (ok) {
+      setTarget(null);
+    }
+  };
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <SupportText>
+        削除できるのは、自分が作成したテンプレート（管理者は標準・全チーム分）です。削除は元に戻せません。
+      </SupportText>
+      {error && <ErrorText>＊{error}</ErrorText>}
+      {templates.length === 0 ? (
+        <SupportText>テンプレートがありません。</SupportText>
+      ) : (
+        <ul className='flex flex-col divide-y divide-solid-gray-300 rounded-8 border border-solid-gray-300'>
+          {templates.map((t) => (
+            <li key={t.id} className='flex items-center justify-between gap-4 px-4 py-3'>
+              <span className='flex min-w-0 items-center gap-2'>
+                <TemplateKindChip kind={t.kind} />
+                <span className='truncate text-std-16N-170 text-solid-gray-900'>{t.title}</span>
+              </span>
+              {t.canDelete ? (
+                <Button
+                  type='button'
+                  variant='outline'
+                  size='sm'
+                  onClick={() => setTarget(t)}
+                  className='flex-none text-error-1'
+                >
+                  削除
+                </Button>
+              ) : (
+                <span className='flex-none text-dns-14N-130 text-solid-gray-500'>削除不可</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <CustomDialog isOpen={target !== null} onClose={() => setTarget(null)}>
+        <CustomDialogPanel>
+          <CustomDialogHeader hasClose onClose={() => setTarget(null)}>
+            テンプレートを削除
+          </CustomDialogHeader>
+          <CustomDialogBody>
+            <p className='text-std-16N-170 text-solid-gray-800'>
+              「{target?.title}」を削除します。元に戻せません。よろしいですか？
+            </p>
+            <div className='mt-6 flex justify-end gap-3'>
+              <Button type='button' variant='outline' size='md' onClick={() => setTarget(null)}>
+                キャンセル
+              </Button>
+              <Button
+                type='button'
+                variant='solid-fill'
+                size='md'
+                onClick={handleConfirm}
+                aria-disabled={submitting || undefined}
+              >
+                {submitting ? '削除中...' : '削除する'}
+              </Button>
+            </div>
+          </CustomDialogBody>
+        </CustomDialogPanel>
+      </CustomDialog>
+    </div>
+  );
+};

--- a/genai-web/packages/web/src/open-genai/prompt-templates/PromptTemplatesPage.tsx
+++ b/genai-web/packages/web/src/open-genai/prompt-templates/PromptTemplatesPage.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react';
+import { PiBookOpenBold } from 'react-icons/pi';
+import { BreadcrumbsNav } from '@/components/ui/BreadcrumbsNav';
+import { Disclosure, DisclosureSummary } from '@/components/ui/dads/Disclosure';
+import { PageTitle } from '@/components/PageTitle';
+import { LayoutBody } from '@/layout/LayoutBody';
+import { PromptCreateSection } from './PromptCreateSection';
+import { PromptManageSection } from './PromptManageSection';
+import { PromptUseSection } from './PromptUseSection';
+import { usePromptTemplates, usePromptTemplateActions } from './usePromptTemplates';
+
+type Mode = 'use' | 'create' | 'manage';
+
+const MODES: { id: Mode; label: string }[] = [
+  { id: 'use', label: '使う' },
+  { id: 'create', label: '作成' },
+  { id: 'manage', label: '管理' },
+];
+
+/**
+ * プロンプトテンプレート専用ページ（OpenGENAI 拡張）。
+ * 源内の汎用 exApp フォームでは操作が縦並びで直感的でないため、一覧→変数→
+ * プレビュー→チャットへ、というカタログ型 UI を専用ページとして提供する。
+ */
+export const PromptTemplatesPage = () => {
+  const [mode, setMode] = useState<Mode>('use');
+  const { templates, teams, canCreateStandard, isLoading, loadError, mutate } =
+    usePromptTemplates();
+  const { create, remove, submitting, error, setError } = usePromptTemplateActions(mutate);
+
+  const switchMode = (next: Mode) => {
+    setError(null);
+    setMode(next);
+  };
+
+  return (
+    <LayoutBody>
+      <PageTitle title='プロンプトテンプレート' />
+      <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-6 p-6 lg:p-8'>
+        <div className='flex flex-col gap-4'>
+          <BreadcrumbsNav
+            items={[
+              { label: 'ホーム', to: '/' },
+              { label: 'AIアプリ', to: '/apps' },
+              { label: 'プロンプトテンプレート' },
+            ]}
+          />
+          <h1 className='text-std-20B-160 lg:text-std-24B-150'>プロンプトテンプレート</h1>
+          <p className='text-std-16N-170 text-solid-gray-700'>
+            標準テンプレートの利用や、個人／チーム共有テンプレートの作成ができます。選ぶとそのままチャットへ流し込めます。
+          </p>
+          <Disclosure className='rounded-8 border border-solid-gray-420 bg-solid-gray-50 px-4 py-3'>
+            <DisclosureSummary>
+              <span className='flex items-center text-std-16B-150'>
+                <PiBookOpenBold className='mr-2 size-5 flex-none' />
+                使い方（クリックで開閉）
+              </span>
+            </DisclosureSummary>
+            <div className='mt-3 flex flex-col gap-1.5 text-std-16N-170 text-solid-gray-700'>
+              <p>・「使う」でテンプレートを選び、本文の {'{{変数}}'} に値を入れるとプレビューに反映されます。</p>
+              <p>・「チャットで開く」で、組み上がった文面がチャットに入ります（送信前に編集できます）。</p>
+              <p>・「作成」で個人／チーム共有／全体公開のテンプレートを追加できます（標準は管理者のみ）。</p>
+              <p>・「管理」で自分が作成したテンプレートを削除できます。</p>
+            </div>
+          </Disclosure>
+        </div>
+
+        <div role='tablist' aria-label='操作' className='flex gap-1 border-b border-solid-gray-300'>
+          {MODES.map((m) => {
+            const isActive = m.id === mode;
+            return (
+              <button
+                key={m.id}
+                type='button'
+                role='tab'
+                aria-selected={isActive}
+                onClick={() => switchMode(m.id)}
+                className={`-mb-px border-b-2 px-4 py-2 text-oln-16B-100 transition-colors focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-black ${
+                  isActive
+                    ? 'border-blue-900 text-blue-900'
+                    : 'border-transparent text-solid-gray-600 hover:text-solid-gray-900'
+                }`}
+              >
+                {m.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {isLoading ? (
+          <p className='text-std-16N-170 text-solid-gray-600'>読み込み中...</p>
+        ) : loadError ? (
+          <p className='text-dns-16N-130 text-error-1' role='alert'>
+            {loadError}
+          </p>
+        ) : (
+          <>
+            {mode === 'use' && <PromptUseSection templates={templates} />}
+            {mode === 'create' && (
+              <PromptCreateSection
+                teams={teams}
+                canCreateStandard={canCreateStandard}
+                submitting={submitting}
+                error={error}
+                onSubmit={async (input) => {
+                  const created = await create(input);
+                  return created !== null;
+                }}
+              />
+            )}
+            {mode === 'manage' && (
+              <PromptManageSection
+                templates={templates}
+                submitting={submitting}
+                error={error}
+                onDelete={remove}
+              />
+            )}
+          </>
+        )}
+      </div>
+    </LayoutBody>
+  );
+};

--- a/genai-web/packages/web/src/open-genai/prompt-templates/PromptUseSection.tsx
+++ b/genai-web/packages/web/src/open-genai/prompt-templates/PromptUseSection.tsx
@@ -1,0 +1,166 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
+import { Button } from '@/components/ui/dads/Button';
+import { Input } from '@/components/ui/dads/Input';
+import { Label } from '@/components/ui/dads/Label';
+import { SupportText } from '@/components/ui/dads/SupportText';
+import { Textarea } from '@/components/ui/dads/Textarea';
+import { TemplateKindChip } from './TemplateKindChip';
+import { missingVariables, substitute } from './templateVars';
+import type { PromptTemplate } from './types';
+
+type Props = {
+  templates: PromptTemplate[];
+};
+
+/** 「使う」: テンプレ一覧から選び、変数を入れてチャットへ流し込む。 */
+export const PromptUseSection = ({ templates }: Props) => {
+  const navigate = useNavigate();
+  const [query, setQuery] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [variables, setVariables] = useState<Record<string, string>>({});
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) {
+      return templates;
+    }
+    return templates.filter(
+      (t) => t.title.toLowerCase().includes(q) || t.body.toLowerCase().includes(q),
+    );
+  }, [templates, query]);
+
+  const selected = useMemo(
+    () => templates.find((t) => t.id === selectedId) ?? null,
+    [templates, selectedId],
+  );
+
+  const onSelect = (t: PromptTemplate) => {
+    setSelectedId(t.id);
+    setVariables({});
+  };
+
+  const preview = selected ? substitute(selected.body, variables) : '';
+  const missing = selected ? missingVariables(selected.body, variables) : [];
+
+  const openInChat = () => {
+    if (!selected) {
+      return;
+    }
+    const filled = substitute(selected.body, variables);
+    const state =
+      selected.target === 'system'
+        ? { systemContext: filled, autoSubmit: false }
+        : { content: filled, autoSubmit: false };
+    navigate('/chat', { state });
+  };
+
+  return (
+    <div className='grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,340px)_minmax(0,1fr)]'>
+      <div className='flex flex-col gap-3'>
+        <Label htmlFor='prompt-search' size='sm'>
+          テンプレートを探す
+        </Label>
+        <Input
+          id='prompt-search'
+          blockSize='md'
+          placeholder='タイトル・本文で検索'
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        {filtered.length === 0 ? (
+          <SupportText className='mt-2'>該当するテンプレートがありません。</SupportText>
+        ) : (
+          <ul className='flex max-h-[60vh] flex-col gap-2 overflow-y-auto pr-1'>
+            {filtered.map((t) => {
+              const isActive = t.id === selectedId;
+              return (
+                <li key={t.id}>
+                  <button
+                    type='button'
+                    onClick={() => onSelect(t)}
+                    aria-pressed={isActive}
+                    className={`flex w-full flex-col gap-1 rounded-8 border px-4 py-3 text-left transition-colors hover:border-blue-900 hover:bg-blue-50 focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-black ${
+                      isActive
+                        ? 'border-blue-900 bg-blue-50'
+                        : 'border-solid-gray-300 bg-white'
+                    }`}
+                  >
+                    <span className='flex items-center gap-2'>
+                      <TemplateKindChip kind={t.kind} />
+                      <span className='text-std-16B-150 text-solid-gray-900'>{t.title}</span>
+                    </span>
+                    <span className='line-clamp-2 text-dns-14N-130 text-solid-gray-600'>
+                      {t.body}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <div className='flex flex-col gap-4'>
+        {!selected ? (
+          <div className='flex min-h-[200px] items-center justify-center rounded-8 border border-dashed border-solid-gray-300 bg-solid-gray-50 p-6 text-center'>
+            <SupportText>左の一覧からテンプレートを選ぶと、ここで内容を編集できます。</SupportText>
+          </div>
+        ) : (
+          <>
+            <div className='flex items-center gap-2'>
+              <TemplateKindChip kind={selected.kind} />
+              <h2 className='text-std-20B-160 text-solid-gray-900'>{selected.title}</h2>
+            </div>
+
+            {selected.variables.length > 0 && (
+              <div className='flex flex-col gap-4'>
+                <p className='text-std-16B-170 text-solid-gray-800'>変数を入力</p>
+                {selected.variables.map((name) => (
+                  <div key={name} className='flex flex-col gap-1.5'>
+                    <Label htmlFor={`var-${name}`} size='sm'>
+                      {name}
+                    </Label>
+                    <Textarea
+                      id={`var-${name}`}
+                      rows={2}
+                      value={variables[name] ?? ''}
+                      onChange={(e) =>
+                        setVariables((prev) => ({ ...prev, [name]: e.target.value }))
+                      }
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className='flex flex-col gap-1.5'>
+              <p className='text-std-16B-170 text-solid-gray-800'>組み上がるプロンプト</p>
+              <pre className='max-h-80 overflow-auto rounded-8 border border-solid-gray-300 bg-solid-gray-50 px-4 py-3 text-dns-14N-130 leading-relaxed whitespace-pre-wrap'>
+                {preview || '（プレビューする内容がありません）'}
+              </pre>
+              {missing.length > 0 && (
+                <SupportText>
+                  未入力の変数: {missing.map((m) => `{{${m}}}`).join(', ')}
+                </SupportText>
+              )}
+            </div>
+
+            <div className='flex flex-wrap items-center gap-3'>
+              <Button type='button' variant='solid-fill' size='md' onClick={openInChat}>
+                {selected.target === 'system'
+                  ? 'システムプロンプトに設定してチャットへ'
+                  : 'チャットで開く'}
+              </Button>
+              <SupportText>
+                {selected.target === 'system'
+                  ? 'チャットのシステムプロンプトに設定されます。'
+                  : 'チャットの入力欄に本文が入ります（送信前に編集できます）。'}
+              </SupportText>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/genai-web/packages/web/src/open-genai/prompt-templates/TemplateKindChip.tsx
+++ b/genai-web/packages/web/src/open-genai/prompt-templates/TemplateKindChip.tsx
@@ -1,0 +1,21 @@
+import { ChipLabel } from '@/components/ui/dads/ChipLabel';
+
+type Props = {
+  kind: string;
+};
+
+const styleOf = (kind: string): string => {
+  switch (kind) {
+    case '標準':
+      return 'bg-blue-50 text-blue-900';
+    case '共有':
+      return 'bg-green-50 text-green-900';
+    default:
+      return 'bg-solid-gray-100 text-solid-gray-700';
+  }
+};
+
+/** テンプレートの区分（標準／共有／個人）を表す小さなラベル。 */
+export const TemplateKindChip = ({ kind }: Props) => {
+  return <ChipLabel className={`min-h-6 px-2 py-0.5 text-oln-14N-100 ${styleOf(kind)}`}>{kind}</ChipLabel>;
+};

--- a/genai-web/packages/web/src/open-genai/prompt-templates/templateVars.ts
+++ b/genai-web/packages/web/src/open-genai/prompt-templates/templateVars.ts
@@ -1,0 +1,41 @@
+// 本文中の {{キー}} を抽出・置換するクライアント側ユーティリティ。
+// prompt-app 側 catalog.substitute / template_variables と同等の挙動。
+
+const VAR_RE = /\{\{\s*([^}]+?)\s*\}\}/g;
+
+/** 本文に含まれる {{キー}} の一覧（重複なし・出現順）。 */
+export const extractVariables = (body: string): string[] => {
+  const seen: string[] = [];
+  for (const match of (body || '').matchAll(new RegExp(VAR_RE))) {
+    const key = match[1].trim();
+    if (!seen.includes(key)) {
+      seen.push(key);
+    }
+  }
+  return seen;
+};
+
+/** 本文中の {{キー}} を値で置換する。未入力のキーはそのまま残す。 */
+export const substitute = (body: string, values: Record<string, string>): string => {
+  return (body || '').replace(VAR_RE, (match, rawKey: string) => {
+    const key = rawKey.trim();
+    const value = values?.[key];
+    if (value === undefined || value === null || value === '') {
+      return match;
+    }
+    return value;
+  });
+};
+
+/** 未入力の {{キー}} 一覧（重複なし）。 */
+export const missingVariables = (body: string, values: Record<string, string>): string[] => {
+  const missing: string[] = [];
+  for (const match of (body || '').matchAll(new RegExp(VAR_RE))) {
+    const key = match[1].trim();
+    const value = values?.[key];
+    if ((value === undefined || value === null || value === '') && !missing.includes(key)) {
+      missing.push(key);
+    }
+  }
+  return missing;
+};

--- a/genai-web/packages/web/src/open-genai/prompt-templates/types.ts
+++ b/genai-web/packages/web/src/open-genai/prompt-templates/types.ts
@@ -1,0 +1,42 @@
+// プロンプトテンプレート専用ページ（源内 UI 制約回避の OpenGENAI 拡張）の型。
+// backend `/prompts/*` → prompt-app の構造化 REST に対応する。
+
+export type PromptTarget = 'content' | 'system';
+
+/** 共有範囲。個人／チーム共有／全体公開／標準（管理者のみ）。 */
+export type PromptShare = 'personal' | 'team' | 'public' | 'standard';
+
+export type PromptTemplate = {
+  id: string;
+  title: string;
+  body: string;
+  target: PromptTarget;
+  /** 区分の表示ラベル（標準／共有／個人）。 */
+  kind: string;
+  isStandard: boolean;
+  /** 本文に含まれる {{変数}} 名の一覧。 */
+  variables: string[];
+  /** 現在の利用者が削除可能か。 */
+  canDelete: boolean;
+};
+
+export type PromptTeam = {
+  id: string;
+  name: string;
+};
+
+export type PromptTemplatesResponse = {
+  templates: PromptTemplate[];
+  /** 標準テンプレートを作成できるか（システム管理者のみ）。 */
+  canCreateStandard: boolean;
+  /** 共有先に選べる所属チーム。 */
+  teams: PromptTeam[];
+};
+
+export type CreateTemplateInput = {
+  title: string;
+  body: string;
+  target: PromptTarget;
+  share: PromptShare;
+  share_team?: string;
+};

--- a/genai-web/packages/web/src/open-genai/prompt-templates/usePromptTemplates.ts
+++ b/genai-web/packages/web/src/open-genai/prompt-templates/usePromptTemplates.ts
@@ -1,0 +1,92 @@
+import { useCallback, useState } from 'react';
+import useSWR from 'swr';
+import { ApiError, teamApi, teamApiFetcher } from '@/lib/fetcher';
+import type { CreateTemplateInput, PromptTemplate, PromptTemplatesResponse } from './types';
+
+export const PROMPT_TEMPLATES_KEY = 'prompts/templates';
+
+const errorMessage = (e: unknown, fallback: string): string => {
+  if (e instanceof ApiError) {
+    const data = e.data as { error?: string } | undefined;
+    if (data?.error) {
+      return data.error;
+    }
+  }
+  return fallback;
+};
+
+const fetchTemplates = async (): Promise<PromptTemplatesResponse> => {
+  const res = await teamApiFetcher<PromptTemplatesResponse>(PROMPT_TEMPLATES_KEY);
+  return {
+    templates: res?.templates ?? [],
+    canCreateStandard: !!res?.canCreateStandard,
+    teams: res?.teams ?? [],
+  };
+};
+
+/** テンプレート一覧・共有先チーム・作成可否を取得する。 */
+export const usePromptTemplates = () => {
+  const { data, error, isLoading, mutate } = useSWR<PromptTemplatesResponse>(
+    PROMPT_TEMPLATES_KEY,
+    fetchTemplates,
+    { revalidateOnFocus: false, suspense: false },
+  );
+
+  return {
+    templates: data?.templates ?? [],
+    teams: data?.teams ?? [],
+    canCreateStandard: data?.canCreateStandard ?? false,
+    isLoading,
+    loadError: error ? 'テンプレートの取得に失敗しました。時間をおいて再度お試しください。' : null,
+    mutate,
+  };
+};
+
+/** テンプレートの作成・削除。実行後に一覧を再取得する。 */
+export const usePromptTemplateActions = (
+  mutate: () => Promise<unknown>,
+) => {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const create = useCallback(
+    async (input: CreateTemplateInput): Promise<PromptTemplate | null> => {
+      setSubmitting(true);
+      setError(null);
+      try {
+        const res = await teamApi.post<{ template: PromptTemplate }>(
+          PROMPT_TEMPLATES_KEY,
+          input,
+        );
+        await mutate();
+        return res.data?.template ?? null;
+      } catch (e) {
+        setError(errorMessage(e, 'テンプレートの作成に失敗しました。'));
+        return null;
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [mutate],
+  );
+
+  const remove = useCallback(
+    async (id: string): Promise<boolean> => {
+      setSubmitting(true);
+      setError(null);
+      try {
+        await teamApi.delete(`${PROMPT_TEMPLATES_KEY}/${encodeURIComponent(id)}`);
+        await mutate();
+        return true;
+      } catch (e) {
+        setError(errorMessage(e, 'テンプレートの削除に失敗しました。'));
+        return false;
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [mutate],
+  );
+
+  return { create, remove, submitting, error, setError };
+};

--- a/genai-web/packages/web/src/routes.tsx
+++ b/genai-web/packages/web/src/routes.tsx
@@ -20,6 +20,11 @@ import { TeamEditPage } from '@/features/teams/edit/TeamEditPage';
 import { TeamsPage } from '@/features/teams/TeamsPage';
 import { TranslatePage } from '@/features/translate/TranslatePage';
 import { WHISPER_EXAPP_PATH } from '@/layout/navItems';
+import { AuditLogsPage } from '@/open-genai/admin-audit/AuditLogsPage';
+import { ModelPolicyPage } from '@/open-genai/admin-modelpolicy/ModelPolicyPage';
+import { NgWordPage } from '@/open-genai/admin-ngword/NgWordPage';
+import { UserMgmtPage } from '@/open-genai/admin-usermgmt/UserMgmtPage';
+import { PromptTemplatesPage } from '@/open-genai/prompt-templates/PromptTemplatesPage';
 import { NotFound } from '@/NotFound';
 import { ApiRequestDataFormatPage } from '@/pages/ApiRequestDataFormat';
 import { isUseCaseEnabled } from '@/utils/isUseCaseEnabled';
@@ -58,6 +63,23 @@ export const createRoutes = (): RouteObject[] => {
   const children: RouteObject[] = [
     { index: true, element: <LandingPage /> },
     { path: 'apps', element: <ExAppsPage /> },
+    // プロンプトテンプレートは専用ページへ。旧 exApp URL（/apps/:teamId/prompt）は
+    // リダイレクトする（ピン留め・ブックマーク・履歴リンクの互換のため）。
+    { path: 'prompts', element: <PromptTemplatesPage /> },
+    { path: 'apps/:teamId/prompt', element: <Navigate to='/prompts' replace /> },
+    // 監査ログは管理者限定の専用ページへ。旧 exApp URL（/apps/:teamId/audit）は
+    // リダイレクトする（ピン留め・ブックマーク・履歴リンクの互換のため）。
+    { path: 'admin/audit', element: <AuditLogsPage /> },
+    { path: 'apps/:teamId/audit', element: <Navigate to='/admin/audit' replace /> },
+    // 利用者一括管理も管理者限定の専用ページへ。旧 exApp URL（/apps/:teamId/usermgmt）は
+    // リダイレクトする（ピン留め・ブックマーク・履歴リンクの互換のため）。
+    { path: 'admin/users', element: <UserMgmtPage /> },
+    { path: 'apps/:teamId/usermgmt', element: <Navigate to='/admin/users' replace /> },
+    // モデル利用制御・入力制限も管理者限定の専用ページへ。旧 exApp URL はリダイレクトする。
+    { path: 'admin/model-policy', element: <ModelPolicyPage /> },
+    { path: 'apps/:teamId/modelpolicy', element: <Navigate to='/admin/model-policy' replace /> },
+    { path: 'admin/ngword', element: <NgWordPage /> },
+    { path: 'apps/:teamId/ngword', element: <Navigate to='/admin/ngword' replace /> },
     { path: 'apps/:teamId/:exAppId', element: <ExAppPage /> },
     { path: 'chat', element: <ChatPage /> },
     { path: 'chat/:chatId', element: <ChatPage /> },

--- a/modelpolicy-app/app/main.py
+++ b/modelpolicy-app/app/main.py
@@ -234,6 +234,59 @@ async def schema(
     return {"placeholder": _build_schema(_read_policy(), models, id2name)}
 
 
+# ---------------------------------------------------------------------------
+# 専用ページ(REST) 用エンドポイント（書き込み）
+#
+# 源内の汎用 exApp フォームでは操作が直感的でないため、backend 経由の専用ページ
+# (/admin/model-policy) から叩く構造化 REST を提供する。読み取りは backend が
+# 読み取り専用で直接参照するため、ここでは書き込み(POST)のみを提供する。
+# 認証は /invoke と同じ（api-key + 内部署名 + SystemAdminGroup）。
+# ---------------------------------------------------------------------------
+def _verify_admin(request: Request) -> JSONResponse | None:
+    h = request.headers
+    err = _check_key(h.get("x-api-key"))
+    if err:
+        return err
+    if not intauth.verify(
+        h.get("x-user-id"),
+        h.get("x-user-groups"),
+        h.get("x-scope"),
+        h.get("x-user-ts"),
+        h.get("x-user-sig"),
+        h.get("x-user-tags"),
+    ):
+        return JSONResponse(status_code=401, content={"error": "invalid internal signature"})
+    if not _is_admin(h.get("x-user-groups")):
+        return JSONResponse(
+            status_code=403,
+            content={"error": "この機能はシステム管理者のみが利用できます（SystemAdminGroup 所属が必要です）"},
+        )
+    return None
+
+
+@app.post("/policy")
+async def set_policy_api(request: Request) -> Any:
+    """構造化ポリシー（{policy:{enabled,default,teams}}）を検証して保存する。
+
+    専用ページはチームIDを直接扱うため、チーム名解決は不要（teams は teamId→models）。
+    """
+    err = _verify_admin(request)
+    if err:
+        return err
+    body = await request.json()
+    raw = body.get("policy")
+    if raw is None:
+        return JSONResponse(status_code=400, content={"error": "policy が指定されていません"})
+    policy, verr = parse_and_validate(json.dumps(raw, ensure_ascii=False))
+    if verr:
+        return JSONResponse(status_code=400, content={"error": verr})
+    try:
+        _write_policy(policy)
+    except Exception as e:  # noqa: BLE001
+        return JSONResponse(status_code=500, content={"error": f"ポリシーの保存に失敗しました: {e}"})
+    return {"policy": policy}
+
+
 @app.post("/invoke")
 async def invoke(
     request: Request,

--- a/ngword-app/app/main.py
+++ b/ngword-app/app/main.py
@@ -220,6 +220,56 @@ async def schema(
     return {"placeholder": _build_schema(_read_rules())}
 
 
+# ---------------------------------------------------------------------------
+# 専用ページ(REST) 用エンドポイント（書き込み）
+#
+# 源内の汎用 exApp フォームでは操作が直感的でないため、backend 経由の専用ページ
+# (/admin/ngword) から叩く構造化 REST を提供する。読み取りは backend が読み取り専用で
+# 直接参照するため、ここでは書き込み(POST)のみを提供する。
+# 認証は /invoke と同じ（api-key + 内部署名 + SystemAdminGroup）。
+# ---------------------------------------------------------------------------
+def _verify_admin(request: Request) -> JSONResponse | None:
+    h = request.headers
+    err = _check_key(h.get("x-api-key"))
+    if err:
+        return err
+    if not intauth.verify(
+        h.get("x-user-id"),
+        h.get("x-user-groups"),
+        h.get("x-scope"),
+        h.get("x-user-ts"),
+        h.get("x-user-sig"),
+        h.get("x-user-tags"),
+    ):
+        return JSONResponse(status_code=401, content={"error": "invalid internal signature"})
+    if not _is_admin(h.get("x-user-groups")):
+        return JSONResponse(
+            status_code=403,
+            content={"error": "この機能はシステム管理者のみが利用できます（SystemAdminGroup 所属が必要です）"},
+        )
+    return None
+
+
+@app.post("/rules")
+async def set_rules_api(request: Request) -> Any:
+    """構造化ルール（{rules:{enabled,case_sensitive,check_mynumber,words,patterns}}）を検証して保存する。"""
+    err = _verify_admin(request)
+    if err:
+        return err
+    body = await request.json()
+    raw = body.get("rules")
+    if raw is None:
+        return JSONResponse(status_code=400, content={"error": "rules が指定されていません"})
+    rules, verr = parse_and_validate(json.dumps(raw, ensure_ascii=False))
+    if verr:
+        return JSONResponse(status_code=400, content={"error": verr})
+    try:
+        _write_rules(rules)
+    except Exception as e:  # noqa: BLE001
+        return JSONResponse(status_code=500, content={"error": f"ルールの保存に失敗しました: {e}"})
+    return {"rules": rules}
+
+
 @app.post("/invoke")
 async def invoke(
     request: Request,

--- a/prompt-app/app/main.py
+++ b/prompt-app/app/main.py
@@ -134,6 +134,43 @@ def _template_items(items: list[dict[str, Any]]) -> list[dict[str, str]]:
     return [{"title": f"{t['title']}（{_kind(t)}）", "value": t["id"]} for t in items]
 
 
+def _template_public(t: dict[str, Any], user_id: str, is_admin: bool) -> dict[str, Any]:
+    """専用ページ(REST)向けのテンプレート表現。UI 表示に必要な情報を含める。"""
+    return {
+        "id": t["id"],
+        "title": t["title"],
+        "body": t["body"],
+        "target": t.get("target", "content"),
+        "kind": _kind(t),
+        "isStandard": bool(t["isStandard"]),
+        "variables": catalog.template_variables(t["body"]),
+        "canDelete": catalog.can_delete(t, user_id, is_admin),
+    }
+
+
+def _verify_ctx(request: Request) -> tuple[JSONResponse | None, dict[str, Any]]:
+    """API キー・内部署名を検証し、利用者コンテキストを返す（専用ページ REST 用）。"""
+    h = request.headers
+    err = _check_key(h.get("x-api-key"))
+    if err:
+        return err, {}
+    if not intauth.verify(
+        h.get("x-user-id"),
+        h.get("x-user-groups"),
+        h.get("x-scope"),
+        h.get("x-user-ts"),
+        h.get("x-user-sig"),
+        h.get("x-user-tags"),
+    ):
+        return JSONResponse(status_code=401, content={"error": "invalid internal signature"}), {}
+    return None, {
+        "user_id": (h.get("x-user-id") or "").strip(),
+        "team_ids": _team_ids(h.get("x-user-tags")),
+        "team_names": _team_name_map(h.get("x-user-teams")),
+        "is_admin": _is_admin(h.get("x-user-groups")),
+    }
+
+
 def _build_form_schema(
     user_id: str,
     team_ids: list[str],
@@ -347,6 +384,132 @@ async def resolve(
         selected_body=selected_body,
     )
     return {"placeholder": ui}
+
+
+# ---------------------------------------------------------------------------
+# 構造化 REST（源内 専用ページ /prompts 用）
+#
+# 汎用 exApp フォームでは縦並び select しか使えず操作が直感的でないため、源内側に
+# 専用ページを設ける。テンプレートの一覧・作成・削除・変数置換を JSON で提供する。
+# 認可・内部署名は /schema・/invoke と同一。従来の /schema・/resolve・/invoke は
+# 後方互換のため維持する。
+# ---------------------------------------------------------------------------
+@app.get("/templates")
+async def list_templates_api(request: Request) -> Any:
+    err, ctx = _verify_ctx(request)
+    if err:
+        return err
+    items = catalog.list_visible(ctx["user_id"], ctx["team_ids"], ctx["is_admin"])
+    return {
+        "templates": [_template_public(t, ctx["user_id"], ctx["is_admin"]) for t in items],
+        "canCreateStandard": ctx["is_admin"],
+        "teams": [
+            {"id": tid, "name": ctx["team_names"].get(tid, tid)} for tid in ctx["team_ids"]
+        ],
+    }
+
+
+@app.post("/templates")
+async def create_template_api(request: Request) -> Any:
+    err, ctx = _verify_ctx(request)
+    if err:
+        return err
+    body = await request.json()
+    title = (body.get("title") or "").strip()
+    tbody = (body.get("body") or "").strip()
+    if not title or not tbody:
+        return JSONResponse(
+            status_code=400, content={"error": "タイトルと本文を入力してください。"}
+        )
+    share = (body.get("share") or "personal").strip().lower()
+    target = (body.get("target") or "content").strip().lower()
+    is_standard = False
+    shared_teams: list[str] = []
+    if share == "standard":
+        if not ctx["is_admin"]:
+            return JSONResponse(
+                status_code=403,
+                content={"error": "標準テンプレートの作成はシステム管理者のみ可能です。"},
+            )
+        is_standard = True
+    elif share == "public":
+        shared_teams = ["public"]
+    elif share == "team":
+        team = (body.get("share_team") or "").strip()
+        if not team:
+            return JSONResponse(
+                status_code=400, content={"error": "共有先チームを指定してください。"}
+            )
+        # 自分が所属していないチームへは共有できない（管理者は例外）
+        if not ctx["is_admin"] and team not in set(ctx["team_ids"]):
+            label = ctx["team_names"].get(team, team)
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "error": (
+                        f"チーム「{label}」に所属していないため共有できません"
+                        "（所属チーム、または個人／全体公開を選択してください）。"
+                    )
+                },
+            )
+        shared_teams = [team]
+    tid = catalog.create_template(
+        title=title,
+        body=tbody,
+        owner_user=ctx["user_id"],
+        target=target,
+        shared_groups=shared_teams,
+        is_standard=is_standard,
+    )
+    t = catalog.get_template(tid)
+    return {"template": _template_public(t, ctx["user_id"], ctx["is_admin"])}
+
+
+@app.delete("/templates/{template_id}")
+async def delete_template_api(template_id: str, request: Request) -> Any:
+    err, ctx = _verify_ctx(request)
+    if err:
+        return err
+    t = catalog.get_template(template_id)
+    if not t:
+        return JSONResponse(
+            status_code=404, content={"error": "指定 ID のテンプレートが見つかりません。"}
+        )
+    if not catalog.can_delete(t, ctx["user_id"], ctx["is_admin"]):
+        return JSONResponse(
+            status_code=403, content={"error": "このテンプレートを削除する権限がありません。"}
+        )
+    catalog.delete_template(template_id)
+    return {"status": "ok"}
+
+
+@app.post("/templates/{template_id}/render")
+async def render_template_api(template_id: str, request: Request) -> Any:
+    err, ctx = _verify_ctx(request)
+    if err:
+        return err
+    t = catalog.get_template(template_id)
+    if not t:
+        return JSONResponse(
+            status_code=404, content={"error": "指定 ID のテンプレートが見つかりません。"}
+        )
+    visible_ids = {
+        x["id"] for x in catalog.list_visible(ctx["user_id"], ctx["team_ids"], ctx["is_admin"])
+    }
+    if template_id not in visible_ids:
+        return JSONResponse(
+            status_code=403, content={"error": "このテンプレートを利用する権限がありません。"}
+        )
+    body = await request.json()
+    raw_vars = body.get("variables") or {}
+    variables: dict[str, str] = {}
+    for k, v in raw_vars.items():
+        if isinstance(v, bool):
+            variables[str(k)] = "true" if v else "false"
+        elif isinstance(v, (str, int, float)):
+            variables[str(k)] = str(v)
+    filled, missing = catalog.substitute(t["body"], variables)
+    return {"filled": filled, "missing": missing, "target": t.get("target", "content")}
 
 
 def _render_list(items: list[dict[str, Any]]) -> str:

--- a/usermgmt-app/app/main.py
+++ b/usermgmt-app/app/main.py
@@ -132,64 +132,79 @@ async def _user_groups(
     return names
 
 
-async def _list_users(inputs: dict[str, Any]) -> str:
-    """Keycloak の利用者一覧を Markdown 表で返す（読み取り専用）。"""
-    search = (inputs.get("search") or "").strip()
+def _coerce_limit(value: Any, default: int = 200) -> int:
     try:
-        limit = int(inputs.get("limit") or 200)
+        limit = int(value or default)
     except (TypeError, ValueError):
-        limit = 200
-    limit = max(1, min(limit, 1000))
+        limit = default
+    return max(1, min(limit, 1000))
 
+
+async def _collect_users(search: str, limit: int) -> tuple[list[dict[str, Any]], bool]:
+    """Keycloak から利用者を集めて構造化リストで返す。
+
+    戻り値: (利用者リスト, 上限に達したか)。各要素は
+    {id, username, email, name, groups[], enabled} を持つ。専用ページ(REST)と
+    従来の Markdown 一覧(/invoke) の共通ソースとして使う。
+    """
+    limit = _coerce_limit(limit)
     page_size = 100
+    raw: list[dict[str, Any]] = []
     users: list[dict[str, Any]] = []
-    try:
-        async with httpx.AsyncClient(timeout=60) as client:
-            token = await _admin_token(client)
-            first = 0
-            while len(users) < limit:
-                params: dict[str, Any] = {
-                    "first": first,
-                    "max": min(page_size, limit - len(users)),
-                }
-                if search:
-                    params["search"] = search
-                res = await client.get(
-                    f"{KEYCLOAK_URL}/admin/realms/{KEYCLOAK_REALM}/users",
-                    params=params,
-                    headers=_auth_headers(token),
-                )
-                res.raise_for_status()
-                batch = res.json() or []
-                if not batch:
-                    break
-                users.extend(batch)
-                if len(batch) < params["max"]:
-                    break
-                first += len(batch)
+    async with httpx.AsyncClient(timeout=60) as client:
+        token = await _admin_token(client)
+        first = 0
+        while len(raw) < limit:
+            params: dict[str, Any] = {
+                "first": first,
+                "max": min(page_size, limit - len(raw)),
+            }
+            if search:
+                params["search"] = search
+            res = await client.get(
+                f"{KEYCLOAK_URL}/admin/realms/{KEYCLOAK_REALM}/users",
+                params=params,
+                headers=_auth_headers(token),
+            )
+            res.raise_for_status()
+            batch = res.json() or []
+            if not batch:
+                break
+            raw.extend(batch)
+            if len(batch) < params["max"]:
+                break
+            first += len(batch)
 
-            rows: list[tuple[str, ...]] = []
-            for u in users:
-                uid = u.get("id") or ""
-                groups = await _user_groups(client, token, uid) if uid else []
-                name = " ".join(
-                    x
-                    for x in [
-                        (u.get("lastName") or "").strip(),
-                        (u.get("firstName") or "").strip(),
-                    ]
-                    if x
-                )
-                rows.append(
-                    (
-                        _md_cell(u.get("username")),
-                        _md_cell(u.get("email")),
-                        _md_cell(name),
-                        _md_cell(",".join(groups) if groups else "-"),
-                        "有効" if u.get("enabled", True) else "無効",
-                        _md_cell(uid[:8] + "…" if len(uid) > 8 else uid),
-                    )
-                )
+        for u in raw:
+            uid = u.get("id") or ""
+            groups = await _user_groups(client, token, uid) if uid else []
+            name = " ".join(
+                x
+                for x in [
+                    (u.get("lastName") or "").strip(),
+                    (u.get("firstName") or "").strip(),
+                ]
+                if x
+            )
+            users.append(
+                {
+                    "id": uid,
+                    "username": u.get("username") or "",
+                    "email": u.get("email") or "",
+                    "name": name,
+                    "groups": groups,
+                    "enabled": bool(u.get("enabled", True)),
+                }
+            )
+    return users, len(users) >= limit
+
+
+async def _list_users(inputs: dict[str, Any]) -> str:
+    """Keycloak の利用者一覧を Markdown 表で返す（読み取り専用・/invoke 後方互換）。"""
+    search = (inputs.get("search") or "").strip()
+    limit = _coerce_limit(inputs.get("limit"))
+    try:
+        users, limit_reached = await _collect_users(search, limit)
     except Exception as e:  # noqa: BLE001
         return f"[Keycloak への接続/認証に失敗しました] {e}"
 
@@ -199,16 +214,30 @@ async def _list_users(inputs: dict[str, Any]) -> str:
     lines = [
         title,
         "",
-        f"件数: **{len(rows)}**" + ("（上限に達しています）" if len(rows) >= limit else ""),
+        f"件数: **{len(users)}**" + ("（上限に達しています）" if limit_reached else ""),
         "",
         "| # | username | email | 氏名 | groups | 状態 | id |",
         "| --- | --- | --- | --- | --- | --- | --- |",
     ]
-    if not rows:
+    if not users:
         lines.append("| - | （該当なし） |  |  |  |  |  |")
     else:
-        for i, cols in enumerate(rows, 1):
-            lines.append(f"| {i} | " + " | ".join(cols) + " |")
+        for i, u in enumerate(users, 1):
+            uid = u["id"]
+            lines.append(
+                f"| {i} | "
+                + " | ".join(
+                    [
+                        _md_cell(u["username"]),
+                        _md_cell(u["email"]),
+                        _md_cell(u["name"]),
+                        _md_cell(",".join(u["groups"]) if u["groups"] else "-"),
+                        "有効" if u["enabled"] else "無効",
+                        _md_cell(uid[:8] + "…" if len(uid) > 8 else uid),
+                    ]
+                )
+                + " |"
+            )
     lines.append("")
     lines.append("> 読み取り専用です。作成・更新・削除は CSV のドライラン／適用を使ってください。")
     return "\n".join(lines)
@@ -286,26 +315,43 @@ async def _process(inputs: dict[str, Any]) -> str:
 
     # apply: Keycloak へ反映
     try:
-        async with httpx.AsyncClient(timeout=60) as client:
-            token = await _admin_token(client)
-            for i, p in enumerate(plans, 1):
-                username = p["username"]
-                action = p["action"]
-                if p["error"]:
-                    lines.append(f"| {i} | {username} | {action} | スキップ | {p['error']} |")
-                    continue
-                try:
-                    existing = await _find_user(client, token, username)
-                    result, note = await _apply_one(client, token, p, existing)
-                except httpx.HTTPStatusError as e:
-                    result, note = "エラー", f"HTTP {e.response.status_code}"
-                except Exception as e:  # noqa: BLE001
-                    result, note = "エラー", str(e)
-                lines.append(f"| {i} | {username} | {action} | {result} | {note} |")
+        results = await _apply_plans(plans)
     except Exception as e:  # noqa: BLE001
         return f"[Keycloak への接続/認証に失敗しました] {e}"
-
+    for i, r in enumerate(results, 1):
+        lines.append(
+            f"| {i} | {r['username']} | {r['action']} | {r['result']} | {r['note']} |"
+        )
     return "\n".join(lines)
+
+
+async def _apply_plans(plans: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """計画を Keycloak へ反映し、行ごとの結果を構造化して返す。
+
+    Markdown レポート(/invoke) と REST(/users/apply) の共通ソース。
+    """
+    results: list[dict[str, str]] = []
+    async with httpx.AsyncClient(timeout=120) as client:
+        token = await _admin_token(client)
+        for p in plans:
+            username = p["username"]
+            action = p["action"]
+            if p["error"]:
+                results.append(
+                    {"username": username, "action": action, "result": "スキップ", "note": p["error"]}
+                )
+                continue
+            try:
+                existing = await _find_user(client, token, username)
+                result, note = await _apply_one(client, token, p, existing)
+            except httpx.HTTPStatusError as e:
+                result, note = "エラー", f"HTTP {e.response.status_code}"
+            except Exception as e:  # noqa: BLE001
+                result, note = "エラー", str(e)
+            results.append(
+                {"username": username, "action": action, "result": result, "note": note}
+            )
+    return results
 
 
 async def _apply_one(
@@ -355,6 +401,114 @@ async def _apply_one(
     created = await _find_user(client, token, plan["username"])
     notes = await _apply_groups(client, token, created["id"], groups) if created else ["作成後IDの取得に失敗"]
     return "作成", "; ".join(notes)
+
+
+# ---------------------------------------------------------------------------
+# 専用ページ(REST) 用エンドポイント
+#
+# 源内の汎用 exApp フォーム（Markdown 出力）では一覧・ドライラン・適用の往復が
+# 直感的でないため、backend 経由の専用ページ(/admin/users)から叩く構造化 REST を提供する。
+# 認証は /invoke と同じ（api-key + 内部署名 + SystemAdminGroup）。
+# ---------------------------------------------------------------------------
+def _verify_admin(request: Request) -> JSONResponse | None:
+    h = request.headers
+    err = _check_key(h.get("x-api-key"))
+    if err:
+        return err
+    if not intauth.verify(
+        h.get("x-user-id"),
+        h.get("x-user-groups"),
+        h.get("x-scope"),
+        h.get("x-user-ts"),
+        h.get("x-user-sig"),
+        h.get("x-user-tags"),
+    ):
+        return JSONResponse(status_code=401, content={"error": "invalid internal signature"})
+    if not _is_admin(h.get("x-user-groups")):
+        return JSONResponse(
+            status_code=403,
+            content={"error": "この機能はシステム管理者のみが利用できます（SystemAdminGroup 所属が必要です）"},
+        )
+    return None
+
+
+def _plans_from_body(body: dict[str, Any]) -> tuple[JSONResponse | None, list[dict[str, Any]]]:
+    csv_text = (body.get("csv_text") or "").strip()
+    if not csv_text:
+        return (
+            JSONResponse(status_code=400, content={"error": "CSV が指定されていません（csv_text が空です）"}),
+            [],
+        )
+    rows = parse_csv(csv_text)
+    if not rows:
+        return (
+            JSONResponse(
+                status_code=400,
+                content={"error": "CSV から有効な行を読み取れませんでした。見出し行（username 等）を確認してください。"},
+            ),
+            [],
+        )
+    return None, plan_rows(rows)
+
+
+def _plan_public(plans: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "username": p["username"],
+            "action": p["action"],
+            "groups": p["groups"],
+            "error": p["error"],
+        }
+        for p in plans
+    ]
+
+
+@app.get("/users")
+async def list_users_api(request: Request) -> Any:
+    err = _verify_admin(request)
+    if err:
+        return err
+    qp = request.query_params
+    search = (qp.get("search") or "").strip()
+    limit = _coerce_limit(qp.get("limit"))
+    try:
+        users, limit_reached = await _collect_users(search, limit)
+    except Exception as e:  # noqa: BLE001
+        return JSONResponse(
+            status_code=502, content={"error": f"Keycloak への接続/認証に失敗しました: {e}"}
+        )
+    return {"users": users, "count": len(users), "limitReached": limit_reached}
+
+
+@app.post("/users/plan")
+async def plan_users_api(request: Request) -> Any:
+    err = _verify_admin(request)
+    if err:
+        return err
+    body = await request.json()
+    perr, plans = _plans_from_body(body)
+    if perr:
+        return perr
+    rows = _plan_public(plans)
+    return {"rows": rows, "count": len(rows)}
+
+
+@app.post("/users/apply")
+async def apply_users_api(request: Request) -> Any:
+    err = _verify_admin(request)
+    if err:
+        return err
+    body = await request.json()
+    perr, plans = _plans_from_body(body)
+    if perr:
+        return perr
+    try:
+        results = await _apply_plans(plans)
+    except Exception as e:  # noqa: BLE001
+        return JSONResponse(
+            status_code=502, content={"error": f"Keycloak への接続/認証に失敗しました: {e}"}
+        )
+    return {"results": results, "count": len(results)}
 
 
 @app.post("/invoke")


### PR DESCRIPTION
## 概要

汎用 exApp フォーム（Form Spec v1）のレイアウト制約により UI が直感的に操作しづらかった画面群を、専用 React ページ + 構造化 REST API へ置き換えました。旧 `/apps/:teamId/*` URL は新 URL へリダイレクトします。

- **プロンプトテンプレート** (`/prompts`): 一覧の検索・区分バッジ・変数入力＋ライブプレビュー・「チャットで開く」を 1 画面に集約
- **監査ログ** (`/admin/audit`): フィルタ・ページング・CSV エクスポート。時刻は **JST** で表示/絞り込み
- **利用者一括管理** (`/admin/users`): 一覧表示・CSV ドライラン/適用
- **モデル利用制御** (`/admin/model-policy`): チーム別に許可モデルを編集
- **入力制限/禁止語** (`/admin/ngword`): 禁止語ルールを編集

## バックエンド

- `backend`: 各 exApp への認証付きプロキシと read-only 参照を追加（`SystemAdminGroup` ガード）
- `prompt-app`: 構造化 REST（`/templates` 系）を追加
- `usermgmt-app`: `/users`・`/users/plan`・`/users/apply` を追加
- `modelpolicy-app` / `ngword-app`: 単一ライター方針を維持しつつ書込用 REST（`POST /policy`・`POST /rules`）を追加

## UI

- 全専用ページの最大幅を `--page-width`（1440px）へ統一し、既存ネイティブ画面と揃えた

## 補足

- 認可ゲート（backend の `_is_system_admin` / フロントの `isSystemAdminGroup`）を全管理ページで適用
- ドキュメント（`README.md` / `OPENGENAI_PATCHES.md` / `CHANGELOG.md`）を更新
- インフラ/運用系の未コミット変更（`docker-compose.prod.yml`・`keycloak`・`nginx.conf`・`*.sh`）は本 PR の対象外

## テスト計画

- [ ] `/prompts` で検索・変数入力・ライブプレビュー・「チャットで開く」を確認
- [ ] `/admin/audit` でフィルタ・ページング・CSV エクスポート、JST 表示を確認
- [ ] `/admin/users` で一覧・CSV ドライラン/適用を確認
- [ ] `/admin/model-policy` でチーム別モデル編集の保存を確認
- [ ] `/admin/ngword` で禁止語ルールの保存を確認
- [ ] 非管理ユーザで管理ページがブロックされることを確認
- [ ] 旧 `/apps/:teamId/*` URL が新 URL へリダイレクトされることを確認

Made with [Cursor](https://cursor.com)