### PR TITLE
feat(prod): S3成果物をnginx経由で配信可能にし OLLAMA_API_KEY を受け渡す

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -57,6 +57,8 @@ services:
       - OPENAI_PROVIDER_API_KEY=${OPENAI_PROVIDER_API_KEY:-}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - AZURE_OPENAI_API_KEY=${AZURE_OPENAI_API_KEY:-}
+      # Ollama Cloud 等を LLM_PROVIDERS の api_key_env=OLLAMA_API_KEY で使う場合に受け渡す
+      - OLLAMA_API_KEY=${OLLAMA_API_KEY:-}
       - DB_PATH=/data/open-genai.db
       # 監査ログ / チャット履歴分離
       - AUDIT_ENABLED=${AUDIT_ENABLED:-true}

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -99,6 +99,23 @@ http {
             proxy_set_header X-Forwarded-Prefix /kc;
         }
 
+        # --- SeaweedFS(S3) 成果物の署名付きURL配信 ---
+        # 8333 を直接公開せず、単一入口(nginx)経由で成果物を配信する構成の場合に使用する。
+        # 署名URLは backend の S3_PUBLIC_ENDPOINT を基に生成されるため、
+        # S3_PUBLIC_ENDPOINT にこのドメイン（例 https://<host>）を設定すること。
+        # パスは S3_BUCKET（既定 open-genai）に一致させる。
+        location /open-genai/ {
+            set $s3_upstream http://seaweedfs:8333;
+            proxy_pass $s3_upstream;
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_buffering off;
+            client_max_body_size 64m;
+        }
+
         # --- フロントエンド（静的ビルド / nginx）---
         location / {
             set $web_upstream http://web:80;


### PR DESCRIPTION
## 概要

本番デプロイ向けの汎用的な2点を追加します（特定環境の情報は含みません）。

- **proxy**: SeaweedFS(S3) の署名付きURL配信用に `location /open-genai/` を追加。ポート `8333` を直接公開せず、単一入口（nginx）経由で成果物を配信する構成に対応します。
- **compose**: `LLM_PROVIDERS` の `api_key_env=OLLAMA_API_KEY` から参照できるよう、backend へ `OLLAMA_API_KEY` を受け渡します（Ollama Cloud 等を OpenAI 互換プロバイダとして利用可能に）。既存の `SAKURA_API_KEY` 等と同じ扱いです。

## 詳細

### `/open-genai/` S3 プロキシ
- 署名URLは backend の `S3_PUBLIC_ENDPOINT` を基に生成されるため、この構成を使う場合は `S3_PUBLIC_ENDPOINT` にこのドメイン（例 `https://<host>`）を設定してください。
- パスは `S3_BUCKET`（既定 `open-genai`）に一致させています。バケット名を変更する場合は `location` も合わせて調整が必要です。
- 8333 を直接公開する既存構成のままでも影響はありません（本 location を使わなければ従来どおり）。

### `OLLAMA_API_KEY` 受け渡し
- 値は `.env` の `${OLLAMA_API_KEY:-}` を参照（既定は空）。未設定なら従来どおり無影響です。

## テスト観点
- [ ] `/open-genai/<key>?<署名>` で成果物がダウンロードできる（S3_PUBLIC_ENDPOINT をドメインに設定した場合）
- [ ] 8333 直接公開の従来構成でも回帰がない
- [ ] `OLLAMA_API_KEY` 未設定時に backend が正常起動する

Made with [Cursor](https://cursor.com)