### PR TITLE
fix(backend): 大容量チャット添付のチャンク爆発による無応答を修正

### DIFF
--- a/backend/app/doc_mapreduce.py
+++ b/backend/app/doc_mapreduce.py
@@ -27,6 +27,10 @@ CHAT_DOC_SUMMARY_BATCH = int(os.environ.get("CHAT_DOC_SUMMARY_BATCH", "8"))
 CHAT_DOC_MAX_SELECT = int(os.environ.get("CHAT_DOC_MAX_SELECT", "12"))
 # 作業コンテキストの最大文字数（最終プロンプトの肥大を防ぐ）。
 CHAT_DOC_WORKING_MAX = int(os.environ.get("CHAT_DOC_WORKING_MAX", "60000"))
+# 見出し分割が目次行などで細切れになったときの上限。超えたら固定長分割へフォールバック。
+CHAT_DOC_MAX_CHUNKS = int(os.environ.get("CHAT_DOC_MAX_CHUNKS", "60"))
+# full 要約時に実際に LLM へ渡すチャンク数の上限（均等サンプル）。
+CHAT_DOC_MAX_SUMMARY_CHUNKS = int(os.environ.get("CHAT_DOC_MAX_SUMMARY_CHUNKS", "24"))
 
 _OUTLINE_PREVIEW = 80
 _OUTLINE_MAX_CHARS = 8000
@@ -53,10 +57,51 @@ def _split_fixed(text: str, size: int) -> list[tuple[str, str]]:
     return parts
 
 
+def _chunks_from_sections(
+    sections: list[tuple[str, str]], size: int
+) -> list[dict[str, Any]]:
+    chunks: list[dict[str, Any]] = []
+    cid = 0
+    for title, body in sections:
+        if len(body) <= int(size * 1.5):
+            chunks.append({"id": cid, "title": title, "text": body})
+            cid += 1
+        else:
+            for sub_title, part in _split_fixed(body, size):
+                chunks.append(
+                    {"id": cid, "title": f"{title}/{sub_title}", "text": part}
+                )
+                cid += 1
+    return chunks
+
+
+def _sample_chunks(
+    chunks: list[dict[str, Any]], limit: int
+) -> list[dict[str, Any]]:
+    """順序を保ったまま最大 limit 件へ均等サンプルし、id を振り直す。"""
+    n = len(chunks)
+    if n <= limit or limit <= 0:
+        return chunks
+    if limit == 1:
+        idxs = [0]
+    else:
+        idxs = sorted({int(i * (n - 1) / (limit - 1)) for i in range(limit)})
+    sampled = [chunks[i] for i in idxs]
+    for i, c in enumerate(sampled):
+        c = dict(c)
+        c["id"] = i
+        sampled[i] = c
+    return sampled
+
+
 def chunk_document(
     text: str, size: int | None = None
 ) -> list[dict[str, Any]]:
-    """見出し優先・長すぎる節は固定長で分割してチャンク列を返す。"""
+    """見出し優先・長すぎる節は固定長で分割してチャンク列を返す。
+
+    PDF 目次のように見出し正規表現へ大量ヒットすると数千チャンクになり得るため、
+    CHAT_DOC_MAX_CHUNKS を超える場合は固定長分割へフォールバックする。
+    """
     size = CHAT_DOC_CHUNK_SIZE if size is None else size
     lines = (text or "").split("\n")
     sections: list[tuple[str, str]] = []
@@ -81,18 +126,14 @@ def chunk_document(
     if not sections:
         sections = [("(空)", (text or "").strip() or "(空)")]
 
-    chunks: list[dict[str, Any]] = []
-    cid = 0
-    for title, body in sections:
-        if len(body) <= int(size * 1.5):
-            chunks.append({"id": cid, "title": title, "text": body})
-            cid += 1
-        else:
-            for sub_title, part in _split_fixed(body, size):
-                chunks.append(
-                    {"id": cid, "title": f"{title}/{sub_title}", "text": part}
-                )
-                cid += 1
+    chunks = _chunks_from_sections(sections, size)
+    # 目次行の誤分割などで細切れになったら固定長へ。それでも多いときは幅を広げて件数を抑える。
+    if len(chunks) > CHAT_DOC_MAX_CHUNKS:
+        adaptive = max(
+            size,
+            (len(text or "") + CHAT_DOC_MAX_CHUNKS - 1) // CHAT_DOC_MAX_CHUNKS,
+        )
+        chunks = _chunks_from_sections(_split_fixed(text, adaptive), adaptive)
     return chunks
 
 
@@ -187,10 +228,14 @@ async def summarize_full(
     *,
     cap: int | None = None,
 ) -> str:
-    """全チャンクをバッチ要約し、質問に関係する情報を落とさずまとめる。"""
+    """全チャンクをバッチ要約し、質問に関係する情報を落とさずまとめる。
+
+    チャンク数が多すぎるときは均等サンプルしてから要約し、LLM 呼び出し爆発を防ぐ。
+    """
     cap = CHAT_DOC_WORKING_MAX if cap is None else cap
+    work = _sample_chunks(chunks, CHAT_DOC_MAX_SUMMARY_CHUNKS)
     summaries: list[str] = []
-    for batch in _batches(chunks, CHAT_DOC_SUMMARY_BATCH):
+    for batch in _batches(work, CHAT_DOC_SUMMARY_BATCH):
         joined = "\n\n".join(
             f"[{c['id']} {c.get('title', '')}]\n{(c.get('text') or '').strip()}"
             for c in batch
@@ -217,7 +262,9 @@ async def summarize_full(
         try:
             s = (await llm(oai)).strip()
         except Exception:  # noqa: BLE001 - 要約失敗時は原文冒頭で代替（欠落させない）
-            s = joined[: cap // max(1, len(_batches(chunks, CHAT_DOC_SUMMARY_BATCH)))]
+            s = joined[
+                : cap // max(1, len(_batches(work, CHAT_DOC_SUMMARY_BATCH)))
+            ]
         if s:
             summaries.append(s)
     merged = "\n\n---\n\n".join(
@@ -279,8 +326,15 @@ async def condense_document(
     coverage, ids = await _plan_reading(question, outline, total, llm)
 
     if coverage == "full":
+        sampled_n = min(total, CHAT_DOC_MAX_SUMMARY_CHUNKS)
         ctx = await summarize_full(chunks, question, llm)
-        note = f"添付「{name}」は大きいため全 {total} 区間を要約して参照しました"
+        if sampled_n < total:
+            note = (
+                f"添付「{name}」は大きいため全 {total} 区間のうち"
+                f"代表 {sampled_n} 区間を要約して参照しました"
+            )
+        else:
+            note = f"添付「{name}」は大きいため全 {total} 区間を要約して参照しました"
     else:
         ctx = assemble_selected(chunks, ids)
         note = (

--- a/backend/app/llm.py
+++ b/backend/app/llm.py
@@ -20,7 +20,7 @@ import httpx
 
 from shared.docextract import extract_doc_text_full
 
-from .doc_mapreduce import condense_document
+from .doc_mapreduce import CHAT_DOC_INLINE_CHARS, condense_document
 
 OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://host.docker.internal:11434")
 # OpenAI 互換のベース URL（未指定/空なら Ollama の /v1 を使う）
@@ -292,7 +292,38 @@ async def chat_stream(
     """
     model_id = _resolve_model(model)
     provider = _provider_for(model_id)
-    openai_messages, notes = await _prepare_openai_messages(messages, model)
+    # 大きい添付のマップリデュースは初回 yield まで時間がかかるため、進捗を先に流す
+    # （プロキシ/UI が無応答に見えるのを防ぐ）
+    try:
+        has_large_docs = False
+        for m in messages:
+            for name, full_text in _extract_doc_texts_full(m):
+                if len(full_text) > CHAT_DOC_INLINE_CHARS:
+                    has_large_docs = True
+                    break
+            if has_large_docs:
+                break
+        if has_large_docs:
+            yield json.dumps(
+                {
+                    "text": "※ 添付資料が大きいため、内容を整理してから回答します…\n\n",
+                },
+                ensure_ascii=False,
+            ) + "\n"
+        openai_messages, notes = await _prepare_openai_messages(messages, model)
+    except Exception as e:  # noqa: BLE001 - ストリームでユーザ向けに返す
+        yield json.dumps(
+            {
+                "text": (
+                    "添付ファイルの処理中にエラーが発生しました。"
+                    "ファイルを分割するか、指示を具体にして再度お試しください。"
+                    f"（詳細: {type(e).__name__}）"
+                ),
+                "stopReason": "error",
+            },
+            ensure_ascii=False,
+        ) + "\n"
+        return
     prefix = _notes_prefix(notes)
     if prefix:
         yield json.dumps({"text": prefix}, ensure_ascii=False) + "\n"

--- a/tests/test_doc_mapreduce.py
+++ b/tests/test_doc_mapreduce.py
@@ -44,6 +44,36 @@ def test_chunk_document_fixed_split() -> None:
     assert [c["id"] for c in chunks] == [0, 1, 2]
 
 
+def test_chunk_document_falls_back_when_headings_explode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """目次のように見出しが大量ヒットしたら件数上限内の固定長分割へフォールバックする。"""
+    monkeypatch.setattr(dm, "CHAT_DOC_MAX_CHUNKS", 5)
+    monkeypatch.setattr(dm, "CHAT_DOC_CHUNK_SIZE", 20)
+    # 【…】行が見出し扱いされ、細切れになる入力
+    body = "\n".join(f"【見出し{i}】\n本文{i}です" for i in range(30))
+    chunks = dm.chunk_document(body)
+    assert len(chunks) <= 5
+    assert len(chunks) >= 1
+
+
+def test_summarize_full_samples_when_too_many_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dm, "CHAT_DOC_INLINE_CHARS", 20)
+    monkeypatch.setattr(dm, "CHAT_DOC_CHUNK_SIZE", 10)
+    monkeypatch.setattr(dm, "CHAT_DOC_SUMMARY_BATCH", 2)
+    monkeypatch.setattr(dm, "CHAT_DOC_MAX_SUMMARY_CHUNKS", 4)
+    body = "あ" * 100  # 10 チャンク → サンプル 4 → バッチ2で 2 回要約
+    plan = json.dumps({"coverage": "full", "chunk_ids": []})
+    llm, calls = _fake_llm(plan)
+    ctx, note = asyncio.run(dm.condense_document("big.txt", body, "全体要約", llm))
+    assert calls["plan"] == 1
+    assert calls["summary"] == 2
+    assert "代表 4 区間" in note
+    assert "区間要約" in ctx
+
+
 def test_parse_plan_partial_selects_ids() -> None:
     coverage, ids = dm.parse_plan('{"coverage":"partial","chunk_ids":[0,2,9]}', total=5)
     assert coverage == "partial"


### PR DESCRIPTION
## Summary
- PDF 目次などが見出し分割に大量ヒットするとチャンクが数千件になり、マップリデュース前段で失敗して `/predict/stream` が空応答になる問題を修正
- チャンク件数上限と固定長フォールバック、全体要約時の代表サンプル、進捗メッセージとエラーのストリーム返却を追加
- 当該 PDF で実機再検証済み（応答が返ることを確認）

## Test plan
- [x] `tests/test_doc_mapreduce.py` パス（見出し爆発フォールバック / 要約サンプルを含む）
- [x] 大きな PDF をチャット添付し「どのような内容か」で進捗表示のあと回答が返ることを確認
- [ ] 小さな添付（60,000 文字以下）は従来どおり全文注入のままであること


Made with [Cursor](https://cursor.com)