### PR TITLE
ナレッジMCPの無認証・公開範囲を明文化し公開バインドを可変化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,16 @@ RAG_MODEL=gpt-oss:20b
 # AI アプリ呼び出し用 API キー（ローカル任意値）
 RAG_API_KEY=local-rag-key
 
+# --- ナレッジ検索 MCP（Dify Agent 連携用） ---
+# 【重要・セキュリティ】knowledge-mcp は無認証で、scope(teamId) を呼び出し側が
+# 任意指定できる。:8002/mcp へ到達できれば全チームのナレッジを読み出せるため、
+# 外部到達可能なホストでは公開範囲を必ず絞ること（下記 BIND / FW / リバプロ）。
+# ホスト公開ポート（Dify から host.docker.internal:<port>/mcp で利用）。
+KNOWLEDGE_MCP_PORT=8002
+# 公開バインドアドレス。既定は全 IF(0.0.0.0)。localhost からのみ使うなら 127.0.0.1、
+# 特定 Dify ホストのみ許すなら Docker ブリッジの gateway IP を指定。
+KNOWLEDGE_MCP_BIND=0.0.0.0
+
 # --- 内部サービス間署名（x-user-* 偽装対策）---
 # backend と全 exApp で同一値。空にすると検証を無効化（開発時のみ）。本番は必ず十分長い乱数に。
 INTERNAL_SIGNING_SECRET=dev-internal-secret-change-me

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@
 
 ---
 
+## [Unreleased]
+
+### セキュリティ / ドキュメント
+
+- ナレッジ検索 MCP（`knowledge-mcp` `:8002/mcp`）が**無認証**で `scope`(teamId) を任意指定でき、到達できれば全チームのナレッジを読める点を明文化。dev `docker-compose.yml` に公開バインドを制御する `KNOWLEDGE_MCP_BIND`（既定 `0.0.0.0` で従来挙動）を追加し、`.env.example`・README・[docs/knowledge-mcp.md](docs/knowledge-mcp.md) に公開範囲の絞り方（loopback/gateway バインド・FW・認証付きリバプロ）を追記。挙動の既定値は不変で、既存環境への影響はない
+
+---
+
 ## [0.5.0] - 2026-07-30
 
 別環境での実運用で見つかった修正・改善をまとめて反映。**本番デプロイの整備**、

--- a/README.md
+++ b/README.md
@@ -757,6 +757,13 @@ ARTIFACT_FETCH_ALLOWED_HOSTS=files.dify.ai,upload.dify.ai,host.docker.internal
 SSRF_PROXY_ALLOW_PRIVATE_DOMAINS=host.docker.internal
 ```
 
+> **⚠️ セキュリティ（ナレッジ MCP の公開範囲）:** `knowledge-mcp`（`:8002/mcp`）は
+> **無認証**で、`scope`(teamId) を呼び出し側が任意指定できるため、到達できる者は
+> 全チームのナレッジを読めます。外部到達可能なホストでは `.env` の
+> `KNOWLEDGE_MCP_BIND`（既定 `0.0.0.0`）を `127.0.0.1`／gateway IP に絞る、
+> ファイアウォールで遮断する、認証付きリバースプロキシ越しにのみ公開する、の
+> いずれかで必ず保護してください（詳細: [docs/knowledge-mcp.md](docs/knowledge-mcp.md) の「セキュリティ / 公開範囲」）。
+
 源内登録の例（workflow / chat）:
 
 ```json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,7 +195,12 @@ services:
       - MCP_HOST=0.0.0.0
       - MCP_PORT=8002
     ports:
-      - "${KNOWLEDGE_MCP_PORT:-8002}:8002"
+      # 注意: knowledge-mcp は無認証で、scope(teamId) は呼び出し側が任意指定できる。
+      # つまり :8002/mcp へ到達できれば全チームのナレッジを読み出せる。
+      # ホスト公開は Dify から host.docker.internal:8002 で利用するためのもの。
+      # 外部到達可能なホストでは KNOWLEDGE_MCP_BIND=127.0.0.1 等で絞るか、
+      # ファイアウォール／認証付きリバースプロキシで必ず保護すること。
+      - "${KNOWLEDGE_MCP_BIND:-0.0.0.0}:${KNOWLEDGE_MCP_PORT:-8002}:8002"
     depends_on:
       - rag-app
     restart: unless-stopped

--- a/docs/knowledge-mcp.md
+++ b/docs/knowledge-mcp.md
@@ -20,7 +20,28 @@ docker compose up -d --build knowledge-mcp rag-app
 | --- | --- |
 | URL | `http://host.docker.internal:8002/mcp`（`KNOWLEDGE_MCP_PORT` で変更可） |
 | 転送 | Streamable HTTP（Dify 1.6+） |
-| 認証 | MCP 自体はキーなし。下流 `rag-app` へ渡す API キーは MCP コンテナ環境変数 |
+| 認証 | **MCP 自体は無認証**（下記「セキュリティ / 公開範囲」を必読）。下流 `rag-app` へ渡す API キーは MCP コンテナ環境変数 |
+
+## セキュリティ / 公開範囲
+
+> **重要:** knowledge-mcp は自前の認証を持ちません。さらに `scope`（teamId）は
+> 呼び出し側が任意に指定できるため、`:8002/mcp` へ到達できる者は **全チームの
+> ナレッジを読み出せます**（既定スコープに限りません）。これは paris 等の特定環境
+> に固有の問題ではなく、本サービス共通の性質です。
+
+ホストポート公開は Dify から `host.docker.internal:8002/mcp` で利用するためのもので、
+compose 内の他サービスは内部 DNS（`http://knowledge-mcp:8002`）で到達するため公開は不要です。
+**インターネット到達可能なホストでは、以下のいずれかで必ず公開範囲を絞ってください。**
+
+| 対策 | 方法 |
+| --- | --- |
+| バインド制限 | `.env` の `KNOWLEDGE_MCP_BIND` を `127.0.0.1`（同一ホストのみ）や Docker ブリッジの gateway IP（特定 Dify ホストのみ）に設定 |
+| ファイアウォール | 当該ポート（既定 8002）への外部アクセスを FW で遮断（現運用の既定手段） |
+| リバースプロキシ | 認証付きの前段（nginx 等）越しにのみ公開 |
+| そもそも公開しない | Dify+MCP を使わない構成では、compose のホストポート公開自体を削除 |
+
+> prod compose（`docker-compose.prod.yml`）は既定で knowledge-mcp のホストポートを
+> 公開しません（内部通信のみ）。公開する場合は上記の保護を前提にしてください。
 
 ## ツール
 


### PR DESCRIPTION
## 概要

`knowledge-mcp`（`:8002/mcp`）は**自前の認証を持たず**、`scope`(teamId) を呼び出し側が任意指定できます。そのため当該ポートへ到達できる者は**全チームのナレッジを読み出せます**。これは特定環境固有ではなく本サービス共通の性質のため、汎用的な明文化と公開範囲の制御点を追加します。

## 変更

- **dev `docker-compose.yml`**: 公開バインドを制御する `KNOWLEDGE_MCP_BIND` を追加（既定 `0.0.0.0` で**従来挙動を維持**）。あわせてリスクと対策を示すコメントを付与
- **`.env.example`**: `KNOWLEDGE_MCP_PORT` / `KNOWLEDGE_MCP_BIND` とセキュリティ注意を追記
- **`README.md`**: ナレッジ MCP 連携節に公開範囲の警告を追記
- **`docs/knowledge-mcp.md`**: 「セキュリティ / 公開範囲」節を新設（loopback/gateway バインド・FW・認証付きリバプロ・非公開化の選択肢を整理）
- **`CHANGELOG.md`**: `[Unreleased]` に記録

## 影響

- 既定値・挙動は不変（`0.0.0.0` 公開のまま）。既存環境への影響はありません
- prod compose（`docker-compose.prod.yml`）は既定で当該ポートを公開しない構成のままです

## 背景

Bugbot レビューで検出。現運用ではファイアウォールで遮断済みですが、汎用的な注意喚起と制御点として整備しました。

## テスト計画

- [ ] `KNOWLEDGE_MCP_BIND=127.0.0.1 docker compose up -d knowledge-mcp` でループバックのみに公開されること
- [ ] 既定（未設定）では従来どおり全 IF に公開され Dify から `host.docker.internal:8002/mcp` で利用できること

Made with [Cursor](https://cursor.com)