### PR TITLE
fix: 添付テキスト文字コード判定とナレッジ source の NFC 正規化

### DIFF
--- a/knowledge-mcp/app/main.py
+++ b/knowledge-mcp/app/main.py
@@ -132,15 +132,20 @@ async def knowledge_list_docs(scope: str = "", tags: str = "") -> str:
         params["tags"] = ",".join(tag_list)
     data = await _get("/knowledge/docs", params)
     # エージェント向けに要点だけ整形（全文は載せない）
+    import unicodedata
+
     docs = data.get("documents") or []
     slim = []
     for d in docs:
         if not isinstance(d, dict):
             continue
+        src = d.get("source") or ""
+        if isinstance(src, str):
+            src = unicodedata.normalize("NFC", src)
         slim.append(
             {
                 "doc_id": d.get("doc_id") or d.get("id"),
-                "source": d.get("source"),
+                "source": src,
                 "tags": d.get("tags") or [],
                 "index_kind": d.get("index_kind"),
             }
@@ -213,7 +218,10 @@ async def knowledge_search(
         "top_k": int(top_k or 4),
         "mode": (mode or "auto").strip().lower(),
     }
-    src = (source or "").strip()
+    # macOS NFD ファイル名と LLM の NFC 表記差を吸収
+    import unicodedata
+
+    src = unicodedata.normalize("NFC", (source or "").strip())
     did = (doc_id or "").strip()
     if src:
         body["source"] = src

--- a/rag-app/app/docstore.py
+++ b/rag-app/app/docstore.py
@@ -133,6 +133,7 @@ def upsert_document(
       - fulltext: 全文のみ（簡易／URL）。コンテキスト収まる場合の全文投入用
     """
     now = _now()
+    source = textnorm.normalize_source(source) or "unknown"
     page_count = len(pages)
     char_count = sum(len(p.get("text") or "") for p in pages)
     tags_s = _tags_json(tags)
@@ -145,17 +146,26 @@ def upsert_document(
             "SELECT doc_id FROM docs WHERE scope = ? AND source = ?",
             (scope, source),
         ).fetchone()
+        if not existing:
+            # macOS 由来 NFD などで保存済みの行を NFC キーで拾う
+            for row in conn.execute(
+                "SELECT doc_id, source FROM docs WHERE scope = ?", (scope,)
+            ).fetchall():
+                if textnorm.normalize_source(row["source"]) == source:
+                    existing = row
+                    break
         if existing:
             doc_id = existing["doc_id"]
             conn.execute("DELETE FROM pages WHERE doc_id = ?", (doc_id,))
             conn.execute("DELETE FROM tree_nodes WHERE doc_id = ?", (doc_id,))
             conn.execute(
                 """
-                UPDATE docs SET tags = ?, page_count = ?, char_count = ?,
+                UPDATE docs SET source = ?, tags = ?, page_count = ?, char_count = ?,
                   truncated = ?, content_hash = ?, index_kind = ?, updated_at = ?
                 WHERE doc_id = ?
                 """,
                 (
+                    source,
                     tags_s,
                     page_count,
                     char_count,
@@ -225,6 +235,9 @@ def _normalize_doc_row(r: sqlite3.Row | dict[str, Any]) -> dict[str, Any]:
     d["index_kind"] = (d.get("index_kind") or "tree").strip().lower()
     if d["index_kind"] not in ("tree", "fulltext"):
         d["index_kind"] = "tree"
+    d["source"] = textnorm.normalize_source(d.get("source") or "") or (
+        d.get("source") or ""
+    )
     return d
 
 
@@ -247,6 +260,9 @@ def list_docs(scope: str, tags: list[str] | None = None) -> list[dict[str, Any]]
             continue
         # 応答も NFC に揃える（LLM がコピーしても照合できる）
         d["tags"] = sorted(doc_tags) if doc_tags else []
+        d["source"] = textnorm.normalize_source(d.get("source") or "") or (
+            d.get("source") or ""
+        )
         out.append(d)
     return out
 
@@ -268,14 +284,26 @@ def get_doc(doc_id: str, scope: str | None = None) -> dict[str, Any] | None:
 
 
 def get_doc_by_source(scope: str, source: str) -> dict[str, Any] | None:
+    """source（ファイル名）で文書を探す。NFC/NFD 差を吸収する。"""
+    src = textnorm.normalize_source(source)
+    if not src:
+        return None
     with _connect() as conn:
         r = conn.execute(
             "SELECT * FROM docs WHERE scope = ? AND source = ?",
-            (scope, source),
+            (scope, src),
         ).fetchone()
-    if not r:
-        return None
-    return _normalize_doc_row(r)
+        if r:
+            return _normalize_doc_row(r)
+        # 既存 NFD 行向けフォールバック
+        rows = conn.execute(
+            "SELECT * FROM docs WHERE scope = ?",
+            (scope,),
+        ).fetchall()
+    for row in rows:
+        if textnorm.normalize_source(row["source"]) == src:
+            return _normalize_doc_row(row)
+    return None
 
 
 def get_toc(doc_id: str) -> list[dict[str, Any]]:

--- a/rag-app/app/main.py
+++ b/rag-app/app/main.py
@@ -306,6 +306,52 @@ async def _migrate_tag_unicode_nfc() -> None:
         print(f"[rag-app] タグ Unicode NFC 移行: {renamed} 件更新")
 
 
+async def _migrate_source_unicode_nfc() -> None:
+    """docs.source / Qdrant payload.source を Unicode NFC に揃える。
+
+    macOS 由来の NFD ファイル名と、LLM が返す NFC ファイル名の不一致で
+    knowledge_search(source=...) が 0 件になるのを防ぐ。
+    """
+    from . import textnorm
+
+    renamed = 0
+    try:
+        with docstore._connect() as conn:  # noqa: SLF001 - 移行専用
+            rows = list(conn.execute("SELECT doc_id, scope, source FROM docs"))
+            for doc_id, scope, source in rows:
+                nfc = textnorm.normalize_source(source)
+                if not nfc or nfc == source:
+                    continue
+                conflict = conn.execute(
+                    "SELECT doc_id FROM docs WHERE scope = ? AND source = ?",
+                    (scope, nfc),
+                ).fetchone()
+                if conflict and conflict["doc_id"] != doc_id:
+                    print(
+                        f"[rag-app] source NFC 移行スキップ（衝突）: "
+                        f"{scope}/{source!r} → {nfc!r}"
+                    )
+                    continue
+                conn.execute(
+                    "UPDATE docs SET source = ? WHERE doc_id = ?",
+                    (nfc, doc_id),
+                )
+                renamed += 1
+                try:
+                    await vectorstore.rename_source_in_payloads(scope, source, nfc)
+                except Exception as e:  # noqa: BLE001
+                    print(
+                        f"[rag-app] Qdrant source NFC 移行警告 "
+                        f"({scope}/{source}): {e}"
+                    )
+    except Exception as e:  # noqa: BLE001
+        print(f"[rag-app] docs source NFC 移行警告: {e}")
+        return
+
+    if renamed:
+        print(f"[rag-app] source Unicode NFC 移行: {renamed} 件更新")
+
+
 @app.on_event("startup")
 async def _startup() -> None:
     await vectorstore.ensure_collection()
@@ -330,6 +376,10 @@ async def _startup() -> None:
         await _migrate_tag_unicode_nfc()
     except Exception as e:  # noqa: BLE001
         print(f"[rag-app] タグ NFC 移行をスキップ: {e}")
+    try:
+        await _migrate_source_unicode_nfc()
+    except Exception as e:  # noqa: BLE001
+        print(f"[rag-app] source NFC 移行をスキップ: {e}")
     # 旧 rag-manage(ADMIN_TEAM scope) → 共有ナレッジ(COMMON) への一度きり移行
     try:
         moved = await vectorstore.reassign_scope(LEGACY_ADMIN_SCOPE, DEFAULT_SCOPE)

--- a/rag-app/app/retrieve.py
+++ b/rag-app/app/retrieve.py
@@ -471,7 +471,12 @@ async def retrieve_full(
     if doc_id:
         docs = [d for d in docs if d.get("doc_id") == doc_id]
     elif source:
-        docs = [d for d in docs if d.get("source") == source]
+        from . import textnorm
+
+        ns = textnorm.normalize_source(source)
+        docs = [
+            d for d in docs if textnorm.normalize_source(d.get("source")) == ns
+        ]
     nodes: list[dict[str, Any]] = []
     for d in docs:
         pages = docstore.get_all_pages(d["doc_id"])
@@ -509,17 +514,22 @@ def _resolve_source_filter(
     scope: str, doc_id: str | None, source: str | None
 ) -> tuple[str | None, str | None, dict[str, Any] | None]:
     """doc_id / source を正規化し、対象文書（あれば）を返す。"""
+    from . import textnorm
+
     did = (doc_id or "").strip() or None
-    src = (source or "").strip() or None
+    src = textnorm.normalize_source(source) or None
     doc: dict[str, Any] | None = None
     if did:
         doc = docstore.get_doc(did, scope)
         if doc and not src:
-            src = (doc.get("source") or "").strip() or None
+            src = textnorm.normalize_source(doc.get("source")) or None
     elif src:
         doc = docstore.get_doc_by_source(scope, src)
         if doc and not did:
             did = doc.get("doc_id")
+        # 解決できた文書の正規化済み source を以降のフィルタに使う
+        if doc:
+            src = textnorm.normalize_source(doc.get("source")) or src
     return did, src, doc
 
 

--- a/rag-app/app/textnorm.py
+++ b/rag-app/app/textnorm.py
@@ -1,7 +1,7 @@
-"""テキスト正規化（タグ名の Unicode 統一など）。
+"""テキスト正規化（タグ名・ファイル名の Unicode 統一など）。
 
 LLM / ブラウザは NFC、macOS 由来のファイル名等は NFD になりやすい。
-タグ照合は常に NFC で行う。
+タグ・source（ファイル名）の照合は常に NFC で行う。
 """
 
 from __future__ import annotations
@@ -25,3 +25,22 @@ def normalize_tags(tags: Iterable[str] | None) -> list[str]:
         if name and name not in out:
             out.append(name)
     return out
+
+
+def normalize_source(source: str | None) -> str:
+    """ファイル名/URL（source）を strip + Unicode NFC に正規化する。"""
+    if source is None:
+        return ""
+    return unicodedata.normalize("NFC", str(source)).strip()
+
+
+def source_match_forms(source: str | None) -> list[str]:
+    """Qdrant 等の厳密一致向けに、NFC/NFD/生値の候補を返す。"""
+    raw = (source or "").strip()
+    if not raw:
+        return []
+    forms: list[str] = []
+    for form in (raw, normalize_source(raw), unicodedata.normalize("NFD", raw)):
+        if form and form not in forms:
+            forms.append(form)
+    return forms

--- a/rag-app/app/tree_ingest.py
+++ b/rag-app/app/tree_ingest.py
@@ -85,6 +85,9 @@ async def _save_pages(
     index_kind: str,
     also_vector: bool,
 ) -> dict[str, Any]:
+    from . import textnorm
+
+    source = textnorm.normalize_source(source) or "unknown"
     full = "\n\n".join(p.get("text") or "" for p in pages)
     content_hash = hashlib.sha256(full.encode("utf-8", "ignore")).hexdigest()
     doc_id = docstore.upsert_document(

--- a/rag-app/app/vectorstore.py
+++ b/rag-app/app/vectorstore.py
@@ -91,6 +91,18 @@ def _scope_filter(
     return filt
 
 
+def _source_filter_clause(source: str | None) -> list[dict[str, Any]] | None:
+    """source フィルタ。NFC/NFD 混在に備え候補形を any で渡す。"""
+    from . import textnorm
+
+    forms = textnorm.source_match_forms(source)
+    if not forms:
+        return None
+    if len(forms) == 1:
+        return [{"key": "source", "match": {"value": forms[0]}}]
+    return [{"key": "source", "match": {"any": forms}}]
+
+
 async def search(
     vector: list[float],
     limit: int,
@@ -100,9 +112,7 @@ async def search(
     require_tags: bool = True,
     source: str | None = None,
 ) -> list[dict[str, Any]]:
-    extra: list[dict[str, Any]] | None = None
-    if source:
-        extra = [{"key": "source", "match": {"value": source}}]
+    extra = _source_filter_clause(source)
     async with httpx.AsyncClient(timeout=30) as client:
         res = await client.post(
             f"{QDRANT_URL}/collections/{COLLECTION}/points/search",
@@ -121,14 +131,13 @@ async def search(
 
 async def delete_by_source(source: str, scope: str) -> None:
     """指定スコープ内の出典(source=ファイル名/URL)のチャンクを全削除する。"""
+    extra = _source_filter_clause(source) or [
+        {"key": "source", "match": {"value": (source or "").strip()}}
+    ]
     async with httpx.AsyncClient(timeout=30) as client:
         res = await client.post(
             f"{QDRANT_URL}/collections/{COLLECTION}/points/delete?wait=true",
-            json={
-                "filter": _scope_filter(
-                    scope, [{"key": "source", "match": {"value": source}}]
-                )
-            },
+            json={"filter": _scope_filter(scope, extra)},
         )
         res.raise_for_status()
 
@@ -239,17 +248,60 @@ async def list_tags(scope: str) -> list[dict[str, Any]]:
 
 async def set_tags_by_source(scope: str, source: str, tags: list[str]) -> None:
     """指定ドキュメントの全チャンクの tags を置き換える。"""
+    extra = _source_filter_clause(source) or [
+        {"key": "source", "match": {"value": (source or "").strip()}}
+    ]
     async with httpx.AsyncClient(timeout=60) as client:
         res = await client.post(
             f"{QDRANT_URL}/collections/{COLLECTION}/points/payload?wait=true",
             json={
                 "payload": {"tags": list(tags)},
-                "filter": _scope_filter(
-                    scope, [{"key": "source", "match": {"value": source}}]
-                ),
+                "filter": _scope_filter(scope, extra),
             },
         )
         res.raise_for_status()
+
+
+async def rename_source_in_payloads(scope: str, old: str, new: str) -> int:
+    """スコープ内のチャンク payload.source を old→new に置換する。"""
+    if not old or not new or old == new:
+        return 0
+    updated = 0
+    offset: Any = None
+    extra = _source_filter_clause(old) or [
+        {"key": "source", "match": {"value": old}}
+    ]
+    async with httpx.AsyncClient(timeout=60) as client:
+        while True:
+            body: dict[str, Any] = {
+                "limit": 128,
+                "with_payload": ["source"],
+                "with_vector": False,
+                "filter": _scope_filter(scope, extra),
+            }
+            if offset is not None:
+                body["offset"] = offset
+            res = await client.post(
+                f"{QDRANT_URL}/collections/{COLLECTION}/points/scroll", json=body
+            )
+            if res.status_code != 200:
+                break
+            result = res.json().get("result", {})
+            points = result.get("points") or []
+            for p in points:
+                pid = p.get("id")
+                payload = p.get("payload") or {}
+                if payload.get("source") == new:
+                    continue
+                await client.post(
+                    f"{QDRANT_URL}/collections/{COLLECTION}/points/payload?wait=true",
+                    json={"payload": {"source": new}, "points": [pid]},
+                )
+                updated += 1
+            offset = result.get("next_page_offset")
+            if offset is None:
+                break
+    return updated
 
 
 async def rename_tag_in_payloads(scope: str, old: str, new: str) -> int:

--- a/shared/docextract.py
+++ b/shared/docextract.py
@@ -60,6 +60,70 @@ def b64_to_bytes(data: str) -> bytes:
     return base64.b64decode(strip_base64_prefix(data))
 
 
+def _score_decoded_text(text: str) -> float:
+    """文字コード候補の尤もらしさ。日本語文書向けに CJK を加点する。"""
+    if not text:
+        return -1.0
+    sample = text if len(text) <= 8000 else text[:8000]
+    cjk = 0
+    replacement = 0
+    controls = 0
+    for ch in sample:
+        o = ord(ch)
+        if ch == "\ufffd":
+            replacement += 1
+        elif (
+            0x3040 <= o <= 0x30FF  # ひらがな・カタカナ
+            or 0x4E00 <= o <= 0x9FFF  # CJK
+            or 0xFF66 <= o <= 0xFF9D  # 半角カナ
+            or 0x3000 <= o <= 0x303F  # 句読点など
+        ):
+            cjk += 1
+        elif o < 32 and ch not in "\t\n\r":
+            controls += 1
+    # 置換文字・制御文字は強く減点。同点なら呼び出し側で utf-8 を優先する。
+    return float(cjk * 3 - replacement * 50 - controls * 5)
+
+
+def decode_text_bytes(raw: bytes) -> str:
+    """テキストバイト列を UTF-8 / CP932 等から自動判定してデコードする。
+
+    役所・業務系の .txt は Shift_JIS (CP932) が多く、UTF-8 固定だと文字化けする。
+    BOM があればそれに従う。UTF-8 として厳密に読めればそれを優先し、
+    失敗した場合のみ CP932 / EUC-JP 等をスコア比較する。
+    """
+    if not raw:
+        return ""
+    if raw.startswith(b"\xef\xbb\xbf"):
+        return raw.decode("utf-8-sig")
+    if raw.startswith(b"\xff\xfe"):
+        return raw.decode("utf-16-le")
+    if raw.startswith(b"\xfe\xff"):
+        return raw.decode("utf-16-be")
+
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        pass
+
+    best_text: str | None = None
+    best_score = float("-inf")
+    for enc in ("cp932", "euc_jp", "iso-2022-jp"):
+        try:
+            text = raw.decode(enc)
+        except UnicodeDecodeError:
+            continue
+        score = _score_decoded_text(text)
+        if best_text is None or score > best_score:
+            best_score = score
+            best_text = text
+
+    if best_text is not None:
+        return best_text
+
+    return raw.decode("utf-8", "replace")
+
+
 def _docx_extract_text(raw: bytes) -> str:
     """docx から本文段落・表・ヘッダー/フッターを本文順に抽出する。
 
@@ -178,7 +242,7 @@ def _extract_raw_text(
             "json",
             "log",
         ) or mt.startswith("text/"):
-            text = raw.decode("utf-8", "ignore")
+            text = decode_text_bytes(raw)
         else:
             return None, None
     except Exception as e:  # noqa: BLE001
@@ -314,7 +378,7 @@ def extract_doc_pages(name: str, media_type: str, b64: str) -> list[dict[str, An
             "json",
             "log",
         ) or mt.startswith("text/"):
-            text = raw.decode("utf-8", "ignore").strip()
+            text = decode_text_bytes(raw).strip()
         else:
             return []
 

--- a/tests/test_docextract.py
+++ b/tests/test_docextract.py
@@ -24,6 +24,33 @@ def test_extract_doc_text_from_plain_text() -> None:
     assert docextract.extract_doc_text("note.txt", "text/plain", payload) == "hello world"
 
 
+def test_decode_text_bytes_prefers_utf8() -> None:
+    text = "戦略ロードマップと優先計画 2026"
+    assert docextract.decode_text_bytes(text.encode("utf-8")) == text
+
+
+def test_decode_text_bytes_cp932() -> None:
+    """Shift_JIS/CP932 の業務テキストを文字化けさせない。"""
+    text = "令和８年度　ＡＩ・ＤＸ推進の重点方針（案）"
+    raw = text.encode("cp932")
+    # 旧実装（utf-8 ignore）では読めないことを確認したうえで新実装を検証
+    assert raw.decode("utf-8", "ignore") != text
+    assert docextract.decode_text_bytes(raw) == text
+
+
+def test_extract_doc_text_from_cp932_txt() -> None:
+    text = "この資料は政策優先度のアウトラインです。"
+    payload = base64.b64encode(text.encode("cp932")).decode("ascii")
+    assert docextract.extract_doc_text("outline.txt", "text/plain", payload) == text
+
+
+def test_extract_doc_pages_from_cp932_txt() -> None:
+    text = "ナレッジ登録経路でも CP932 を正しく読む。"
+    payload = base64.b64encode(text.encode("cp932")).decode("ascii")
+    pages = docextract.extract_doc_pages("outline.txt", "text/plain", payload)
+    assert "".join(p["text"] for p in pages) == text
+
+
 def test_extract_doc_text_from_pdf() -> None:
     writer = PdfWriter()
     writer.add_blank_page(width=72, height=72)

--- a/tests/test_textnorm_source.py
+++ b/tests/test_textnorm_source.py
@@ -1,0 +1,52 @@
+"""source（ファイル名）の Unicode NFC 正規化。"""
+
+from __future__ import annotations
+
+import unicodedata
+
+from conftest import load_service_module
+
+
+def test_normalize_source_nfc_for_mac_filename() -> None:
+    textnorm = load_service_module("rag-app/app/textnorm.py")
+    nfc = "20260803_三重県市町村総合事務組合_トレンド研修資料.pdf"
+    nfd = unicodedata.normalize("NFD", nfc)
+    assert nfc != nfd
+    assert textnorm.normalize_source(nfd) == nfc
+    assert textnorm.normalize_source(nfc) == nfc
+
+
+def test_source_match_forms_includes_both() -> None:
+    textnorm = load_service_module("rag-app/app/textnorm.py")
+    nfc = "トレンド.pdf"
+    nfd = unicodedata.normalize("NFD", nfc)
+    forms = textnorm.source_match_forms(nfc)
+    assert nfc in forms
+    assert nfd in forms
+
+
+def test_get_doc_by_source_accepts_nfc_when_stored_nfd(
+    tmp_path, monkeypatch
+) -> None:
+    docstore = load_service_module("rag-app/app/docstore.py")
+    monkeypatch.setattr(docstore, "DB_PATH", str(tmp_path / "rag_meta.db"))
+    docstore.init_db()
+
+    nfc = "トレンド研修.pdf"
+    nfd = unicodedata.normalize("NFD", nfc)
+    # 移行前データ相当: DB に NFD を直接入れる
+    with docstore._connect() as conn:  # noqa: SLF001
+        conn.execute(
+            """
+            INSERT INTO docs (
+              doc_id, scope, source, tags, page_count, char_count,
+              truncated, content_hash, index_kind, created_at, updated_at
+            ) VALUES (?, ?, ?, '[]', 1, 1, 0, '', 'tree', '1', '1')
+            """,
+            ("doc-1", "scope-1", nfd),
+        )
+
+    found = docstore.get_doc_by_source("scope-1", nfc)
+    assert found is not None
+    assert found["doc_id"] == "doc-1"
+    assert found["source"] == nfc


### PR DESCRIPTION
## Summary
- チャット添付の `.txt` を UTF-8 固定で読んでいたため、CP932（Shift_JIS）の業務ファイルが文字化けする問題を修正（文字コード自動判定）
- ナレッジ MCP で macOS 由来の NFD ファイル名と LLM の NFC 表記が一致せず、`knowledge_search(source=...)` が 0 件になる問題を修正（タグと同様に source も NFC 化・既存データ移行）

## Test plan
- [ ] CP932 の `.txt` をチャットに添付し、日本語本文が読めること
- [ ] UTF-8 の `.txt` も従来どおり読めること
- [ ] ナレッジ検索エージェントでタグ→資料指定→内容照会ができ、本文が返ること（例: 三重県研修 PDF）
- [ ] `rag-app` 起動ログに source NFC 移行が出てもエラーにならないこと


Made with [Cursor](https://cursor.com)