### PR TITLE
feat: 添付・ナレッジの個人情報検知（警告／ラベル）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@
 
 ## [Unreleased]
 
+### 添付・ナレッジの個人情報検知（警告／ラベル）
+
+- `shared/pii_scan.py`: 氏名・住所・電話番号・マイナンバーを種別付きで検知（匿名化なし）。電話・マイナンバーは正規表現／検査数字、住所はパターン補助、氏名・住所 NER は任意の GiNZA（`PII_INSTALL_NER=1` ビルド）
+- チャット等: `PUT /files` 保存と同時に警告（`warned` / `categories`）。フロントは添付行に種別を表示（送信は可）
+- ナレッジ: 登録を非同期化（`ingest_status`）。ジョブ内で索引化のあと PII 検知し、`DocsSection` にラベル表示。`NGWORD_DB_PATH` を rag-app が backend_data 経由で参照
+- 入力制限画面: 添付警告・ナレッジ検知・NER のトグルを追加
+
 ### 通常チャット添付の大容量対応（その場マップリデュース）
 
 - backend: チャット添付を 30,000 文字で黙って打ち切る挙動を廃止し、`shared/docextract.py` に切り捨てなしの `extract_doc_text_full` を追加（安全弁 `MAX_CHAT_DOC_CHARS` 既定 500,000、超過は明示注記で先頭保持）

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,6 +16,12 @@ RUN apt-get update \
 COPY backend/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
+# 氏名・住所 NER（GiNZA）。未導入でも電話・マイナンバー・住所パターンは動作する。
+ARG PII_INSTALL_NER=0
+RUN if [ "$PII_INSTALL_NER" = "1" ]; then \
+      pip install --no-cache-dir 'ginza>=5.1.3' 'ja-ginza>=5.1.3'; \
+    fi
+
 COPY shared ./shared
 COPY backend/app ./app
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1890,14 +1890,66 @@ async def get_upload_url(request: Request) -> str:
     return f"{PUBLIC_BASE_URL}/files/{key}"
 
 
+def _guess_media_type(filename: str) -> str:
+    """拡張子からおおまかな mediaType を推定する（添付検査用）。"""
+    ext = filename.lower().rsplit(".", 1)[-1] if "." in filename else ""
+    return {
+        "pdf": "application/pdf",
+        "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "txt": "text/plain",
+        "md": "text/markdown",
+        "csv": "text/csv",
+        "tsv": "text/tab-separated-values",
+        "html": "text/html",
+        "htm": "text/html",
+        "json": "application/json",
+        "log": "text/plain",
+    }.get(ext, "")
+
+
 @app.put("/files/{key:path}")
 async def put_file(key: str, request: Request) -> dict[str, Any]:
+    """添付を保存し、抽出可能な本文があれば個人情報を警告検知する（ブロックしない）。"""
     full = _safe_path(key)
     os.makedirs(os.path.dirname(full), exist_ok=True)
     data = await request.body()
     with open(full, "wb") as f:
         f.write(data)
-    return {}
+
+    result: dict[str, Any] = {"warned": False, "categories": []}
+    try:
+        from shared.pii_scan import format_warning_message, load_pii_settings, scan
+        from shared.docextract import extract_doc_text_full
+        import base64 as _b64
+
+        settings = load_pii_settings()
+        if not settings.get("warn_attachments", True):
+            return result
+        filename = os.path.basename(key) or "file"
+        media_type = _guess_media_type(filename)
+        b64 = _b64.b64encode(data).decode("ascii")
+        text = extract_doc_text_full(filename, media_type, b64)
+        if not text or text.startswith("(添付ファイル"):
+            return result
+        scanned = scan(
+            text,
+            enable_ner=bool(settings.get("check_pii_ner", True)),
+            ner_max_chars=int(os.environ.get("PII_NER_MAX_CHARS", "8000")),
+            check_mynumber=bool(settings.get("check_mynumber", True)),
+        )
+        cats = list(scanned.get("categories") or [])
+        hits = list(scanned.get("hits") or [])
+        if cats:
+            result = {
+                "warned": True,
+                "categories": cats,
+                "hits": hits,
+                "message": format_warning_message(scanned),
+            }
+    except Exception as e:  # noqa: BLE001 - 保存自体は成功させる
+        print(f"[files] 個人情報検査をスキップ: {e}")
+    return result
 
 
 @app.get("/files/{key:path}")

--- a/backend/app/ngwords.py
+++ b/backend/app/ngwords.py
@@ -30,6 +30,9 @@ _DEFAULT: dict[str, Any] = {
     "enabled": False,
     "case_sensitive": False,
     "check_mynumber": True,
+    "warn_attachments": True,
+    "scan_knowledge_pii": True,
+    "check_pii_ner": True,
     "words": [],
     "patterns": [],
 }
@@ -75,9 +78,10 @@ def _read_rules() -> dict[str, Any]:
         data = json.loads(row[0])
         if not isinstance(data, dict):
             return dict(_DEFAULT)
-        # 旧ルールにキーが無い場合は既定でマイナンバー検査を有効にする
-        if "check_mynumber" not in data:
-            data["check_mynumber"] = True
+        # 旧ルールにキーが無い場合は既定値を補完する
+        for key, default in _DEFAULT.items():
+            if key not in data:
+                data[key] = default
         return data
     except Exception:  # noqa: BLE001 - 読取不可時は制限なし
         return dict(_DEFAULT)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -39,6 +39,8 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+      args:
+        PII_INSTALL_NER: ${PII_INSTALL_NER:-0}
     container_name: open-genai-backend
     # ホストにポート公開しない（proxy 経由のみ）
     expose:
@@ -223,6 +225,8 @@ services:
     build:
       context: .
       dockerfile: rag-app/Dockerfile
+      args:
+        PII_INSTALL_NER: ${PII_INSTALL_NER:-0}
     container_name: open-genai-rag-app
     environment:
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
@@ -250,8 +254,11 @@ services:
       - URL_REFRESH_INTERVAL=${URL_REFRESH_INTERVAL:-86400}
       # URL 取り込みの SSRF 対策: 生成元の既知ホストのみ許可を推奨（カンマ区切り）
       - URL_FETCH_ALLOWED_HOSTS=${URL_FETCH_ALLOWED_HOSTS:-}
+      # 入力制限ルール（添付警告・ナレッジ PII）を backend と共有
+      - NGWORD_DB_PATH=/ngword-data/ngwords.db
     volumes:
       - rag_app_data:/data
+      - backend_data:/ngword-data:ro
     extra_hosts:
       - "host.docker.internal:host-gateway"
     # embed は profiles で任意起動のため depends_on にしない（埋め込みは呼び出し時のみ必要）。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+      args:
+        PII_INSTALL_NER: ${PII_INSTALL_NER:-0}
     container_name: open-genai-backend
     expose:
       - "8000"
@@ -155,6 +157,8 @@ services:
     build:
       context: .
       dockerfile: rag-app/Dockerfile
+      args:
+        PII_INSTALL_NER: ${PII_INSTALL_NER:-0}
     container_name: open-genai-rag-app
     environment:
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
@@ -172,8 +176,11 @@ services:
       - URL_REFRESH_INTERVAL=${URL_REFRESH_INTERVAL:-86400}
       # URL 取り込みの SSRF 対策: 許可ホスト(カンマ区切り, 空=内部宛先のみ拒否)
       - URL_FETCH_ALLOWED_HOSTS=${URL_FETCH_ALLOWED_HOSTS:-}
+      # 入力制限ルール（添付警告・ナレッジ PII）を backend と共有
+      - NGWORD_DB_PATH=/ngword-data/ngwords.db
     volumes:
       - rag_app_data:/data
+      - backend_data:/ngword-data:ro
     # Dify 等の外部コンテナから host.docker.internal:8001 で Retrieval API を叩けるように公開
     ports:
       - "${RAG_APP_PORT:-8001}:8001"

--- a/genai-web/packages/types/src/message.d.ts
+++ b/genai-web/packages/types/src/message.d.ts
@@ -44,6 +44,16 @@ export type UploadedFileType = {
   uploading: boolean;
   deleting?: boolean;
   errorMessages: string[];
+  /** 個人情報検知の警告（ブロックではない） */
+  piiWarned?: boolean;
+  piiCategories?: string[];
+  piiMessage?: string;
+  piiHits?: Array<{
+    category: string;
+    match: string;
+    context: string;
+    offset?: number;
+  }>;
 };
 
 export type FileLimit = {

--- a/genai-web/packages/web/src/features/chat/components/ChatInput.tsx
+++ b/genai-web/packages/web/src/features/chat/components/ChatInput.tsx
@@ -236,6 +236,34 @@ export const ChatInput = (props: Props) => {
                               uploadedFile.errorMessages.map((error) => (
                                 <p key={error}>＊{error}</p>
                               ))}
+                            {uploadedFile.piiWarned && (
+                              <div className='text-orange-800 whitespace-pre-wrap'>
+                                <p>
+                                  ＊
+                                  {(uploadedFile.piiMessage || '').split('\n')[0] ||
+                                    `個人情報の可能性: ${(uploadedFile.piiCategories ?? []).join('・')}`}
+                                </p>
+                                {(uploadedFile.piiHits ?? []).length > 0 ? (
+                                  <ul className='mt-1 list-disc pl-5 text-dns-14N-130'>
+                                    {(uploadedFile.piiHits ?? []).slice(0, 6).map((h, i) => (
+                                      <li key={`${h.category}-${h.offset ?? i}-${h.match}`}>
+                                        {h.category}: 「{h.context || h.match}」
+                                      </li>
+                                    ))}
+                                  </ul>
+                                ) : (
+                                  (uploadedFile.piiMessage || '')
+                                    .split('\n')
+                                    .slice(1)
+                                    .filter(Boolean)
+                                    .map((line) => (
+                                      <p key={line} className='text-dns-14N-130'>
+                                        {line}
+                                      </p>
+                                    ))
+                                )}
+                              </div>
+                            )}
                           </FileUploadFileInfo>
                           <Button
                             id={`attached-file-${idx}-remove`}

--- a/genai-web/packages/web/src/hooks/useFiles.ts
+++ b/genai-web/packages/web/src/hooks/useFiles.ts
@@ -237,12 +237,16 @@ const useFilesState = create<{
         .then(async (signedUrlRes) => {
           const signedUrl = signedUrlRes.data;
           const fileUrl = extractBaseURL(signedUrl); // 署名付き url からクエリパラメータを除外
-          // ファイルのアップロード
-          fileApi.uploadFile(signedUrl, { file: uploadedFile.file }).then(() => {
+          // ファイルのアップロード（応答に個人情報警告が付く場合がある）
+          fileApi.uploadFile(signedUrl, { file: uploadedFile.file }).then((scan) => {
             set(
               produce((state) => {
                 state.uploadedFilesDict[id][idx].uploading = false;
                 state.uploadedFilesDict[id][idx].s3Url = fileUrl;
+                state.uploadedFilesDict[id][idx].piiWarned = Boolean(scan?.warned);
+                state.uploadedFilesDict[id][idx].piiCategories = scan?.categories ?? [];
+                state.uploadedFilesDict[id][idx].piiHits = scan?.hits ?? [];
+                state.uploadedFilesDict[id][idx].piiMessage = scan?.message;
                 state.base64Cache = {
                   ...state.base64Cache,
                   [fileUrl]: reader.result?.toString() ?? '',

--- a/genai-web/packages/web/src/lib/fetcher.ts
+++ b/genai-web/packages/web/src/lib/fetcher.ts
@@ -160,6 +160,20 @@ export const teamApiFetcher = <T>(url: string): Promise<T> =>
 export const genUApiFetcher = <T>(url: string): Promise<T> =>
   genUApi.get<T>(url).then((res) => res.data);
 
+export type PiiHit = {
+  category: string;
+  match: string;
+  context: string;
+  offset?: number;
+};
+
+export type UploadPutResponse = {
+  warned?: boolean;
+  categories?: string[];
+  hits?: PiiHit[];
+  message?: string;
+};
+
 export const uploadToSignedUrl = async (
   url: string,
   data: File | Blob,
@@ -174,4 +188,14 @@ export const uploadToSignedUrl = async (
     throw new ApiError(res.status, undefined);
   }
   return res;
+};
+
+/** Open GENAI の PUT /files 応答（個人情報警告）を JSON として読む。 */
+export const readUploadPutJson = async (res: Response): Promise<UploadPutResponse> => {
+  try {
+    const data = (await res.clone().json()) as UploadPutResponse;
+    return data && typeof data === 'object' ? data : {};
+  } catch {
+    return {};
+  }
 };

--- a/genai-web/packages/web/src/lib/fileApi.ts
+++ b/genai-web/packages/web/src/lib/fileApi.ts
@@ -6,7 +6,8 @@ import {
   GetFileUploadSignedUrlResponse,
   UploadFileRequest,
 } from 'genai-web';
-import { genUApi, uploadToSignedUrl } from '@/lib/fetcher';
+import { genUApi, readUploadPutJson, uploadToSignedUrl } from '@/lib/fetcher';
+import type { UploadPutResponse } from '@/lib/fetcher';
 
 const parseS3Url = (s3Url: string) => {
   let result = /^s3:\/\/(?<bucketName>.+?)\/(?<prefix>.+)/.exec(s3Url);
@@ -35,8 +36,12 @@ export const getSignedUrl = (req: GetFileUploadSignedUrlRequest) => {
   return genUApi.post<GetFileUploadSignedUrlResponse>('file/url', req);
 };
 
-export const uploadFile = (url: string, req: UploadFileRequest) => {
-  return uploadToSignedUrl(url, req.file, 'file/*');
+export const uploadFile = async (
+  url: string,
+  req: UploadFileRequest,
+): Promise<UploadPutResponse> => {
+  const res = await uploadToSignedUrl(url, req.file, 'file/*');
+  return readUploadPutJson(res);
 };
 
 export const getFileDownloadSignedUrl = async (s3Url: string) => {

--- a/genai-web/packages/web/src/open-genai/admin-ngword/NgWordPage.tsx
+++ b/genai-web/packages/web/src/open-genai/admin-ngword/NgWordPage.tsx
@@ -89,6 +89,7 @@ export const NgWordPage = () => {
             <p>・「入力制限」を有効にすると、禁止ワード・機密情報を含む入力をブロックします。</p>
             <p>・禁止ワードは1行に1語、機密情報パターンは1行に1つの正規表現で入力します。</p>
             <p>・マイナンバー検査は検査用数字が一致する12桁のみブロックします（単なる12桁数字では止めません）。</p>
+            <p>・添付アップロード時の警告とナレッジ登録時の検知は、氏名・住所・電話・マイナンバーを種別付きで表示します（ブロックしません）。</p>
             <p>・システム管理者による管理系アプリの実行は本制限の対象外です。</p>
           </div>
         </Disclosure>
@@ -129,6 +130,9 @@ const RulesEditor = ({ rules, submitting, error, setError, onSave }: EditorProps
   const [enabled, setEnabled] = useState(rules.enabled);
   const [caseSensitive, setCaseSensitive] = useState(rules.case_sensitive);
   const [checkMynumber, setCheckMynumber] = useState(rules.check_mynumber);
+  const [warnAttachments, setWarnAttachments] = useState(rules.warn_attachments ?? true);
+  const [scanKnowledgePii, setScanKnowledgePii] = useState(rules.scan_knowledge_pii ?? true);
+  const [checkPiiNer, setCheckPiiNer] = useState(rules.check_pii_ner ?? true);
   const [words, setWords] = useState((rules.words ?? []).join('\n'));
   const [patterns, setPatterns] = useState((rules.patterns ?? []).join('\n'));
   const [localError, setLocalError] = useState<string | null>(null);
@@ -139,6 +143,9 @@ const RulesEditor = ({ rules, submitting, error, setError, onSave }: EditorProps
     setEnabled(rules.enabled);
     setCaseSensitive(rules.case_sensitive);
     setCheckMynumber(rules.check_mynumber);
+    setWarnAttachments(rules.warn_attachments ?? true);
+    setScanKnowledgePii(rules.scan_knowledge_pii ?? true);
+    setCheckPiiNer(rules.check_pii_ner ?? true);
     setWords((rules.words ?? []).join('\n'));
     setPatterns((rules.patterns ?? []).join('\n'));
     setDone(false);
@@ -161,6 +168,9 @@ const RulesEditor = ({ rules, submitting, error, setError, onSave }: EditorProps
       enabled,
       case_sensitive: caseSensitive,
       check_mynumber: checkMynumber,
+      warn_attachments: warnAttachments,
+      scan_knowledge_pii: scanKnowledgePii,
+      check_pii_ner: checkPiiNer,
       words: toLines(words),
       patterns: toLines(patterns),
     });
@@ -207,6 +217,33 @@ const RulesEditor = ({ rules, submitting, error, setError, onSave }: EditorProps
             onChange={(e) => setCheckMynumber(e.target.checked)}
           />
           マイナンバー検査を行う（検査用数字が一致する12桁のみ）
+        </label>
+        <label className='flex items-center gap-2 text-std-16N-170 text-solid-gray-900'>
+          <input
+            type='checkbox'
+            className='size-5'
+            checked={warnAttachments}
+            onChange={(e) => setWarnAttachments(e.target.checked)}
+          />
+          添付アップロード時に個人情報を警告する（氏名・住所・電話・マイナンバー）
+        </label>
+        <label className='flex items-center gap-2 text-std-16N-170 text-solid-gray-900'>
+          <input
+            type='checkbox'
+            className='size-5'
+            checked={scanKnowledgePii}
+            onChange={(e) => setScanKnowledgePii(e.target.checked)}
+          />
+          ナレッジ登録時に個人情報を検知する（管理画面にラベル表示）
+        </label>
+        <label className='flex items-center gap-2 text-std-16N-170 text-solid-gray-900'>
+          <input
+            type='checkbox'
+            className='size-5'
+            checked={checkPiiNer}
+            onChange={(e) => setCheckPiiNer(e.target.checked)}
+          />
+          氏名・住所の NER 検知を行う（GiNZA。未導入時は電話・マイナンバーと住所パターンのみ）
         </label>
       </fieldset>
 

--- a/genai-web/packages/web/src/open-genai/admin-ngword/types.ts
+++ b/genai-web/packages/web/src/open-genai/admin-ngword/types.ts
@@ -5,6 +5,12 @@ export type NgWordRules = {
   enabled: boolean;
   case_sensitive: boolean;
   check_mynumber: boolean;
+  /** チャット等の添付アップロード時に個人情報を警告する */
+  warn_attachments: boolean;
+  /** ナレッジ登録ジョブ内で個人情報を検知する */
+  scan_knowledge_pii: boolean;
+  /** 氏名・住所の NER（GiNZA）を使う */
+  check_pii_ner: boolean;
   words: string[];
   patterns: string[];
 };

--- a/genai-web/packages/web/src/open-genai/knowledge/DocsSection.tsx
+++ b/genai-web/packages/web/src/open-genai/knowledge/DocsSection.tsx
@@ -157,16 +157,56 @@ export const DocsSection = ({
             <li key={d.doc_id || d.source} className='flex flex-col gap-2 px-4 py-3'>
               <div className='flex flex-wrap items-start justify-between gap-3'>
                 <div className='flex flex-col gap-1'>
-                  <span className='flex items-center gap-2 text-oln-16N-100 break-all'>
+                  <span className='flex flex-wrap items-center gap-2 text-oln-16N-100 break-all'>
                     <ChipLabel className='bg-solid-gray-100 text-solid-gray-800'>
                       {isUrl(d.source) ? 'URL' : d.index_kind === 'tree' ? '構造化' : '全文'}
                     </ChipLabel>
+                    {(d.ingest_status === 'queued' || d.ingest_status === 'processing') && (
+                      <ChipLabel className='bg-solid-gray-200 text-solid-gray-800'>
+                        {d.ingest_status === 'queued' ? '登録待ち' : '登録中'}
+                      </ChipLabel>
+                    )}
+                    {d.ingest_status === 'failed' && (
+                      <ChipLabel className='bg-red-50 text-red-900' title={d.ingest_error || undefined}>
+                        登録失敗
+                      </ChipLabel>
+                    )}
+                    {d.pii_status === 'pending' && d.ingest_status === 'ready' && (
+                      <ChipLabel className='bg-solid-gray-200 text-solid-gray-800'>
+                        個人情報検査中
+                      </ChipLabel>
+                    )}
+                    {d.pii_status === 'suspected' && (
+                      <ChipLabel
+                        className='bg-orange-50 text-orange-900'
+                        title={
+                          (d.pii_hits ?? [])
+                            .slice(0, 5)
+                            .map((h) => `${h.category}: ${h.context || h.match}`)
+                            .join('\n') || (d.pii_labels ?? []).join('・') || undefined
+                        }
+                      >
+                        個人情報: {(d.pii_labels ?? []).join('・') || '検知'}
+                      </ChipLabel>
+                    )}
                     <span className='font-bold'>{d.source}</span>
                   </span>
                   <span className='text-dns-14N-130 text-solid-gray-600'>
                     {d.page_count > 0 ? `${d.page_count} ページ・` : ''}
                     タグ: {(d.tags ?? []).length > 0 ? (d.tags ?? []).join(', ') : 'なし（検索対象外）'}
+                    {d.ingest_status === 'failed' && d.ingest_error
+                      ? `・${d.ingest_error}`
+                      : ''}
                   </span>
+                  {d.pii_status === 'suspected' && (d.pii_hits ?? []).length > 0 && (
+                    <ul className='text-dns-14N-130 text-orange-900 list-disc pl-5'>
+                      {(d.pii_hits ?? []).slice(0, 5).map((h, i) => (
+                        <li key={`${h.category}-${h.offset ?? i}-${h.match}`}>
+                          {h.category}: 「{h.context || h.match}」
+                        </li>
+                      ))}
+                    </ul>
+                  )}
                 </div>
                 {canManage && (
                   <div className='flex shrink-0 gap-2'>

--- a/genai-web/packages/web/src/open-genai/knowledge/RegisterSection.tsx
+++ b/genai-web/packages/web/src/open-genai/knowledge/RegisterSection.tsx
@@ -55,7 +55,9 @@ export const RegisterSection = ({ scope, tags, mutateTags, mutateDocs }: Props) 
       );
       const res = await registerFiles(scope, mode, mergeTags(selected, newTagsText), uploads);
       const count = res.documents?.length ?? 0;
-      success(`${count} 件のドキュメントを登録しました。`);
+      success(
+        `${count} 件の登録を受け付けました。バックグラウンドで索引化・個人情報検査を行います。`,
+      );
       setFiles([]);
       if (fileInputRef.current) {
         fileInputRef.current.value = '';
@@ -77,7 +79,7 @@ export const RegisterSection = ({ scope, tags, mutateTags, mutateDocs }: Props) 
     setBusy(true);
     try {
       await registerUrl(scope, url.trim(), mergeTags(urlSelected, urlNewTagsText));
-      success(`URL を登録しました。`);
+      success('URL の登録を受け付けました。バックグラウンドで取得・検査します。');
       setUrl('');
       setUrlSelected([]);
       setUrlNewTagsText('');

--- a/genai-web/packages/web/src/open-genai/knowledge/types.ts
+++ b/genai-web/packages/web/src/open-genai/knowledge/types.ts
@@ -42,6 +42,19 @@ export type KnowledgeDoc = {
   content_hash?: string;
   /** 索引種別。 */
   index_kind: 'tree' | 'fulltext';
+  /** 非同期登録の状態。 */
+  ingest_status?: 'queued' | 'processing' | 'ready' | 'failed';
+  ingest_error?: string;
+  /** 個人情報検知。 */
+  pii_status?: 'pending' | 'clear' | 'suspected' | 'error';
+  pii_labels?: string[];
+  /** 検知箇所の抜粋（警告表示用） */
+  pii_hits?: Array<{
+    category: string;
+    match: string;
+    context: string;
+    offset?: number;
+  }>;
   created_at?: string;
   updated_at?: string;
 };

--- a/genai-web/packages/web/src/open-genai/knowledge/useKnowledge.ts
+++ b/genai-web/packages/web/src/open-genai/knowledge/useKnowledge.ts
@@ -48,7 +48,20 @@ export const useDocs = (scope: string | undefined, tags?: string[]) => {
           params: { scope: scope!, ...(tagParam ? { tags: tagParam } : {}) },
         })
         .then((r) => r.data),
-    { revalidateOnFocus: false },
+    {
+      revalidateOnFocus: false,
+      // 登録中・PII 検査中がある間だけ短間隔で再取得
+      refreshInterval: (latest) => {
+        const docs = latest?.documents ?? [];
+        const busy = docs.some(
+          (d) =>
+            d.ingest_status === 'queued' ||
+            d.ingest_status === 'processing' ||
+            d.pii_status === 'pending',
+        );
+        return busy ? 2000 : 0;
+      },
+    },
   );
   return { docs: (data?.documents ?? []) as KnowledgeDoc[], error, isLoading, mutate };
 };

--- a/ngword-app/app/main.py
+++ b/ngword-app/app/main.py
@@ -34,6 +34,10 @@ app = FastAPI(title="Open GENAI NG-Word App", version="0.1.0")
 _DEFAULT: dict[str, Any] = {
     "enabled": False,
     "case_sensitive": False,
+    "check_mynumber": True,
+    "warn_attachments": True,
+    "scan_knowledge_pii": True,
+    "check_pii_ner": True,
     "words": [],
     "patterns": [],
 }
@@ -112,6 +116,9 @@ _EXAMPLE = (
     '  "enabled": true,\n'
     '  "case_sensitive": false,\n'
     '  "check_mynumber": true,\n'
+    '  "warn_attachments": true,\n'
+    '  "scan_knowledge_pii": true,\n'
+    '  "check_pii_ner": true,\n'
     '  "words": ["禁止語の例"],\n'
     '  "patterns": []\n'
     '}'
@@ -173,6 +180,43 @@ def _build_schema(rules: dict[str, Any]) -> dict[str, Any]:
             if rules.get("check_mynumber") is False
             else "true",
             "desc": "総務省令の検査用数字で個人番号らしさを判定します（単なる12桁数字では止めません）。",
+            "visibleWhen": set_vw,
+        },
+        "warn_attachments": {
+            "type": "select",
+            "title": "添付アップロード時の個人情報警告",
+            "items": [
+                {"title": "する", "value": "true"},
+                {"title": "しない", "value": "false"},
+            ],
+            "default_value": "false"
+            if rules.get("warn_attachments") is False
+            else "true",
+            "desc": "チャット等の添付保存時に氏名・住所・電話・マイナンバーを警告します（ブロックしません）。",
+            "visibleWhen": set_vw,
+        },
+        "scan_knowledge_pii": {
+            "type": "select",
+            "title": "ナレッジ登録時の個人情報検知",
+            "items": [
+                {"title": "する", "value": "true"},
+                {"title": "しない", "value": "false"},
+            ],
+            "default_value": "false"
+            if rules.get("scan_knowledge_pii") is False
+            else "true",
+            "visibleWhen": set_vw,
+        },
+        "check_pii_ner": {
+            "type": "select",
+            "title": "氏名・住所の NER 検知",
+            "items": [
+                {"title": "する（GiNZA）", "value": "true"},
+                {"title": "しない（電話・マイナンバーのみ）", "value": "false"},
+            ],
+            "default_value": "false"
+            if rules.get("check_pii_ner") is False
+            else "true",
             "visibleWhen": set_vw,
         },
         "words": {
@@ -309,6 +353,9 @@ async def invoke(
                 "enabled": _as_bool(inputs.get("enabled")),
                 "case_sensitive": _as_bool(inputs.get("case_sensitive")),
                 "check_mynumber": _as_bool(inputs.get("check_mynumber", True)),
+                "warn_attachments": _as_bool(inputs.get("warn_attachments", True)),
+                "scan_knowledge_pii": _as_bool(inputs.get("scan_knowledge_pii", True)),
+                "check_pii_ner": _as_bool(inputs.get("check_pii_ner", True)),
                 "words": [w.strip() for w in (inputs.get("words") or "").splitlines() if w.strip()],
                 "patterns": [
                     p.strip() for p in (inputs.get("patterns") or "").splitlines() if p.strip()

--- a/ngword-app/app/ngrules.py
+++ b/ngword-app/app/ngrules.py
@@ -5,6 +5,9 @@
       "enabled": true,
       "case_sensitive": false,
       "check_mynumber": true,
+      "warn_attachments": true,
+      "scan_knowledge_pii": true,
+      "check_pii_ner": true,
       "words": ["禁止語1"],
       "patterns": ["\\\\d{3}-\\\\d{4}"]
     }
@@ -34,6 +37,9 @@ def parse_and_validate(text: str) -> tuple[dict[str, Any] | None, str | None]:
     enabled = bool(data.get("enabled", False))
     case_sensitive = bool(data.get("case_sensitive", False))
     check_mynumber = bool(data.get("check_mynumber", True))
+    warn_attachments = bool(data.get("warn_attachments", True))
+    scan_knowledge_pii = bool(data.get("scan_knowledge_pii", True))
+    check_pii_ner = bool(data.get("check_pii_ner", True))
 
     words = data.get("words", [])
     if not isinstance(words, list) or not all(isinstance(x, str) for x in words):
@@ -53,6 +59,9 @@ def parse_and_validate(text: str) -> tuple[dict[str, Any] | None, str | None]:
             "enabled": enabled,
             "case_sensitive": case_sensitive,
             "check_mynumber": check_mynumber,
+            "warn_attachments": warn_attachments,
+            "scan_knowledge_pii": scan_knowledge_pii,
+            "check_pii_ner": check_pii_ner,
             "words": [str(w) for w in words if w],
             "patterns": [str(p) for p in patterns if p],
         },
@@ -70,6 +79,12 @@ def render_rules(rules: dict[str, Any]) -> str:
         f"- 大文字小文字の区別: {'する' if rules.get('case_sensitive') else 'しない'}",
         f"- マイナンバー検査（検査数字）: "
         f"{'する' if rules.get('check_mynumber', True) else 'しない'}",
+        f"- 添付アップロード時の個人情報警告: "
+        f"{'する' if rules.get('warn_attachments', True) else 'しない'}",
+        f"- ナレッジ登録時の個人情報検知: "
+        f"{'する' if rules.get('scan_knowledge_pii', True) else 'しない'}",
+        f"- 氏名・住所の NER 検知: "
+        f"{'する' if rules.get('check_pii_ner', True) else 'しない'}",
         f"- 禁止ワード数: {len(words)}",
         f"- 機密パターン数: {len(patterns)}",
     ]

--- a/rag-app/Dockerfile
+++ b/rag-app/Dockerfile
@@ -9,6 +9,12 @@ ENV PYTHONUNBUFFERED=1 \
 COPY rag-app/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
+# 氏名・住所 NER（GiNZA）。未導入でも電話・マイナンバー・住所パターンは動作する。
+ARG PII_INSTALL_NER=0
+RUN if [ "$PII_INSTALL_NER" = "1" ]; then \
+      pip install --no-cache-dir 'ginza>=5.1.3' 'ja-ginza>=5.1.3'; \
+    fi
+
 COPY shared ./shared
 COPY rag-app/app ./app
 

--- a/rag-app/app/docstore.py
+++ b/rag-app/app/docstore.py
@@ -60,6 +60,26 @@ def init_db() -> None:
             conn.execute(
                 "ALTER TABLE docs ADD COLUMN index_kind TEXT NOT NULL DEFAULT 'tree'"
             )
+        if "ingest_status" not in cols:
+            conn.execute(
+                "ALTER TABLE docs ADD COLUMN ingest_status TEXT NOT NULL DEFAULT 'ready'"
+            )
+        if "ingest_error" not in cols:
+            conn.execute(
+                "ALTER TABLE docs ADD COLUMN ingest_error TEXT NOT NULL DEFAULT ''"
+            )
+        if "pii_status" not in cols:
+            conn.execute(
+                "ALTER TABLE docs ADD COLUMN pii_status TEXT NOT NULL DEFAULT 'clear'"
+            )
+        if "pii_labels" not in cols:
+            conn.execute(
+                "ALTER TABLE docs ADD COLUMN pii_labels TEXT NOT NULL DEFAULT '[]'"
+            )
+        if "pii_hits" not in cols:
+            conn.execute(
+                "ALTER TABLE docs ADD COLUMN pii_hits TEXT NOT NULL DEFAULT '[]'"
+            )
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS pages (
@@ -67,6 +87,19 @@ def init_db() -> None:
               page INTEGER NOT NULL,
               text TEXT NOT NULL,
               PRIMARY KEY (doc_id, page),
+              FOREIGN KEY (doc_id) REFERENCES docs(doc_id) ON DELETE CASCADE
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS ingest_payloads (
+              doc_id TEXT PRIMARY KEY,
+              kind TEXT NOT NULL,
+              mode TEXT NOT NULL DEFAULT 'tree',
+              media_type TEXT NOT NULL DEFAULT '',
+              content_b64 TEXT NOT NULL DEFAULT '',
+              url TEXT NOT NULL DEFAULT '',
               FOREIGN KEY (doc_id) REFERENCES docs(doc_id) ON DELETE CASCADE
             )
             """
@@ -161,7 +194,8 @@ def upsert_document(
             conn.execute(
                 """
                 UPDATE docs SET source = ?, tags = ?, page_count = ?, char_count = ?,
-                  truncated = ?, content_hash = ?, index_kind = ?, updated_at = ?
+                  truncated = ?, content_hash = ?, index_kind = ?, updated_at = ?,
+                  ingest_status = 'ready', ingest_error = ''
                 WHERE doc_id = ?
                 """,
                 (
@@ -182,8 +216,9 @@ def upsert_document(
                 """
                 INSERT INTO docs (
                   doc_id, scope, source, tags, page_count, char_count,
-                  truncated, content_hash, index_kind, created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                  truncated, content_hash, index_kind, created_at, updated_at,
+                  ingest_status, ingest_error, pii_status, pii_labels
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'ready', '', 'pending', '[]')
                 """,
                 (
                     doc_id,
@@ -228,6 +263,26 @@ def upsert_document(
     return doc_id  # type: ignore[return-value]
 
 
+def _parse_pii_labels(raw: str | None) -> list[str]:
+    try:
+        v = json.loads(raw or "[]")
+        if isinstance(v, list):
+            return [str(x) for x in v if x]
+        return []
+    except (json.JSONDecodeError, TypeError):
+        return []
+
+
+def _parse_pii_hits(raw: str | None) -> list[dict[str, Any]]:
+    try:
+        v = json.loads(raw or "[]")
+        if isinstance(v, list):
+            return [x for x in v if isinstance(x, dict)]
+        return []
+    except (json.JSONDecodeError, TypeError):
+        return []
+
+
 def _normalize_doc_row(r: sqlite3.Row | dict[str, Any]) -> dict[str, Any]:
     d = dict(r)
     d["tags"] = _parse_tags(d.get("tags"))
@@ -238,6 +293,17 @@ def _normalize_doc_row(r: sqlite3.Row | dict[str, Any]) -> dict[str, Any]:
     d["source"] = textnorm.normalize_source(d.get("source") or "") or (
         d.get("source") or ""
     )
+    status = (d.get("ingest_status") or "ready").strip().lower()
+    if status not in ("queued", "processing", "ready", "failed"):
+        status = "ready"
+    d["ingest_status"] = status
+    d["ingest_error"] = d.get("ingest_error") or ""
+    pii = (d.get("pii_status") or "clear").strip().lower()
+    if pii not in ("pending", "clear", "suspected", "error"):
+        pii = "clear"
+    d["pii_status"] = pii
+    d["pii_labels"] = _parse_pii_labels(d.get("pii_labels"))
+    d["pii_hits"] = _parse_pii_hits(d.get("pii_hits"))
     return d
 
 
@@ -246,7 +312,8 @@ def list_docs(scope: str, tags: list[str] | None = None) -> list[dict[str, Any]]
         rows = conn.execute(
             """
             SELECT doc_id, scope, source, tags, page_count, char_count,
-                   truncated, content_hash, index_kind, created_at, updated_at
+                   truncated, content_hash, index_kind, created_at, updated_at,
+                   ingest_status, ingest_error, pii_status, pii_labels, pii_hits
             FROM docs WHERE scope = ? ORDER BY source
             """,
             (scope,),
@@ -403,8 +470,178 @@ def delete_by_source(scope: str, source: str) -> bool:
     if not doc:
         return False
     with _connect() as conn:
+        conn.execute("DELETE FROM ingest_payloads WHERE doc_id = ?", (doc["doc_id"],))
         conn.execute("DELETE FROM docs WHERE doc_id = ?", (doc["doc_id"],))
     return True
+
+
+def enqueue_file(
+    *,
+    scope: str,
+    source: str,
+    tags: list[str] | None,
+    mode: str,
+    media_type: str,
+    content_b64: str,
+) -> dict[str, Any]:
+    """非同期登録用に stub 行と payload を作成し queued で返す。"""
+    now = _now()
+    source = textnorm.normalize_source(source) or "unknown"
+    kind = (mode or "tree").strip().lower()
+    if kind not in ("tree", "fulltext"):
+        kind = "tree"
+    tags_s = _tags_json(tags)
+    with _connect() as conn:
+        existing = conn.execute(
+            "SELECT doc_id FROM docs WHERE scope = ? AND source = ?",
+            (scope, source),
+        ).fetchone()
+        if existing:
+            doc_id = existing["doc_id"]
+            conn.execute(
+                """
+                UPDATE docs SET tags = ?, index_kind = ?, updated_at = ?,
+                  ingest_status = 'queued', ingest_error = '',
+                  pii_status = 'pending', pii_labels = '[]'
+                WHERE doc_id = ?
+                """,
+                (tags_s, kind, now, doc_id),
+            )
+            conn.execute("DELETE FROM ingest_payloads WHERE doc_id = ?", (doc_id,))
+        else:
+            doc_id = new_doc_id()
+            conn.execute(
+                """
+                INSERT INTO docs (
+                  doc_id, scope, source, tags, page_count, char_count,
+                  truncated, content_hash, index_kind, created_at, updated_at,
+                  ingest_status, ingest_error, pii_status, pii_labels
+                ) VALUES (?, ?, ?, ?, 0, 0, 0, '', ?, ?, ?, 'queued', '', 'pending', '[]')
+                """,
+                (doc_id, scope, source, tags_s, kind, now, now),
+            )
+        conn.execute(
+            """
+            INSERT INTO ingest_payloads (doc_id, kind, mode, media_type, content_b64, url)
+            VALUES (?, 'file', ?, ?, ?, '')
+            """,
+            (doc_id, kind, media_type or "", content_b64 or ""),
+        )
+    doc = get_doc(doc_id, scope)
+    return doc or {"doc_id": doc_id, "scope": scope, "source": source}
+
+
+def enqueue_url(
+    *,
+    scope: str,
+    url: str,
+    tags: list[str] | None,
+) -> dict[str, Any]:
+    """URL 登録を queued で受け付ける。"""
+    now = _now()
+    source = textnorm.normalize_source(url) or url
+    tags_s = _tags_json(tags)
+    with _connect() as conn:
+        existing = conn.execute(
+            "SELECT doc_id FROM docs WHERE scope = ? AND source = ?",
+            (scope, source),
+        ).fetchone()
+        if existing:
+            doc_id = existing["doc_id"]
+            conn.execute(
+                """
+                UPDATE docs SET tags = ?, index_kind = 'fulltext', updated_at = ?,
+                  ingest_status = 'queued', ingest_error = '',
+                  pii_status = 'pending', pii_labels = '[]'
+                WHERE doc_id = ?
+                """,
+                (tags_s, now, doc_id),
+            )
+            conn.execute("DELETE FROM ingest_payloads WHERE doc_id = ?", (doc_id,))
+        else:
+            doc_id = new_doc_id()
+            conn.execute(
+                """
+                INSERT INTO docs (
+                  doc_id, scope, source, tags, page_count, char_count,
+                  truncated, content_hash, index_kind, created_at, updated_at,
+                  ingest_status, ingest_error, pii_status, pii_labels
+                ) VALUES (?, ?, ?, ?, 0, 0, 0, '', 'fulltext', ?, ?, 'queued', '', 'pending', '[]')
+                """,
+                (doc_id, scope, source, tags_s, now, now),
+            )
+        conn.execute(
+            """
+            INSERT INTO ingest_payloads (doc_id, kind, mode, media_type, content_b64, url)
+            VALUES (?, 'url', 'fulltext', '', '', ?)
+            """,
+            (doc_id, url),
+        )
+    doc = get_doc(doc_id, scope)
+    return doc or {"doc_id": doc_id, "scope": scope, "source": source}
+
+
+def get_ingest_payload(doc_id: str) -> dict[str, Any] | None:
+    with _connect() as conn:
+        r = conn.execute(
+            "SELECT * FROM ingest_payloads WHERE doc_id = ?", (doc_id,)
+        ).fetchone()
+    return dict(r) if r else None
+
+
+def delete_ingest_payload(doc_id: str) -> None:
+    with _connect() as conn:
+        conn.execute("DELETE FROM ingest_payloads WHERE doc_id = ?", (doc_id,))
+
+
+def set_ingest_status(
+    doc_id: str,
+    status: str,
+    *,
+    error: str = "",
+) -> None:
+    with _connect() as conn:
+        conn.execute(
+            """
+            UPDATE docs SET ingest_status = ?, ingest_error = ?, updated_at = ?
+            WHERE doc_id = ?
+            """,
+            (status, error or "", _now(), doc_id),
+        )
+
+
+def set_pii_result(
+    doc_id: str,
+    *,
+    pii_status: str,
+    pii_labels: list[str] | None = None,
+    pii_hits: list[dict[str, Any]] | None = None,
+) -> None:
+    with _connect() as conn:
+        conn.execute(
+            """
+            UPDATE docs SET pii_status = ?, pii_labels = ?, pii_hits = ?, updated_at = ?
+            WHERE doc_id = ?
+            """,
+            (
+                pii_status,
+                json.dumps(pii_labels or [], ensure_ascii=False),
+                json.dumps(pii_hits or [], ensure_ascii=False),
+                _now(),
+                doc_id,
+            ),
+        )
+
+
+def list_ingest_job_ids(statuses: list[str] | None = None) -> list[str]:
+    wanted = statuses or ["queued", "processing"]
+    placeholders = ",".join("?" for _ in wanted)
+    with _connect() as conn:
+        rows = conn.execute(
+            f"SELECT doc_id FROM docs WHERE ingest_status IN ({placeholders})",
+            wanted,
+        ).fetchall()
+    return [str(r["doc_id"]) for r in rows]
 
 
 def delete_scope(scope: str) -> int:

--- a/rag-app/app/main.py
+++ b/rag-app/app/main.py
@@ -24,6 +24,7 @@ from fastapi import FastAPI, Header, Request
 from fastapi.responses import JSONResponse
 
 from shared.docextract import DocExtractError, extract_doc_text
+from shared.pii_scan import load_pii_settings, scan as pii_scan
 
 from . import (
     docstore,
@@ -401,6 +402,18 @@ async def _startup() -> None:
         asyncio.create_task(_url_refresh_loop())
     except Exception as e:  # noqa: BLE001
         print(f"[rag-app] URL 自動更新スケジューラ起動をスキップ: {e}")
+    # 再起動で残った登録ジョブのリカバリ
+    try:
+        for jid in docstore.list_ingest_job_ids(["processing"]):
+            docstore.set_ingest_status(
+                jid, "failed", error="プロセス再起動により処理が中断されました。"
+            )
+            docstore.set_pii_result(jid, pii_status="error", pii_labels=[])
+            docstore.delete_ingest_payload(jid)
+        for jid in docstore.list_ingest_job_ids(["queued"]):
+            _schedule_ingest_job(jid)
+    except Exception as e:  # noqa: BLE001
+        print(f"[rag-app] ingest ジョブリカバリをスキップ: {e}")
     # RAG_SEED_SAMPLES=false で起動時のサンプル自動投入を無効化できる（本番想定）。
     seed_samples = os.environ.get("RAG_SEED_SAMPLES", "true").lower() != "false"
     try:
@@ -983,7 +996,7 @@ async def _kb_delete_tag(scope: str, name: str) -> None:
 async def _kb_register_files(
     scope: str, files: list[dict[str, str]], tags: list[str], mode: str
 ) -> list[dict[str, Any]]:
-    """ファイル群を取り込む。mode='tree'（構造化）/'fulltext'（簡易・全文）。"""
+    """ファイル群を同期取り込み（invoke 互換・テスト用）。"""
     if tags:
         tagstore.ensure_tags(scope, tags)
     results: list[dict[str, Any]] = []
@@ -1025,6 +1038,161 @@ async def _kb_register_url(scope: str, url: str, tags: list[str]) -> dict[str, A
     urlstore.add_url(scope, url, tags, title)
     urlstore.mark_fetched(scope, url, content_hash, title)
     return {"url": url, "title": title, "added_chunks": added}
+
+
+async def _apply_pii_for_doc(doc_id: str) -> None:
+    """索引済みドキュメント本文を個人情報検知し pii_* を更新する。"""
+    settings = load_pii_settings()
+    if not settings.get("scan_knowledge_pii", True):
+        docstore.set_pii_result(doc_id, pii_status="clear", pii_labels=[])
+        return
+    pages = docstore.get_all_pages(doc_id)
+    text = "\n\n".join((p.get("text") or "") for p in pages)
+    if not text.strip():
+        docstore.set_pii_result(doc_id, pii_status="clear", pii_labels=[])
+        return
+    try:
+        result = pii_scan(
+            text,
+            enable_ner=bool(settings.get("check_pii_ner", True)),
+            # ナレッジは非同期のため大きめ上限（同期アップロードの 8k とは別）
+            ner_max_chars=int(os.environ.get("PII_KNOWLEDGE_NER_MAX_CHARS", "200000")),
+            check_mynumber=bool(settings.get("check_mynumber", True)),
+        )
+        cats = list(result.get("categories") or [])
+        hits = list(result.get("hits") or [])
+        docstore.set_pii_result(
+            doc_id,
+            pii_status="suspected" if cats else "clear",
+            pii_labels=cats,
+            pii_hits=hits,
+        )
+    except Exception as e:  # noqa: BLE001
+        print(f"[rag-app] PII 検知失敗 doc_id={doc_id}: {e}")
+        docstore.set_pii_result(doc_id, pii_status="error", pii_labels=[])
+
+
+async def _run_ingest_job(doc_id: str) -> None:
+    """queued ドキュメントをバックグラウンドで索引化し、続けて PII 検知する。"""
+    payload = docstore.get_ingest_payload(doc_id)
+    doc = docstore.get_doc(doc_id)
+    if not payload or not doc:
+        return
+    scope = doc["scope"]
+    source = doc["source"]
+    tags = list(doc.get("tags") or [])
+    docstore.set_ingest_status(doc_id, "processing")
+    try:
+        kind = (payload.get("kind") or "file").strip().lower()
+        if kind == "url":
+            url = (payload.get("url") or source or "").strip()
+            await _kb_register_url(scope, url, tags)
+            # ingest_url 経路でも doc 行が upsert される。doc_id が変わった場合に備える
+            fresh = docstore.get_doc_by_source(scope, url) or docstore.get_doc(doc_id)
+            target_id = (fresh or {}).get("doc_id") or doc_id
+        else:
+            mode = (payload.get("mode") or "tree").strip().lower()
+            media_type = payload.get("media_type") or ""
+            content_b64 = payload.get("content_b64") or ""
+            if mode == "fulltext":
+                info = await tree_ingest.ingest_fulltext_file(
+                    scope=scope,
+                    filename=source,
+                    media_type=media_type,
+                    content_b64=content_b64,
+                    tags=tags,
+                    also_vector=True,
+                )
+            else:
+                info = await tree_ingest.ingest_structured_file(
+                    scope=scope,
+                    filename=source,
+                    media_type=media_type,
+                    content_b64=content_b64,
+                    tags=tags,
+                    also_vector=True,
+                )
+            target_id = info.get("doc_id") or doc_id
+
+        docstore.set_ingest_status(target_id, "ready")
+        await _apply_pii_for_doc(target_id)
+        docstore.delete_ingest_payload(doc_id)
+        if target_id != doc_id:
+            docstore.delete_ingest_payload(target_id)
+    except DocExtractError as e:
+        docstore.set_ingest_status(doc_id, "failed", error=str(e))
+        docstore.set_pii_result(doc_id, pii_status="error", pii_labels=[])
+        docstore.delete_ingest_payload(doc_id)
+    except KnowledgeError as e:
+        docstore.set_ingest_status(doc_id, "failed", error=str(e))
+        docstore.set_pii_result(doc_id, pii_status="error", pii_labels=[])
+        docstore.delete_ingest_payload(doc_id)
+    except Exception as e:  # noqa: BLE001
+        print(f"[rag-app] ingest job 失敗 doc_id={doc_id}: {e}")
+        docstore.set_ingest_status(doc_id, "failed", error=str(e))
+        docstore.set_pii_result(doc_id, pii_status="error", pii_labels=[])
+        docstore.delete_ingest_payload(doc_id)
+
+
+def _schedule_ingest_job(doc_id: str) -> None:
+    try:
+        asyncio.create_task(_run_ingest_job(doc_id))
+    except Exception as e:  # noqa: BLE001
+        print(f"[rag-app] ingest job 起動失敗: {e}")
+
+
+async def _kb_enqueue_files(
+    scope: str, files: list[dict[str, str]], tags: list[str], mode: str
+) -> list[dict[str, Any]]:
+    """ファイル登録を受け付け、バックグラウンド処理を開始する。"""
+    if tags:
+        tagstore.ensure_tags(scope, tags)
+    results: list[dict[str, Any]] = []
+    for f in files:
+        filename = f.get("filename") or "uploaded"
+        media_type = f.get("media_type") or f.get("type") or ""
+        content_b64 = f.get("content") or ""
+        doc = docstore.enqueue_file(
+            scope=scope,
+            source=filename,
+            tags=tags,
+            mode=mode,
+            media_type=media_type,
+            content_b64=content_b64,
+        )
+        _schedule_ingest_job(doc["doc_id"])
+        results.append(
+            {
+                "doc_id": doc["doc_id"],
+                "source": doc.get("source") or filename,
+                "page_count": int(doc.get("page_count") or 0),
+                "char_count": int(doc.get("char_count") or 0),
+                "vector_chunks": 0,
+                "index_kind": doc.get("index_kind") or mode,
+                "ingest_status": doc.get("ingest_status") or "queued",
+                "pii_status": doc.get("pii_status") or "pending",
+                "pii_labels": doc.get("pii_labels") or [],
+            }
+        )
+    return results
+
+
+async def _kb_enqueue_url(scope: str, url: str, tags: list[str]) -> dict[str, Any]:
+    url = (url or "").strip()
+    if not url.startswith("http://") and not url.startswith("https://"):
+        raise KnowledgeError("http(s):// で始まる URL を指定してください。")
+    if tags:
+        tagstore.ensure_tags(scope, tags)
+    doc = docstore.enqueue_url(scope=scope, url=url, tags=tags)
+    _schedule_ingest_job(doc["doc_id"])
+    return {
+        "url": url,
+        "title": "",
+        "added_chunks": 0,
+        "doc_id": doc["doc_id"],
+        "ingest_status": doc.get("ingest_status") or "queued",
+        "pii_status": doc.get("pii_status") or "pending",
+    }
 
 
 async def _kb_delete_source(scope: str, source: str) -> None:
@@ -1603,12 +1771,10 @@ async def api_register(
     if not files:
         return JSONResponse(status_code=400, content={"error": "登録するファイルを添付してください。"})
     try:
-        infos = await _kb_register_files(scope, files, tags, mode)
-    except DocExtractError as e:
-        return JSONResponse(status_code=400, content={"error": str(e)})
+        infos = await _kb_enqueue_files(scope, files, tags, mode)
     except Exception as e:  # noqa: BLE001
         return JSONResponse(status_code=500, content={"error": str(e)})
-    return {"ok": True, "scope": scope, "mode": mode, "documents": infos}
+    return {"ok": True, "accepted": True, "scope": scope, "mode": mode, "documents": infos}
 
 
 @app.post("/knowledge/urls")
@@ -1631,14 +1797,12 @@ async def api_register_url(
         return JSONResponse(status_code=403, content=_FORBIDDEN_MANAGE)
     tags = _parse_tags(body.get("tags"))
     try:
-        r = await _kb_register_url(scope, body.get("url") or "", tags)
+        r = await _kb_enqueue_url(scope, body.get("url") or "", tags)
     except KnowledgeError as e:
         return JSONResponse(status_code=400, content={"error": str(e)})
-    except httpx.HTTPError as e:
-        return JSONResponse(status_code=400, content={"error": f"URL の取得に失敗しました: {e}"})
     except Exception as e:  # noqa: BLE001
         return JSONResponse(status_code=500, content={"error": str(e)})
-    return {"ok": True, "scope": scope, **r}
+    return {"ok": True, "accepted": True, "scope": scope, **r}
 
 
 @app.post("/knowledge/urls/delete")

--- a/shared/pii_scan.py
+++ b/shared/pii_scan.py
@@ -1,0 +1,364 @@
+"""個人情報の検知（氏名・住所・電話番号・マイナンバー）。
+
+- 検知のみ（匿名化・マスクは行わない）。
+- 警告 UI 用に、検知箇所の短い抜粋（match / context）を返す。
+- GiNZA が無い／失敗時は氏名をスキップし、住所は正規表現補助のみ。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+from typing import Any
+
+from shared.mynumber import find_valid_mynumbers
+
+# 表示用ラベル（この集合以外は返さない）
+CAT_NAME = "氏名"
+CAT_ADDRESS = "住所"
+CAT_PHONE = "電話番号"
+CAT_MYNUMBER = "マイナンバー"
+ALL_CATEGORIES = (CAT_NAME, CAT_ADDRESS, CAT_PHONE, CAT_MYNUMBER)
+
+# 同期経路の NER 上限（文字）
+DEFAULT_NER_MAX_CHARS = int(os.environ.get("PII_NER_MAX_CHARS", "8000"))
+# 警告に載せる抜粋の最大件数（種別ごと）
+MAX_HITS_PER_CATEGORY = int(os.environ.get("PII_MAX_HITS_PER_CATEGORY", "5"))
+CONTEXT_RADIUS = 24
+
+NGWORD_DB_PATH = os.environ.get("NGWORD_DB_PATH", "/data/ngwords.db")
+
+# 国内電話（0 始まり、区切り任意）。短すぎる一致を避けるため桁数を見る。
+_PHONE_RE = re.compile(
+    r"(?<!\d)(?:0\d{1,4}[-−ー－]\d{1,4}[-−ー－]\d{3,4}|0[789]0[-−ー－]?\d{4}[-−ー－]?\d{4}|0\d{9,10})(?!\d)"
+)
+
+# 都道府県＋市区町村を含む住所っぽい並び（補助。NER と併用）
+_ADDRESS_RE = re.compile(
+    r"(?:東京都|北海道|(?:京都|大阪)府|"
+    r"(?:青森|岩手|宮城|秋田|山形|福島|茨城|栃木|群馬|埼玉|千葉|神奈川|"
+    r"新潟|富山|石川|福井|山梨|長野|岐阜|静岡|愛知|三重|滋賀|奈良|和歌山|"
+    r"鳥取|島根|岡山|広島|山口|徳島|香川|愛媛|高知|福岡|佐賀|長崎|熊本|"
+    r"大分|宮崎|鹿児島|沖縄)県)"
+    r"[^\s\n　]{1,40}?(?:市|区|町|村)"
+)
+
+_UUID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+
+# 氏名 NER の明らかな誤検知を落とす
+_CJK_RE = re.compile(r"[\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff]")
+_PERSON_REJECT_RE = re.compile(
+    r"(AI|OSPO|エージェント|モデル|システム|デジタル|サーバ|クラウド|メッシュ|"
+    r"右中央|左中央|右上|左上|右下|左下|中央|吹き出し)",
+    re.IGNORECASE,
+)
+
+_DEFAULT_SETTINGS: dict[str, Any] = {
+    "warn_attachments": True,
+    "scan_knowledge_pii": True,
+    "check_pii_ner": True,
+    "check_mynumber": True,
+}
+
+_nlp = None
+_nlp_failed = False
+
+
+def _mask_uuids(text: str) -> str:
+    return _UUID_RE.sub("[UUID]", text)
+
+
+def load_pii_settings() -> dict[str, Any]:
+    """ngwords.db のルールから PII 関連フラグを読む（読取専用・失敗時は既定）。"""
+    out = dict(_DEFAULT_SETTINGS)
+    path = os.environ.get("NGWORD_DB_PATH", NGWORD_DB_PATH)
+    if not os.path.exists(path):
+        return out
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=5)
+        try:
+            row = conn.execute("SELECT rules FROM ngword_rules WHERE id = 1").fetchone()
+        finally:
+            conn.close()
+        if not row or not row[0]:
+            return out
+        data = json.loads(row[0])
+        if not isinstance(data, dict):
+            return out
+        for key in _DEFAULT_SETTINGS:
+            if key in data:
+                out[key] = bool(data[key])
+        return out
+    except Exception:  # noqa: BLE001
+        return out
+
+
+def _phone_digits(s: str) -> str:
+    return re.sub(r"\D", "", s)
+
+
+def _context(text: str, start: int, end: int, radius: int = CONTEXT_RADIUS) -> str:
+    a = max(0, start - radius)
+    b = min(len(text), end + radius)
+    frag = text[a:b].replace("\n", " ").replace("\r", " ")
+    frag = re.sub(r"\s+", " ", frag).strip()
+    prefix = "…" if a > 0 else ""
+    suffix = "…" if b < len(text) else ""
+    return f"{prefix}{frag}{suffix}"
+
+
+def _hit(category: str, match: str, context: str, start: int) -> dict[str, Any]:
+    return {
+        "category": category,
+        "match": match.strip(),
+        "context": context,
+        "offset": start,
+    }
+
+
+def _looks_like_person_name(text: str) -> bool:
+    """GiNZA Person の誤検知をある程度落とす。"""
+    t = (text or "").strip()
+    if not t or len(t) < 2 or len(t) > 20:
+        return False
+    if not _CJK_RE.search(t):
+        return False  # 英数字のみ（OSPO 等）は除外
+    if _PERSON_REJECT_RE.search(t):
+        return False
+    # 「生成AI・AI」のように記号・英字が混ざる複合語は除外
+    if "・" in t or "/" in t:
+        return False
+    ascii_letters = sum(1 for c in t if ("A" <= c <= "Z") or ("a" <= c <= "z"))
+    if ascii_letters >= 2:
+        return False
+    return True
+
+
+def find_phone_hits(text: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    if not text:
+        return out
+    for m in _PHONE_RE.finditer(text):
+        digits = _phone_digits(m.group(0))
+        if len(digits) in (10, 11) and digits.startswith("0"):
+            out.append(
+                _hit(CAT_PHONE, m.group(0), _context(text, m.start(), m.end()), m.start())
+            )
+            if len(out) >= MAX_HITS_PER_CATEGORY:
+                break
+    return out
+
+
+def find_address_hits(text: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    if not text:
+        return out
+    for m in _ADDRESS_RE.finditer(text):
+        out.append(
+            _hit(CAT_ADDRESS, m.group(0), _context(text, m.start(), m.end()), m.start())
+        )
+        if len(out) >= MAX_HITS_PER_CATEGORY:
+            break
+    return out
+
+
+def find_mynumber_hits(text: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    if not text:
+        return out
+    for m in re.finditer(r"\d{12}", text):
+        val = m.group(0)
+        if val in find_valid_mynumbers(val):
+            # 表示は一部マスク（アップロード者向けでも丸ごと出さない）
+            masked = val[:4] + "****" + val[-4:]
+            out.append(
+                _hit(CAT_MYNUMBER, masked, _context(text, m.start(), m.end()), m.start())
+            )
+            if len(out) >= MAX_HITS_PER_CATEGORY:
+                break
+    return out
+
+
+def _get_nlp():  # type: ignore[no-untyped-def]
+    global _nlp, _nlp_failed
+    if _nlp_failed:
+        return None
+    if _nlp is not None:
+        return _nlp
+    try:
+        import spacy  # type: ignore
+
+        # ginza 5.2 + spacy 3.8 で compound_splitter の split_mode=None が落ちるため除外
+        load_kw = {"exclude": ["compound_splitter"]}
+        try:
+            _nlp = spacy.load("ja_ginza", **load_kw)
+        except Exception:  # noqa: BLE001
+            try:
+                _nlp = spacy.load("ja_ginza_electra", **load_kw)
+            except Exception:  # noqa: BLE001
+                _nlp = spacy.load("ja_ginza")
+        return _nlp
+    except Exception as e:  # noqa: BLE001
+        print(f"[pii_scan] GiNZA 読込失敗（氏名 NER は無効）: {e}")
+        _nlp_failed = True
+        return None
+
+
+def _ner_hits(text: str, *, max_chars: int) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """(氏名 hits, 住所 hits)。"""
+    name_hits: list[dict[str, Any]] = []
+    addr_hits: list[dict[str, Any]] = []
+    if not text:
+        return name_hits, addr_hits
+    nlp = _get_nlp()
+    if nlp is None:
+        return name_hits, addr_hits
+    sample = text if len(text) <= max_chars else text[:max_chars]
+    try:
+        disable = [p for p in nlp.pipe_names if p not in ("tok2vec", "ner")]
+        with nlp.select_pipes(disable=disable):
+            doc = nlp(sample)
+    except Exception:  # noqa: BLE001
+        try:
+            doc = nlp(sample)
+        except Exception:  # noqa: BLE001
+            return name_hits, addr_hits
+
+    for ent in doc.ents:
+        label = (ent.label_ or "").upper()
+        span = ent.text.strip()
+        if label == "PERSON" or label.startswith("PERSON"):
+            if not _looks_like_person_name(span):
+                continue
+            if len(name_hits) < MAX_HITS_PER_CATEGORY:
+                name_hits.append(
+                    _hit(
+                        CAT_NAME,
+                        span,
+                        _context(sample, ent.start_char, ent.end_char),
+                        ent.start_char,
+                    )
+                )
+        elif label in (
+            "GPE",
+            "LOC",
+            "LOCATION",
+            "FACILITY",
+            "CITY",
+            "PROVINCE",
+            "COUNTRY",
+            "ADDRESS",
+        ) or any(x in label for x in ("LOC", "GPE", "ADDRESS", "FACILITY", "CITY", "PROVINCE")):
+            if len(addr_hits) < MAX_HITS_PER_CATEGORY and span:
+                addr_hits.append(
+                    _hit(
+                        CAT_ADDRESS,
+                        span,
+                        _context(sample, ent.start_char, ent.end_char),
+                        ent.start_char,
+                    )
+                )
+    return name_hits, addr_hits
+
+
+def scan(
+    text: str,
+    *,
+    enable_ner: bool = True,
+    ner_max_chars: int | None = None,
+    check_mynumber: bool = True,
+) -> dict[str, Any]:
+    """テキストを検査し、種別・件数・検知箇所の抜粋を返す。
+
+    戻り値:
+      {
+        "categories": ["電話番号", ...],
+        "counts": {"電話番号": 1, ...},
+        "hits": [{"category","match","context","offset"}, ...],
+      }
+    """
+    empty = {"categories": [], "counts": {}, "hits": []}
+    if not text or not text.strip():
+        return empty
+
+    hay = _mask_uuids(text)
+    hits: list[dict[str, Any]] = []
+    counts: dict[str, int] = {}
+
+    phone_hits = find_phone_hits(hay)
+    if phone_hits:
+        counts[CAT_PHONE] = len(phone_hits)
+        hits.extend(phone_hits)
+
+    if check_mynumber:
+        myn_hits = find_mynumber_hits(hay)
+        if myn_hits:
+            # find_valid_mynumbers 全件に近い件数が欲しい場合もあるが、表示は上限付き
+            all_myn = find_valid_mynumbers(hay)
+            counts[CAT_MYNUMBER] = len(all_myn) if all_myn else len(myn_hits)
+            hits.extend(myn_hits)
+
+    addr_hits = find_address_hits(hay)
+    name_hits: list[dict[str, Any]] = []
+    if enable_ner:
+        cap = DEFAULT_NER_MAX_CHARS if ner_max_chars is None else ner_max_chars
+        ner_names, ner_addrs = _ner_hits(hay, max_chars=max(0, cap))
+        name_hits = ner_names
+        # 住所は正規表現と NER をマージ（match 重複除去）
+        seen = {h["match"] for h in addr_hits}
+        for h in ner_addrs:
+            if h["match"] not in seen and len(addr_hits) < MAX_HITS_PER_CATEGORY:
+                addr_hits.append(h)
+                seen.add(h["match"])
+
+    if name_hits:
+        counts[CAT_NAME] = len(name_hits)
+        hits.extend(name_hits)
+    if addr_hits:
+        counts[CAT_ADDRESS] = len(addr_hits)
+        hits.extend(addr_hits)
+
+    categories = [c for c in ALL_CATEGORIES if c in counts]
+    # categories 順に hits を並べる
+    order = {c: i for i, c in enumerate(ALL_CATEGORIES)}
+    hits.sort(key=lambda h: (order.get(h["category"], 99), h.get("offset") or 0))
+    return {"categories": categories, "counts": counts, "hits": hits}
+
+
+def format_categories(categories: list[str]) -> str:
+    """UI 向けの「A・B・C」連結。"""
+    return "・".join(categories)
+
+
+def format_warning_message(result: dict[str, Any]) -> str:
+    """警告文（種別 + 検知例）。"""
+    cats = list(result.get("categories") or [])
+    if not cats:
+        return ""
+    lines = [f"個人情報の可能性: {format_categories(cats)}"]
+    hits = list(result.get("hits") or [])
+    # 種別ごとに最大2件の例
+    by_cat: dict[str, list[dict[str, Any]]] = {}
+    for h in hits:
+        by_cat.setdefault(h["category"], []).append(h)
+    for cat in cats:
+        examples = by_cat.get(cat) or []
+        if not examples:
+            continue
+        shown = examples[:2]
+        parts = []
+        for h in shown:
+            m = h.get("match") or ""
+            ctx = h.get("context") or ""
+            if ctx and m and m in ctx:
+                parts.append(f"「{ctx}」")
+            elif m:
+                parts.append(f"「{m}」")
+        if parts:
+            lines.append(f"・{cat}: " + " / ".join(parts))
+    return "\n".join(lines)

--- a/tests/test_pii_scan.py
+++ b/tests/test_pii_scan.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+
+from shared import pii_scan as pii_mod
+from shared.pii_scan import (
+    CAT_ADDRESS,
+    CAT_MYNUMBER,
+    CAT_PHONE,
+    format_categories,
+    scan,
+)
+
+
+def test_scan_phone_and_mynumber() -> None:
+    text = "連絡先は 090-1234-5678、番号 123456789018 です"
+    result = scan(text, enable_ner=False, check_mynumber=True)
+    assert CAT_PHONE in result["categories"]
+    assert CAT_MYNUMBER in result["categories"]
+    assert format_categories(result["categories"]).count("・") >= 1
+
+
+def test_scan_invalid_mynumber_ignored() -> None:
+    text = "無効な12桁 123456789019 のみ"
+    result = scan(text, enable_ner=False, check_mynumber=True)
+    assert CAT_MYNUMBER not in result["categories"]
+
+
+def test_scan_address_pattern() -> None:
+    text = "送付先: 大分県大分市荷揚町2番31号"
+    result = scan(text, enable_ner=False, check_mynumber=False)
+    assert CAT_ADDRESS in result["categories"]
+
+
+def test_scan_uuid_not_phone() -> None:
+    text = "id=550e8400-e29b-41d4-a716-446655440000"
+    result = scan(text, enable_ner=False, check_mynumber=True)
+    assert result["categories"] == []
+
+
+def test_format_categories_order() -> None:
+    assert format_categories(["電話番号", "マイナンバー"]) == "電話番号・マイナンバー"
+
+
+def test_scan_person_name_with_ginza() -> None:
+    """GiNZA 導入時のみ氏名 NER を検証する。"""
+    pii_mod._nlp = None
+    pii_mod._nlp_failed = False
+    if pii_mod._get_nlp() is None:
+        pytest.skip("ja_ginza 未導入")
+    result = scan(
+        "申請者は山田太郎です。電話は090-1234-5678です。",
+        enable_ner=True,
+        check_mynumber=False,
+    )
+    assert "氏名" in result["categories"]
+    assert "電話番号" in result["categories"]
+    assert any(h["category"] == "氏名" and "山田" in h["match"] for h in result["hits"])
+    assert any(h["category"] == "電話番号" for h in result["hits"])
+
+
+def test_scan_rejects_ner_false_positives() -> None:
+    """組織略称や AI 用語を氏名扱いにしない。"""
+    pii_mod._nlp = None
+    pii_mod._nlp_failed = False
+    if pii_mod._get_nlp() is None:
+        pytest.skip("ja_ginza 未導入")
+    text = (
+        "生成AI・AIエージェントの急速な進展を踏まえ、府省庁初のOSPO。"
+        "右中央の吹き出しには連携とある。"
+    )
+    result = scan(text, enable_ner=True, check_mynumber=False)
+    assert "氏名" not in result["categories"]


### PR DESCRIPTION
## Summary
- チャット等の同期アップロード時に、氏名・住所・電話番号・マイナンバーを検知し、種別と検知箇所の抜粋付きで警告する（登録自体はブロックしない）
- ナレッジ登録を非同期化し、ジョブ内で索引作成と個人情報検知を一体実行。管理画面にラベル／状態を表示する
- 氏名 NER は任意の GiNZA（`PII_INSTALL_NER`）、誤検知抑制フィルタと管理トグル、単体テストを追加する

## Test plan
- [ ] `PUT /files` で電話番号・マイナンバー等を含むテキストを上げ、警告と抜粋が返ること
- [ ] 一般文書（組織名・計画書など）で氏名の誤警告が出にくいこと
- [ ] ナレッジ登録後に pending → ready へ遷移し、検知時は `pii_labels` が表示されること
- [ ] 管理画面の添付警告／ナレッジ検知トグルが効くこと
- [ ] `tests/test_pii_scan.py` が通ること
- [ ] 本番は `PII_INSTALL_NER=1` で backend/rag-app をビルドし、proxy 含め正常応答すること


Made with [Cursor](https://cursor.com)