### PR TITLE
feat(exapp): 添付非対応の対話アプリで「ファイルを添付」ボタンを非表示にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,7 +864,7 @@ curl -s -w "\nHTTP %{http_code}\n" \
 
 - 会話の文脈は、源内が会話ごとに発行する `sessionId` を `dify-app` が **Dify の `conversation_id` に対応付けて保持**することで維持されます（SQLite, `dify_app_data` ボリューム）。
 - 画面の **「新しい会話」** ボタンで `sessionId` をリセットし、新しい Dify 会話を開始できます。
-- 画像 / ドキュメントの添付に対応します（`dify-app` が `/v1/files/upload` 経由で Dify に渡します）。
+- 画像 / ドキュメントの添付に対応します（`dify-app` が `/v1/files/upload` 経由で Dify に渡します）。**「ファイルを添付」ボタンは、アプリがファイルを受け付けられる場合のみ表示**されます（下記「ファイル添付」の判定条件を参照）。ファイルを使わないエージェント（例: ナレッジ検索エージェント）ではボタンは出ません。
 - チャットフロー用アプリには **チャットフローの API キー** を登録してください（ワークフローとはキーで区別）。
 
 > 補足: フォーム型アプリ（ワークフロー等）でも、placeholder に `conversation_history` キーを含めると実行結果に「会話を続ける」ボタンが出ます（疑似チャット）。チャットフローは上記の対話型 UI を使うため、この指定は不要です。
@@ -885,6 +885,17 @@ curl -s -w "\nHTTP %{http_code}\n" \
 
 - 変数の型（`file` / `file-list`）も `/v1/parameters` から判定し、単一/配列で渡します。
 - Dify 側でフローが「メッセージ添付」ではなく「入力変数(file-list)」でファイルを受け取る設計（`file_upload.enabled: false` でも入力変数は利用可）にも対応します。
+
+#### 添付ボタンの表示可否（能力検知）
+
+対話型 UI の「ファイルを添付」ボタンは、`dify-app` の `/schema` が返す `features.file_attach` が `true` のときだけ表示されます。判定は次の順で行い、いずれにも該当しない場合や `/parameters` の取得に失敗した場合は **非表示（fail-closed）** です。
+
+1. `config` の `"file_attach": true` / `false`（明示指定。`false` は他条件より優先して強制 OFF）
+2. `config` に `"file_var"` が設定されている
+3. Dify の `/v1/parameters` の `user_input_form` に `file` / `file-list` 型の入力変数がある
+4. Dify の `/v1/parameters` の `file_upload.enabled` が `true`（メッセージ添付 `sys.files` 経路）
+
+これにより、`file_upload.enabled: false` かつ file 入力変数を持たないアプリ（例: ナレッジ検索エージェント）では、押しても効かない添付ボタンが表示されなくなります。
 
 ### 成果物ファイル（SeaweedFS 再ホスト）
 

--- a/dify-app/app/main.py
+++ b/dify-app/app/main.py
@@ -712,6 +712,51 @@ async def _detect_file_input(base: str, api_key: str) -> tuple[str | None, bool]
     return None, False
 
 
+def _config_flag(cfg: dict[str, Any], key: str) -> bool | None:
+    """config の真偽フラグを解釈する。未設定は None（bool / 文字列表記の両対応）。"""
+    if key not in cfg:
+        return None
+    val = cfg.get(key)
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        s = val.strip().lower()
+        if s in ("true", "1", "yes", "on"):
+            return True
+        if s in ("false", "0", "no", "off"):
+            return False
+    return None
+
+
+def _file_attach_supported(params: dict[str, Any], cfg: dict[str, Any]) -> bool:
+    """このアプリがファイル添付を受け付けられるかを判定する。
+
+    優先順:
+      1. config.file_attach が明示指定されていればそれに従う（false は強制 OFF）
+      2. config.file_var が設定されていれば True
+      3. Dify /parameters の user_input_form に file / file-list があれば True
+      4. Dify /parameters の file_upload.enabled が True なら True（sys.files 経路）
+    それ以外・判定不能は False（fail-closed）。
+    """
+    explicit = _config_flag(cfg, "file_attach")
+    if explicit is not None:
+        return explicit
+    if cfg.get("file_var"):
+        return True
+    if not isinstance(params, dict):
+        return False
+    for item in params.get("user_input_form", []) or []:
+        if not isinstance(item, dict):
+            continue
+        for spec in item.values():
+            if isinstance(spec, dict) and spec.get("type") in ("file", "file-list"):
+                return True
+    file_upload = params.get("file_upload")
+    if isinstance(file_upload, dict) and file_upload.get("enabled") is True:
+        return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Dify 呼び出し（streaming で受信して集約）
 # ---------------------------------------------------------------------------
@@ -1044,11 +1089,18 @@ async def schema(
     x_api_key: str | None = Header(default=None),
     x_app_config: str | None = Header(default=None),
 ) -> Any:
-    """Dify の /parameters を取得し、源内のフォーム定義(placeholder) に変換して返す。"""
+    """Dify の /parameters を取得し、源内のフォーム定義(placeholder) に変換して返す。
+
+    併せて、このアプリがファイル添付を受け付けられるか（features.file_attach）を返す。
+    取得失敗時も config の明示指定（file_attach / file_var）は尊重し、それ以外は False。
+    """
     cfg = _parse_config(x_app_config)
     base = (cfg.get("dify_base_url") or DEFAULT_DIFY_BASE_URL).rstrip("/")
     if not base:
-        return {"placeholder": {}}
+        return {
+            "placeholder": {},
+            "features": {"file_attach": _file_attach_supported({}, cfg)},
+        }
     try:
         async with httpx.AsyncClient(timeout=15) as client:
             res = await client.get(
@@ -1056,11 +1108,21 @@ async def schema(
                 headers={"Authorization": f"Bearer {x_api_key or ''}"},
             )
         if res.status_code != 200:
-            return {"placeholder": {}}
-        form = res.json().get("user_input_form", [])
+            return {
+                "placeholder": {},
+                "features": {"file_attach": _file_attach_supported({}, cfg)},
+            }
+        params = res.json()
     except (httpx.HTTPError, ValueError):
-        return {"placeholder": {}}
-    return {"placeholder": _convert_user_input_form(form, cfg=cfg)}
+        return {
+            "placeholder": {},
+            "features": {"file_attach": _file_attach_supported({}, cfg)},
+        }
+    form = params.get("user_input_form", []) if isinstance(params, dict) else []
+    return {
+        "placeholder": _convert_user_input_form(form, cfg=cfg),
+        "features": {"file_attach": _file_attach_supported(params, cfg)},
+    }
 
 
 @app.post("/invoke")

--- a/genai-web/packages/web/src/features/exapp/ExAppPage.tsx
+++ b/genai-web/packages/web/src/features/exapp/ExAppPage.tsx
@@ -71,13 +71,21 @@ export const ExAppPage = () => {
     placeholderEmpty &&
     (!!configObj?.dify_base_url || configObj?.dynamic_schema === true);
 
-  const { uiJson: fetchedUiJson, isLoading: isSchemaLoading } = useFetchExAppSchema(
-    teamId,
-    exAppId,
-    shouldFetchSchema,
-  );
+  // chat 型 Dify アプリは、ファイル添付の可否(features.file_attach)を判定するため
+  // /schema を取得する（フォーム生成は不要でも features のために叩く）。
+  const shouldFetchChatFeatures = !!exApp && isChatApp && !!configObj?.dify_base_url;
+
+  const {
+    uiJson: fetchedUiJson,
+    features,
+    isLoading: isSchemaLoading,
+  } = useFetchExAppSchema(teamId, exAppId, shouldFetchSchema || shouldFetchChatFeatures);
 
   const uiJson = shouldFetchSchema ? fetchedUiJson : placeholderUiJson;
+
+  // features を確定できた場合のみ添付ボタンを表示（ロード中・判定不能は非表示）。
+  const chatFileAttachEnabled =
+    shouldFetchChatFeatures && !isSchemaLoading && features?.file_attach === true;
 
   const defaultValuesJson = useMemo(() => {
     if (!uiJson) {
@@ -126,7 +134,7 @@ export const ExAppPage = () => {
               <Divider className='my-6' />
 
               {isChatApp ? (
-                <ExAppChat exApp={exApp} />
+                <ExAppChat exApp={exApp} fileAttachEnabled={chatFileAttachEnabled} />
               ) : (
                 <>
                   {shouldFetchSchema && isSchemaLoading ? (

--- a/genai-web/packages/web/src/features/exapp/components/ExAppChat.tsx
+++ b/genai-web/packages/web/src/features/exapp/components/ExAppChat.tsx
@@ -20,6 +20,8 @@ type ChatMessage = {
 
 type Props = {
   exApp: ExApp;
+  // アプリがファイル添付を受け付けられる場合のみ「ファイルを添付」を表示する。
+  fileAttachEnabled?: boolean;
 };
 
 // 対話型 AI アプリ（Dify チャットフロー連携）。
@@ -27,7 +29,7 @@ type Props = {
 // dify-app 側の session -> conversation_id 対応に委ねる。
 const ACCEPT = 'image/*,.pdf,.docx,.xlsx,.txt,.md,.csv,.html,.json';
 
-export const ExAppChat = ({ exApp }: Props) => {
+export const ExAppChat = ({ exApp, fileAttachEnabled = false }: Props) => {
   const { invokeExApp } = useInvokeExApp();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
@@ -158,7 +160,7 @@ export const ExAppChat = ({ exApp }: Props) => {
       {error && <p className='text-error-2'>{error}</p>}
 
       <div className='flex flex-col gap-2'>
-        {files.length > 0 && (
+        {fileAttachEnabled && files.length > 0 && (
           <div className='flex items-center gap-2 text-dns-14N-130 text-solid-gray-700'>
             <span>添付: {files.map((f) => f.name).join(', ')}</span>
             <Button variant='text' size='sm' onClick={() => setFiles([])}>
@@ -180,24 +182,28 @@ export const ExAppChat = ({ exApp }: Props) => {
 
         <div className='flex items-center justify-between'>
           <div className='flex items-center gap-2'>
-            <input
-              ref={fileInputRef}
-              type='file'
-              multiple
-              accept={ACCEPT}
-              className='hidden'
-              onChange={(e) => {
-                setFiles(Array.from(e.target.files ?? []));
-                e.target.value = '';
-              }}
-            />
-            <Button
-              variant='outline'
-              size='md'
-              onClick={() => fileInputRef.current?.click()}
-            >
-              ファイルを添付
-            </Button>
+            {fileAttachEnabled && (
+              <>
+                <input
+                  ref={fileInputRef}
+                  type='file'
+                  multiple
+                  accept={ACCEPT}
+                  className='hidden'
+                  onChange={(e) => {
+                    setFiles(Array.from(e.target.files ?? []));
+                    e.target.value = '';
+                  }}
+                />
+                <Button
+                  variant='outline'
+                  size='md'
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  ファイルを添付
+                </Button>
+              </>
+            )}
             <Button variant='text' size='md' onClick={startNewConversation}>
               新しい会話
             </Button>

--- a/genai-web/packages/web/src/features/exapp/hooks/useFetchExAppSchema.ts
+++ b/genai-web/packages/web/src/features/exapp/hooks/useFetchExAppSchema.ts
@@ -2,17 +2,23 @@ import { useEffect, useState } from 'react';
 import { teamApi } from '@/lib/fetcher';
 import { GovAIFormUIJson } from '../types';
 
+export type ExAppSchemaFeatures = {
+  file_attach?: boolean;
+};
+
 type SchemaResponse = {
   placeholder: GovAIFormUIJson;
+  features?: ExAppSchemaFeatures;
 };
 
 /**
- * AI アプリの入力フォーム定義(placeholder)を実行時に取得する。
+ * AI アプリの入力フォーム定義(placeholder)と機能フラグ(features)を実行時に取得する。
  * Dify 連携アプリなどで、データ形式(JSON)未設定時に endpoint の /schema から
- * 入力スキーマを動的取得してフォームを生成するために使う。
+ * 入力スキーマを動的取得してフォームを生成したり、ファイル添付の可否を判定するために使う。
  */
 export const useFetchExAppSchema = (teamId: string, exAppId: string, enabled: boolean) => {
   const [uiJson, setUiJson] = useState<GovAIFormUIJson>({});
+  const [features, setFeatures] = useState<ExAppSchemaFeatures>({});
   // 初回レンダーで空フォームが一瞬出るのを防ぐ（effect より先に loading 表示）
   const [isLoading, setIsLoading] = useState(enabled);
 
@@ -28,11 +34,13 @@ export const useFetchExAppSchema = (teamId: string, exAppId: string, enabled: bo
       .then((res) => {
         if (!cancelled) {
           setUiJson(res.data?.placeholder ?? {});
+          setFeatures(res.data?.features ?? {});
         }
       })
       .catch(() => {
         if (!cancelled) {
           setUiJson({});
+          setFeatures({});
         }
       })
       .finally(() => {
@@ -45,5 +53,5 @@ export const useFetchExAppSchema = (teamId: string, exAppId: string, enabled: bo
     };
   }, [teamId, exAppId, enabled]);
 
-  return { uiJson, isLoading };
+  return { uiJson, features, isLoading };
 };

--- a/genai-web/packages/web/tests/features/exapp/components/ExAppChat.test.tsx
+++ b/genai-web/packages/web/tests/features/exapp/components/ExAppChat.test.tsx
@@ -1,0 +1,46 @@
+import { render } from '@testing-library/react';
+import { ExApp } from 'genai-web';
+import { describe, expect, it, vi } from 'vitest';
+import { ExAppChat } from '../../../../src/features/exapp/components/ExAppChat';
+
+// invoke フックは fetcher に依存するため、描画テストではスタブ化する
+vi.mock('../../../../src/features/exapp/hooks/useInvokeExApp.ts', () => ({
+  useInvokeExApp: () => ({ invokeExApp: vi.fn() }),
+}));
+
+describe('ExAppChat file attach button', () => {
+  const mockExApp: ExApp = {
+    teamId: 'team-123',
+    exAppId: 'app-123',
+    exAppName: 'テストチャット',
+    endpoint: 'https://example.com/invoke',
+    placeholder: '{}',
+    description: '',
+    howToUse: '',
+    apiKey: 'test-api-key',
+    createdDate: '2025-01-01',
+    updatedDate: '2025-01-01',
+  };
+
+  it('hides the attach button when fileAttachEnabled is false', () => {
+    const { queryByText, getByText } = render(
+      <ExAppChat exApp={mockExApp} fileAttachEnabled={false} />,
+    );
+
+    expect(queryByText('ファイルを添付')).toBeNull();
+    // 「新しい会話」は常に表示される（無効化されるのは添付だけ）
+    expect(getByText('新しい会話')).toBeDefined();
+  });
+
+  it('hides the attach button by default (prop omitted)', () => {
+    const { queryByText } = render(<ExAppChat exApp={mockExApp} />);
+
+    expect(queryByText('ファイルを添付')).toBeNull();
+  });
+
+  it('shows the attach button when fileAttachEnabled is true', () => {
+    const { getByText } = render(<ExAppChat exApp={mockExApp} fileAttachEnabled />);
+
+    expect(getByText('ファイルを添付')).toBeDefined();
+  });
+});

--- a/tests/test_dify_file_attach.py
+++ b/tests/test_dify_file_attach.py
@@ -1,0 +1,132 @@
+"""dify-app のファイル添付可否判定（features.file_attach）ヘルパ。"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MAIN = ROOT / "dify-app" / "app" / "main.py"
+
+
+def _load():
+    # ホストに fastapi / httpx が無くてもヘルパを検証できるよう最小スタブを入れる
+    if "fastapi" not in sys.modules:
+        import types
+
+        class _App:
+            def __init__(self, *a, **k):
+                pass
+
+            def on_event(self, *a, **k):
+                def deco(fn):
+                    return fn
+
+                return deco
+
+            def get(self, *a, **k):
+                def deco(fn):
+                    return fn
+
+                return deco
+
+            def post(self, *a, **k):
+                def deco(fn):
+                    return fn
+
+                return deco
+
+        fastapi = types.ModuleType("fastapi")
+        fastapi.FastAPI = _App  # type: ignore[attr-defined]
+        fastapi.Header = lambda *a, **k: None  # type: ignore[attr-defined]
+        fastapi.Request = object  # type: ignore[attr-defined]
+        responses = types.ModuleType("fastapi.responses")
+        responses.JSONResponse = dict  # type: ignore[attr-defined]
+        sys.modules["fastapi"] = fastapi
+        sys.modules["fastapi.responses"] = responses
+    if "httpx" not in sys.modules:
+        import types
+
+        httpx = types.ModuleType("httpx")
+
+        class _AsyncClient:
+            def __init__(self, *a, **k):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+        httpx.AsyncClient = _AsyncClient  # type: ignore[attr-defined]
+        sys.modules["httpx"] = httpx
+
+    spec = importlib.util.spec_from_file_location("dify_app_main", MAIN)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["dify_app_main"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_config_flag_bool_and_string():
+    mod = _load()
+    assert mod._config_flag({}, "file_attach") is None
+    assert mod._config_flag({"file_attach": True}, "file_attach") is True
+    assert mod._config_flag({"file_attach": False}, "file_attach") is False
+    assert mod._config_flag({"file_attach": "true"}, "file_attach") is True
+    assert mod._config_flag({"file_attach": "off"}, "file_attach") is False
+    # 解釈不能な値は None（未指定扱い）
+    assert mod._config_flag({"file_attach": "maybe"}, "file_attach") is None
+
+
+def test_file_attach_enabled_via_file_upload():
+    mod = _load()
+    params = {"user_input_form": [], "file_upload": {"enabled": True}}
+    assert mod._file_attach_supported(params, {}) is True
+
+
+def test_file_attach_enabled_via_file_input_variable():
+    mod = _load()
+    params = {
+        "user_input_form": [
+            {"file-list": {"variable": "upload_files", "type": "file-list"}}
+        ],
+        "file_upload": {"enabled": False},
+    }
+    assert mod._file_attach_supported(params, {}) is True
+
+
+def test_file_attach_enabled_via_config_file_var():
+    mod = _load()
+    params = {"user_input_form": [], "file_upload": {"enabled": False}}
+    assert mod._file_attach_supported(params, {"file_var": "docs"}) is True
+
+
+def test_file_attach_config_false_overrides_params():
+    mod = _load()
+    # /parameters 上は添付可能でも、config.file_attach=false なら強制 OFF
+    params = {"user_input_form": [], "file_upload": {"enabled": True}}
+    assert mod._file_attach_supported(params, {"file_attach": False}) is False
+
+
+def test_file_attach_disabled_for_knowledge_agent_shape():
+    mod = _load()
+    # ナレッジ検索エージェント相当: file_upload 無効・file 入力変数なし
+    params = {
+        "user_input_form": [
+            {"text-input": {"variable": "scope", "type": "text-input"}}
+        ],
+        "file_upload": {"enabled": False},
+    }
+    assert mod._file_attach_supported(params, {}) is False
+
+
+def test_file_attach_fail_closed_on_empty_params():
+    mod = _load()
+    # /parameters 取得失敗時（空 dict）は config の明示指定が無ければ False
+    assert mod._file_attach_supported({}, {}) is False
+    # 取得失敗でも config.file_attach=true は尊重
+    assert mod._file_attach_supported({}, {"file_attach": True}) is True


### PR DESCRIPTION
## 概要

Dify チャット型 UI で常時表示していた「ファイルを添付」ボタンを、**アプリが実際にファイル入力を受け付けられる場合だけ表示**するよう能力検知（capability detection）します。押せるのに効かないボタンによる UX 上の混乱を解消します。

きっかけは「ナレッジ検索エージェント」で、`file_upload.enabled: false` かつ file 入力変数を持たないため、添付しても内容が使われないのにボタンだけ表示されていた点です。

## 変更内容

### dify-app
- `GET /schema` が `features.file_attach` を返すよう拡張（`_config_flag` / `_file_attach_supported` を追加）。
- 判定順（いずれか該当で `true`、なければ / 取得失敗時は `false` = fail-closed）:
  1. `config.file_attach`（明示指定。`false` は強制 OFF で最優先）
  2. `config.file_var` 設定あり
  3. Dify `/parameters` の `user_input_form` に `file` / `file-list` 入力変数
  4. Dify `/parameters` の `file_upload.enabled === true`（`sys.files` 経路）

### web
- `useFetchExAppSchema` が `features` も返す。
- `ExAppPage` は chat 型 + `dify_base_url` あり のとき `/schema` を取得し、確定後のみ `fileAttachEnabled` を渡す（ロード中・判定不能は非表示でチラつき防止）。
- `ExAppChat` は `fileAttachEnabled` が `true` のときだけ添付ボタン・選択ファイル表示を描画。

### ドキュメント / テスト
- `README.md` に判定条件を追記。
- `tests/test_dify_file_attach.py`（判定ロジック 7 ケース）、`ExAppChat.test.tsx`（ボタン表示 3 ケース）を追加。

## 動作確認

デプロイ済み環境で `dify-app` の `/schema` を直接検証:

| config | `features.file_attach` |
| --- | --- |
| 設定なし | `false` |
| `file_attach: true` | `true` |
| `file_var: "docs"` | `true` |
| chat のみ（file 入力なし / params 取得不可）| `false` |

ナレッジ検索エージェントでは `false` となり、添付ボタンが非表示になることを確認。

## Test plan

- [x] Python: `tests/test_dify_file_attach.py` 7/7 パス
- [ ] web: `ExAppChat.test.tsx`（CI の Vitest で実行）
- [x] `dify-app` / `web` 再ビルド・再作成後に `/schema` の features を実機確認

## 補足

backend の `POST /exapps/schema` は dify-app の応答をそのまま転送するため改修不要。paris 環境固有の運用設定（compose の一部・keycloak realm・proxy・起動スクリプト等）は本 PR に含めていません。

Made with [Cursor](https://cursor.com)