### PR TITLE
fix(web): アップロード URL のオブジェクトキー抽出を共通化

### DIFF
--- a/genai-web/packages/web/src/features/transcribe/hooks/useTranscribe.ts
+++ b/genai-web/packages/web/src/features/transcribe/hooks/useTranscribe.ts
@@ -1,3 +1,4 @@
+import { fileObjectKeyFromUrl } from '@/lib/fileUrl';
 import { useTranscribeStore } from '../stores/useTranscribeStore';
 import { useFetchTranscription } from './useFetchTranscription';
 import { useTranscribeApi } from './useTranscribeApi';
@@ -26,8 +27,12 @@ export const useTranscribe = () => {
     // 音声のアップロード
     await api.uploadAudio(signedUrl, { file: targetFile });
 
-    // 署名付き URL から S3 Key を抽出 (`{identityId}/{uuid}/{filename}` 形式)
-    const audioKey = decodeURIComponent(new URL(signedUrl).pathname.replace(/^\//, ''));
+    // 署名付き URL からオブジェクトキーを抽出（/api プレフィックスは含めない）
+    const audioKey = fileObjectKeyFromUrl(signedUrl);
+    if (!audioKey) {
+      setLoading(false);
+      throw new Error('アップロード URL から音声キーを取得できませんでした');
+    }
 
     // 音声認識
     const startTranscriptionRes = await api.startTranscription({

--- a/genai-web/packages/web/src/hooks/useFiles.ts
+++ b/genai-web/packages/web/src/hooks/useFiles.ts
@@ -4,29 +4,10 @@ import { produce } from 'immer';
 import { useCallback } from 'react';
 import { createWithEqualityFn as create } from 'zustand/traditional';
 import * as fileApi from '@/lib/fileApi';
+import { fileObjectKeyFromUrl } from '@/lib/fileUrl';
 
 const extractBaseURL = (url: string) => {
   return url.split(/[?#]/)[0];
-};
-
-/** アップロード URL からストレージキー（`files/<uuid>/<name>`）を取り出す。
- *
- * PUBLIC_BASE_URL が `https://host/api` のとき pathname は `/api/files/...` になる。
- * 先頭の `/api` を誤ってキーに含めると DELETE が 401/失敗し、解除でログアウト扱いになる。
- */
-const fileKeyFromUrl = (fileUrl: string): string | undefined => {
-  try {
-    const pathname = decodeURIComponent(new URL(fileUrl).pathname);
-    const marker = '/files/';
-    const idx = pathname.indexOf(marker);
-    if (idx >= 0) {
-      return pathname.slice(idx + 1); // files/<uuid>/<name>
-    }
-    const stripped = pathname.replace(/^\//, '');
-    return stripped || undefined;
-  } catch {
-    return undefined;
-  }
 };
 
 const useFilesState = create<{
@@ -287,7 +268,7 @@ const useFilesState = create<{
     let targetIndex = findTargetIndex();
     if (targetIndex > -1) {
       const s3Url = get().uploadedFilesDict[id][targetIndex].s3Url ?? '';
-      const fileName = fileKeyFromUrl(s3Url);
+      const fileName = fileObjectKeyFromUrl(s3Url);
 
       if (fileName) {
         // Set deleting state

--- a/genai-web/packages/web/src/lib/fileApi.ts
+++ b/genai-web/packages/web/src/lib/fileApi.ts
@@ -63,7 +63,7 @@ export const getFileDownloadSignedUrl = async (s3Url: string) => {
 
 export const deleteUploadedFile = async (fileName: string) => {
   // PUT/GET と同じ `/files/<key>` を使う（認証不要の公開パス）。
-  // スラッシュはパス区切りとして残し、セグメント単位でエンコードする。
+  // fileName はオブジェクトキー（`<uuid>/<name>`）。スラッシュは区切りとして残す。
   const key = fileName.replace(/^\/+/, '').replace(/^files\//, '');
   const encoded = key
     .split('/')

--- a/genai-web/packages/web/src/lib/fileUrl.ts
+++ b/genai-web/packages/web/src/lib/fileUrl.ts
@@ -1,0 +1,30 @@
+/**
+ * アップロード URL からストレージ上のオブジェクトキーを取り出す。
+ *
+ * PUBLIC_BASE_URL が `https://host/api` のとき pathname は `/api/files/<key>` になる。
+ * 先頭の `/api` をキーに含めると削除・文字起こし開始などが誤動作する。
+ *
+ * @returns 例: `<uuid>/<filename>`（先頭の `files/` は含まない）
+ */
+export const fileObjectKeyFromUrl = (fileUrl: string): string | undefined => {
+  try {
+    const pathname = decodeURIComponent(new URL(fileUrl).pathname);
+    const marker = '/files/';
+    const idx = pathname.indexOf(marker);
+    if (idx >= 0) {
+      const key = pathname.slice(idx + marker.length);
+      return key || undefined;
+    }
+
+    let stripped = pathname.replace(/^\//, '');
+    if (stripped.startsWith('api/')) {
+      stripped = stripped.slice('api/'.length);
+    }
+    if (stripped.startsWith('files/')) {
+      stripped = stripped.slice('files/'.length);
+    }
+    return stripped || undefined;
+  } catch {
+    return undefined;
+  }
+};

--- a/genai-web/packages/web/tests/lib/fileUrl.test.ts
+++ b/genai-web/packages/web/tests/lib/fileUrl.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { fileObjectKeyFromUrl } from '@/lib/fileUrl';
+
+describe('fileObjectKeyFromUrl', () => {
+  it('strips /api prefix from Open GENAI upload URLs', () => {
+    expect(
+      fileObjectKeyFromUrl(
+        'https://paris.example.jp/api/files/84c61db9-bb82-4fc2-9102-eef0e4e65789/image.png',
+      ),
+    ).toBe('84c61db9-bb82-4fc2-9102-eef0e4e65789/image.png');
+  });
+
+  it('handles /files without /api', () => {
+    expect(fileObjectKeyFromUrl('https://example.com/files/uuid/a.wav')).toBe('uuid/a.wav');
+  });
+
+  it('ignores query string', () => {
+    expect(
+      fileObjectKeyFromUrl('https://example.com/api/files/uuid/a.txt?X-Amz-Signature=1'),
+    ).toBe('uuid/a.txt');
+  });
+
+  it('returns undefined for invalid URL', () => {
+    expect(fileObjectKeyFromUrl('not-a-url')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- `/api/files/...` 形式のアップロード URL からオブジェクトキーを正しく取り出す共通ヘルパ `fileObjectKeyFromUrl` を追加
- チャット添付削除（既存修正）と文字起こし開始（`useTranscribe`）の両方で利用
- 単体テストを追加

## Test plan
- [ ] チャット添付の解除がログアウトせず動作すること
- [ ] （文字起こし画面を使う場合）音声アップロード後の開始リクエストの `audioKey` に `api/` が含まれないこと


Made with [Cursor](https://cursor.com)