### PR TITLE
fix: 添付解除ログアウトと knowledge-mcp ポート公開

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1908,17 +1908,33 @@ async def get_file(key: str) -> FileResponse:
     return FileResponse(full)
 
 
-@app.delete("/file/{file_name:path}")
-async def delete_file(file_name: str) -> dict[str, Any]:
-    # file_name は "files/<uuid>/<name>" 形式（フロントが pathname から生成）
-    key = file_name[len("files/") :] if file_name.startswith("files/") else file_name
+def _delete_stored_file(key: str) -> None:
+    """FILES_DIR 配下のオブジェクトを削除する（存在しなければ何もしない）。"""
+    # 旧フロントが pathname 全体（api/files/... や files/...）を渡す場合を吸収
+    for prefix in ("api/files/", "files/"):
+        if key.startswith(prefix):
+            key = key[len(prefix) :]
+            break
     try:
         full = _safe_path(key)
         if os.path.isfile(full):
             os.remove(full)
     except ValueError:
         pass
-    return None
+
+
+@app.delete("/files/{key:path}")
+async def delete_file_public(key: str) -> dict[str, Any]:
+    """添付ファイル削除（PUT/GET と同じ /files 配下。Authorization 不要）。"""
+    _delete_stored_file(key)
+    return {}
+
+
+@app.delete("/file/{file_name:path}")
+async def delete_file(file_name: str) -> dict[str, Any]:
+    # 互換: 旧フロントの /file/<pathname> 削除
+    _delete_stored_file(file_name)
+    return {}
 
 
 # ---------------------------------------------------------------------------

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -259,7 +259,8 @@ services:
       - qdrant
     restart: unless-stopped
 
-  # ナレッジ検索 MCP（Dify Agent 向け）。外部公開が必要なら ports を追加する。
+  # ナレッジ検索 MCP（Dify Agent 向け）。
+  # host.docker.internal:${KNOWLEDGE_MCP_PORT} で Dify から利用する。
   knowledge-mcp:
     build: ./knowledge-mcp
     container_name: open-genai-knowledge-mcp
@@ -269,6 +270,9 @@ services:
       - RAG_DEFAULT_SCOPE=${RAG_DEFAULT_SCOPE:-00000000-0000-0000-0000-000000000000}
       - MCP_HOST=0.0.0.0
       - MCP_PORT=8002
+    ports:
+      # 無認証のため、公開範囲は KNOWLEDGE_MCP_BIND で絞ること（既定は全インターフェース）。
+      - "${KNOWLEDGE_MCP_BIND:-0.0.0.0}:${KNOWLEDGE_MCP_PORT:-8103}:8002"
     depends_on:
       - rag-app
     restart: unless-stopped

--- a/genai-web/packages/web/src/hooks/useFiles.ts
+++ b/genai-web/packages/web/src/hooks/useFiles.ts
@@ -9,6 +9,26 @@ const extractBaseURL = (url: string) => {
   return url.split(/[?#]/)[0];
 };
 
+/** アップロード URL からストレージキー（`files/<uuid>/<name>`）を取り出す。
+ *
+ * PUBLIC_BASE_URL が `https://host/api` のとき pathname は `/api/files/...` になる。
+ * 先頭の `/api` を誤ってキーに含めると DELETE が 401/失敗し、解除でログアウト扱いになる。
+ */
+const fileKeyFromUrl = (fileUrl: string): string | undefined => {
+  try {
+    const pathname = decodeURIComponent(new URL(fileUrl).pathname);
+    const marker = '/files/';
+    const idx = pathname.indexOf(marker);
+    if (idx >= 0) {
+      return pathname.slice(idx + 1); // files/<uuid>/<name>
+    }
+    const stripped = pathname.replace(/^\//, '');
+    return stripped || undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 const useFilesState = create<{
   uploadFiles: (id: string, files: File[], fileLimit: FileLimit, accept: string[]) => Promise<void>;
   checkFiles: (id: string, fileLimit: FileLimit, accept: string[]) => Promise<void>;
@@ -266,15 +286,8 @@ const useFilesState = create<{
 
     let targetIndex = findTargetIndex();
     if (targetIndex > -1) {
-      // S3 Key にはスラッシュや `:` を含む (例: `{identityId}/{uuid}/{filename}`)
-      // ため、URL のパス部分全体を復号して Key として扱う
       const s3Url = get().uploadedFilesDict[id][targetIndex].s3Url ?? '';
-      let fileName: string | undefined;
-      try {
-        fileName = decodeURIComponent(new URL(s3Url).pathname.replace(/^\//, ''));
-      } catch {
-        fileName = undefined;
-      }
+      const fileName = fileKeyFromUrl(s3Url);
 
       if (fileName) {
         // Set deleting state
@@ -284,15 +297,22 @@ const useFilesState = create<{
           }),
         );
 
-        await fileApi.deleteUploadedFile(fileName);
+        try {
+          await fileApi.deleteUploadedFile(fileName);
+        } catch (error) {
+          // サーバ削除に失敗しても UI 上は外す（再クリックでログアウト等に繋がらないようにする）
+          console.error('Failed to delete uploaded file:', error);
+        }
 
         // 削除処理中に他の画像も削除された場合に、Indexがズレるため再取得する
         targetIndex = findTargetIndex();
-        set(
-          produce((state) => {
-            state.uploadedFilesDict[id].splice(targetIndex, 1);
-          }),
-        );
+        if (targetIndex > -1) {
+          set(
+            produce((state) => {
+              state.uploadedFilesDict[id].splice(targetIndex, 1);
+            }),
+          );
+        }
 
         // Refresh error messages
         await checkFiles(id, fileLimit, accept);

--- a/genai-web/packages/web/src/lib/fileApi.ts
+++ b/genai-web/packages/web/src/lib/fileApi.ts
@@ -62,7 +62,15 @@ export const getFileDownloadSignedUrl = async (s3Url: string) => {
 };
 
 export const deleteUploadedFile = async (fileName: string) => {
-  return genUApi.delete<DeleteFileResponse>(`file/${encodeURIComponent(fileName)}`);
+  // PUT/GET と同じ `/files/<key>` を使う（認証不要の公開パス）。
+  // スラッシュはパス区切りとして残し、セグメント単位でエンコードする。
+  const key = fileName.replace(/^\/+/, '').replace(/^files\//, '');
+  const encoded = key
+    .split('/')
+    .filter(Boolean)
+    .map((seg) => encodeURIComponent(seg))
+    .join('/');
+  return genUApi.delete<DeleteFileResponse>(`files/${encoded}`);
 };
 
 export const getS3Uri = (s3Url: string) => {


### PR DESCRIPTION
## Summary
- チャット添付の「解除」でログアウトしてしまう不具合を修正（削除キーから誤った `api/` を除去し、PUT/GET と同じ `/files` 公開パスで削除）
- 本番 `docker-compose.prod.yml` で knowledge-mcp のホストポート（`:8103`）を公開し、Dify からの MCP 接続断を防ぐ

## Test plan
- [ ] チャットにファイルを添付し「解除」してもログアウトせず、添付が外れること
- [ ] 画像・テキストいずれの添付でも解除できること
- [ ] `host.docker.internal:8103/mcp` に到達でき、ナレッジ検索エージェントが動くこと


Made with [Cursor](https://cursor.com)