### PR TITLE
feat: 日程調整（chosei）をオプション exApp として追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,23 @@ OLLAMA_BASE_URL=http://host.docker.internal:11434
 # Ollama もコンテナで動かす場合（docker compose --profile ollama up）は以下に変更
 # OLLAMA_BASE_URL=http://ollama:11434
 
+# --- 日程調整（オプション: profiles: ["chosei"]）---
+# COMPOSE_PROFILES=chosei
+# CHOSEI_PUBLIC_ENDPOINT=http://localhost:8010
+# CHOSEI_PUBLIC_PORT=8010
+# CHOSEI_RETENTION_DAYS=90
+# CHOSEI_MODEL=qwen2.5:7b
+# 詳細は docs/chosei.md
+
+# --- 日程調整（オプション: profiles: ["chosei"]）---
+# docker compose --profile chosei up -d
+# または: COMPOSE_PROFILES=chosei
+# CHOSEI_APP_URL=http://chosei-app:8010/invoke
+# 外部ゲスト向け公開 URL（開発時は chosei-app のホスト公開ポート）
+# CHOSEI_PUBLIC_ENDPOINT=http://localhost:8010
+# CHOSEI_PUBLIC_PORT=8010
+# CHOSEI_RETENTION_DAYS=90
+
 # LLM は OpenAI 互換 API 経由で呼び出します。
 # 未指定なら OLLAMA_BASE_URL + /v1 を使用します。
 # vLLM / LM Studio / OpenAI 等に向ける場合のみ設定してください。

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -86,6 +86,15 @@ EMBED_DIM=1024
 # --- 例: ローカル日本語埋め込み ruri-v3-310m を embed サイドカーで使う場合 ---
 #   下記を有効化し、`docker compose --profile embed ...`（または COMPOSE_PROFILES=embed）で起動する。
 # COMPOSE_PROFILES=embed
+#
+# --- 日程調整（オプション: profiles: ["chosei"]）---
+#   外部ゲスト用 URL を別ホストで公開する（/public のみ。proxy/chosei.public.conf.example 参照）。
+#   embed と併用する場合は COMPOSE_PROFILES=embed,chosei
+# COMPOSE_PROFILES=chosei
+# CHOSEI_PUBLIC_ENDPOINT=https://chosei.example.lg.jp
+# CHOSEI_RETENTION_DAYS=90
+# CHOSEI_MODEL=qwen2.5:7b
+# 詳細は docs/chosei.md
 # EMBED_BASE_URL=http://embed:80/v1
 # EMBED_API_KEY=-
 # EMBED_MODEL=cl-nagoya/ruri-v3-310m

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ deletion-report-*.txt
 !/docs/knowledge-api.md
 !/docs/knowledge-mcp.md
 !/docs/dify-knowledge.md
+!/docs/chosei.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@
 
 ## [Unreleased]
 
+### 日程調整（chosei）オプション機能
+
+- `chosei-app`（FastAPI + SQLite）を Compose `profiles: ["chosei"]` でオプション起動
+- 庁内は専用ページ `/chosei`（DADS）。外部ゲストは `CHOSEI_PUBLIC_ENDPOINT` の `/public` のみ（デュアルイングレス）
+- 暗証番号は bcrypt ハッシュ保存。保持日数は `CHOSEI_RETENTION_DAYS`（既定 90 日）
+- LLM アシスト（庁内のみ）: 最適日提案・自然文からの日程候補・案内文下書き（Ollama 等の OpenAI 互換 API）
+- 詳細は [`docs/chosei.md`](docs/chosei.md)
+
 ## [0.6.0] - 2026-08-06
 
 添付・ナレッジの個人情報検知、ナレッジ管理の専用ページ化、チャット大容量添付のマップリデュース、

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Linux + NVIDIA GPU 機（例: **NVIDIA DGX Spark**）でも動作します。
 
 ### 4 つの柱
 
-1. **自治体実務を想定した機能** — 監査ログ（3 年以上保持）、利用者 CSV 一括管理、モデル利用制御、禁止語／個人情報検知（添付警告・ナレッジラベル、任意の GiNZA NER）、プロンプトテンプレート、契約終了時の完全削除と報告書生成
+1. **自治体実務を想定した機能** — 監査ログ（3 年以上保持）、利用者 CSV 一括管理、モデル利用制御、禁止語／個人情報検知（添付警告・ナレッジラベル、任意の GiNZA NER）、プロンプトテンプレート、日程調整（オプション profile）、契約終了時の完全削除と報告書生成
 2. **チーム主体・複数所属** — 親子階層のないフラットなチーム。利用者は複数チームに所属可能。AI アプリ・RAG ナレッジ・保存プロンプトの共有は **所属チーム** を軸に制御
 3. **源内 UI 制約の opt-in 拡張** — Form Spec v1（条件表示・リアクティブフォーム・プレビュー）、`dynamic_schema` による動的フォーム、各画面の折りたたみヘルプ。既存 exApp は無改修で従来どおり動作
 4. **成果物のオブジェクトストレージ** — AI アプリ（Dify 等）が生成したファイルを SeaweedFS に保存し、backend 経由で署名付き URL を提示
@@ -82,6 +82,7 @@ Linux + NVIDIA GPU 機（例: **NVIDIA DGX Spark**）でも動作します。
 | `modelpolicy-app/` | モデル利用制御ポリシー管理（管理者限定 exApp） |
 | `ngword-app/` | 禁止語・個人情報検知の設定（管理者限定 exApp。添付警告／ナレッジ検知／NER トグル） |
 | `prompt-app/` | プロンプトテンプレートカタログ（標準／個人／グループ共有） |
+| `chosei-app/` | 日程調整（オプション・`profiles: ["chosei"]`。詳細は [`docs/chosei.md`](docs/chosei.md)） |
 | `seaweedfs/` | 成果物配信用 S3 互換ストレージ設定 |
 | `scripts/` | 運用スクリプト（契約終了時の完全削除・報告書生成 等） |
 | `docs/` | Open GENAI レイヤのガイド（[ナレッジ API](docs/knowledge-api.md) / [MCP](docs/knowledge-mcp.md) / [Dify 事例](docs/dify-knowledge.md)） |

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -94,6 +94,11 @@ NGWORD_APP_URL = os.environ.get("NGWORD_APP_URL", "http://ngword-app:8008/invoke
 # プロンプトテンプレート「AI アプリ」連携先（全ユーザー利用可）
 PROMPT_APP_URL = os.environ.get("PROMPT_APP_URL", "http://prompt-app:8009/invoke")
 
+# 日程調整（Compose profiles: ["chosei"] でオプション起動。未起動時は専用ページが案内を出す）
+# 実 API は /chosei/* プロキシ。endpoint 末尾の /invoke はヘルスチェック導出用（実体なし可）。
+CHOSEI_APP_URL = os.environ.get("CHOSEI_APP_URL", "http://chosei-app:8010/invoke")
+CHOSEI_PUBLIC_ENDPOINT = (os.environ.get("CHOSEI_PUBLIC_ENDPOINT") or "").rstrip("/")
+
 # 管理者(SystemAdminGroup)のみに一覧表示・実行を許可する exApp
 # （共有ナレッジの管理系は共通チーム上だが管理者限定）
 ADMIN_ONLY_EXAPP_IDS = {
@@ -350,6 +355,31 @@ PROMPT_SEED: dict[str, Any] = {
     "status": "published",
 }
 
+# 日程調整（共通アプリ）。UI は専用ページ /chosei。Compose profile `chosei` 未起動時は
+# /health 失敗で一覧非表示。endpoint はヘルスチェック用（実 API は /chosei/* プロキシ）。
+CHOSEI_SEED: dict[str, Any] = {
+    "exAppId": "chosei",
+    "teamId": COMMON_TEAM_ID,
+    "exAppName": "日程調整",
+    "endpoint": (
+        CHOSEI_APP_URL
+        if CHOSEI_APP_URL.endswith("/invoke")
+        else CHOSEI_APP_URL.rstrip("/") + "/invoke"
+    ),
+    "apiKey": RAG_API_KEY,
+    "config": "",
+    "placeholder": "",
+    "description": "庁内・外部参加者向けの日程調整。専用画面で作成・回答・集計できます。",
+    "howToUse": (
+        "## 使い方\n\n"
+        "- 専用ページ「日程調整」からイベントを作成し、共有 URL を配布します。\n"
+        "- 庁内利用者はログインしたまま回答できます。外部は公開 URL から回答します。\n"
+        "- 有効化: `docker compose --profile chosei up -d` または `COMPOSE_PROFILES=chosei`。\n"
+    ),
+    "copyable": False,
+    "status": "published",
+}
+
 def _team_rag_search_app(team_name: str) -> dict[str, Any]:
     return {
         "exAppName": f"{team_name}のナレッジ検索",
@@ -421,6 +451,7 @@ EXAPP_SEEDS = [
     MODELPOLICY_SEED,
     NGWORD_SEED,
     PROMPT_SEED,
+    CHOSEI_SEED,
 ]
 
 # 源内 Web の汎用ページ／専用ページに統合したため exApp 登録を廃止した ID。
@@ -2521,6 +2552,261 @@ async def render_prompt_template(template_id: str, request: Request) -> JSONResp
     body = await request.json()
     return await _proxy_prompt(
         "POST", _prompt_app_url(f"/templates/{template_id}/render"), headers, body
+    )
+
+
+# ---------------------------------------------------------------------------
+# 日程調整専用ページ(/chosei) 用プロキシ
+#
+# Compose profiles: ["chosei"] 未起動時は接続失敗 → 専用ページが有効化案内を表示する。
+# スコープは共通チーム(COMMON_TEAM_ID)固定。
+# ---------------------------------------------------------------------------
+def _chosei_app_url(path: str) -> str:
+    if CHOSEI_APP_URL.endswith("/invoke"):
+        base = CHOSEI_APP_URL[: -len("/invoke")]
+    else:
+        base = CHOSEI_APP_URL.rstrip("/")
+    return base + path
+
+
+def _chosei_headers(request: Request) -> tuple[JSONResponse | None, dict[str, str]]:
+    claims = _claims_from_request(request)
+    user_id = _user_id(claims)
+    if not user_id:
+        return JSONResponse(status_code=401, content={"error": "認証が必要です"}), {}
+    groups_str = ",".join(claims.get("groups") or [])
+    team_ids = _user_team_ids_str(user_id)
+    teams_hdr = _user_teams_header(user_id)
+    headers = {
+        "x-api-key": RAG_API_KEY,
+        "x-user-id": user_id,
+        "x-user-groups": groups_str,
+        "x-user-tags": team_ids,
+        "x-user-teams": teams_hdr,
+        "x-scope": COMMON_TEAM_ID,
+        **intauth.signed_headers(user_id, groups_str, COMMON_TEAM_ID, team_ids),
+        "Content-Type": "application/json",
+    }
+    return None, headers
+
+
+async def _proxy_chosei(
+    method: str,
+    url: str,
+    headers: dict[str, str],
+    json_body: Any | None = None,
+    *,
+    timeout: float = 30,
+) -> JSONResponse:
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            res = await client.request(method, url, headers=headers, json=json_body)
+    except httpx.HTTPError as e:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error": (
+                    "日程調整サービスに接続できませんでした。"
+                    "有効化するには `docker compose --profile chosei up -d` "
+                    "または `COMPOSE_PROFILES=chosei` を設定してください。"
+                    f"（詳細: {e}）"
+                ),
+                "enabled": False,
+            },
+        )
+    try:
+        payload = res.json()
+    except ValueError:
+        payload = {"error": "日程調整サービスから不正な応答を受け取りました"}
+    return JSONResponse(status_code=res.status_code, content=payload)
+
+
+@app.get("/chosei/config")
+async def chosei_config(request: Request) -> JSONResponse:
+    err, headers = _chosei_headers(request)
+    if err:
+        return err
+    res = await _proxy_chosei("GET", _chosei_app_url("/config"), headers)
+    # サービス側の public_endpoint が空でも、backend 側の env を補完して返す
+    if res.status_code == 200:
+        try:
+            data = json.loads(res.body)
+            if isinstance(data, dict) and CHOSEI_PUBLIC_ENDPOINT:
+                data["public_endpoint"] = (
+                    data.get("public_endpoint") or CHOSEI_PUBLIC_ENDPOINT
+                )
+            return JSONResponse(status_code=200, content=data)
+        except Exception:  # noqa: BLE001
+            pass
+    return res
+
+
+@app.get("/chosei/events")
+async def chosei_list_events(request: Request) -> JSONResponse:
+    err, headers = _chosei_headers(request)
+    if err:
+        return err
+    return await _proxy_chosei("GET", _chosei_app_url("/events"), headers)
+
+
+@app.post("/chosei/events")
+async def chosei_create_event(request: Request) -> JSONResponse:
+    err, headers = _chosei_headers(request)
+    if err:
+        return err
+    body = await request.json()
+    return await _proxy_chosei("POST", _chosei_app_url("/events"), headers, body)
+
+
+@app.get("/chosei/events/{event_id}")
+async def chosei_get_event(event_id: str, request: Request) -> JSONResponse:
+    err, headers = _chosei_headers(request)
+    if err:
+        return err
+    return await _proxy_chosei(
+        "GET", _chosei_app_url(f"/events/{event_id}"), headers
+    )
+
+
+@app.put("/chosei/events/{event_id}")
+async def chosei_update_event(event_id: str, request: Request) -> JSONResponse:
+    err, headers = _chosei_headers(request)
+    if err:
+        return err
+    body = await request.json()
+    return await _proxy_chosei(
+        "PUT", _chosei_app_url(f"/events/{event_id}"), headers, body
+    )
+
+
+@app.delete("/chosei/events/{event_id}")
+async def chosei_delete_event(event_id: str, request: Request) -> JSONResponse:
+    err, headers = _chosei_headers(request)
+    if err:
+        return err
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        body = {}
+    return await _proxy_chosei(
+        "DELETE", _chosei_app_url(f"/events/{event_id}"), headers, body
+    )
+
+
+@app.post("/chosei/events/{event_id}/responses")
+async def chosei_submit_response(event_id: str, request: Request) -> JSONResponse:
+    err, headers = _chosei_headers(request)
+    if err:
+        return err
+    body = await request.json()
+    return await _proxy_chosei(
+        "POST", _chosei_app_url(f"/events/{event_id}/responses"), headers, body
+    )
+
+
+@app.delete("/chosei/events/{event_id}/participants/{participant_name}")
+async def chosei_delete_participant(
+    event_id: str, participant_name: str, request: Request
+) -> JSONResponse:
+    err, headers = _chosei_headers(request)
+    if err:
+        return err
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        body = {}
+    return await _proxy_chosei(
+        "DELETE",
+        _chosei_app_url(
+            f"/events/{event_id}/participants/{quote(participant_name, safe='')}"
+        ),
+        headers,
+        body,
+    )
+
+
+@app.post("/chosei/assist/parse-dates")
+async def chosei_assist_parse_dates(request: Request) -> JSONResponse:
+    """自然文から日程候補を抽出（LLM）。"""
+    err, headers = _chosei_headers(request)
+    if err:
+        return err
+    body = await request.json()
+    return await _proxy_chosei(
+        "POST",
+        _chosei_app_url("/assist/parse-dates"),
+        headers,
+        body,
+        timeout=120,
+    )
+
+
+@app.post("/chosei/events/{event_id}/assist/recommend")
+async def chosei_assist_recommend(event_id: str, request: Request) -> JSONResponse:
+    """回答マトリクスから最適日を提案（LLM、失敗時は簡易集計）。"""
+    err, headers = _chosei_headers(request)
+    if err:
+        return err
+    return await _proxy_chosei(
+        "POST",
+        _chosei_app_url(f"/events/{event_id}/assist/recommend"),
+        headers,
+        {},
+        timeout=120,
+    )
+
+
+@app.post("/chosei/events/{event_id}/assist/invite")
+async def chosei_assist_invite(event_id: str, request: Request) -> JSONResponse:
+    """外部共有向けの案内文を下書き（LLM）。"""
+    err, headers = _chosei_headers(request)
+    if err:
+        return err
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        body = {}
+    return await _proxy_chosei(
+        "POST",
+        _chosei_app_url(f"/events/{event_id}/assist/invite"),
+        headers,
+        body,
+        timeout=120,
+    )
+
+
+@app.get("/chosei/events/{event_id}/carrier")
+async def chosei_event_carrier(
+    event_id: str, request: Request, format: str = Query(default="txt")
+) -> Response:
+    """外部共有 URL のリンクファイルをダウンロードさせる（LGWAN carrier）。"""
+    err, headers = _chosei_headers(request)
+    if err:
+        return err
+    res = await _proxy_chosei(
+        "GET",
+        _chosei_app_url(f"/events/{event_id}/carrier") + f"?format={quote(format)}",
+        headers,
+    )
+    if res.status_code != 200:
+        return res
+    try:
+        data = json.loads(res.body)
+    except Exception:  # noqa: BLE001
+        return JSONResponse(status_code=502, content={"error": "不正な応答です"})
+    content = data.get("content") or ""
+    filename = data.get("filename") or "chosei_link.txt"
+    fmt = (data.get("format") or format or "txt").lower()
+    media = "text/html; charset=utf-8" if fmt == "html" else "text/plain; charset=utf-8"
+    ascii_name = "".join(c if c.isascii() and c not in '"\\' else "_" for c in filename)
+    disposition = (
+        f'attachment; filename="{ascii_name}"; '
+        f"filename*=UTF-8''{quote(filename)}"
+    )
+    return Response(
+        content=content.encode("utf-8"),
+        media_type=media,
+        headers={"Content-Disposition": disposition},
     )
 
 

--- a/chosei-app/Dockerfile
+++ b/chosei-app/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+COPY public ./public
+
+EXPOSE 8010
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8010"]

--- a/chosei-app/app/assist.py
+++ b/chosei-app/app/assist.py
@@ -1,0 +1,288 @@
+"""日程調整向け LLM アシスト（最適日提案・自然文パース・案内文）。"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from . import llm, store
+
+JST = ZoneInfo("Asia/Tokyo")
+
+
+def _matrix_summary(detail: dict[str, Any]) -> dict[str, Any]:
+    dates = detail["dates"]
+    responses = detail["responses"]
+    stats = detail["statistics"]
+    participants: list[str] = []
+    seen: set[str] = set()
+    for r in responses:
+        if r["participant_name"] not in seen:
+            seen.add(r["participant_name"])
+            participants.append(r["participant_name"])
+    by_person: dict[str, dict[int, str]] = {}
+    for r in responses:
+        by_person.setdefault(r["participant_name"], {})[r["event_date_id"]] = r["status"]
+    rows = []
+    for d in dates:
+        st = stats.get(str(d["id"])) or {}
+        cells = {
+            name: by_person.get(name, {}).get(d["id"], "—") for name in participants
+        }
+        rows.append(
+            {
+                "date_id": d["id"],
+                "date_time": d["date_time"],
+                "end_time": d.get("end_time"),
+                "is_all_day": d.get("is_all_day"),
+                "ok": st.get("ok", 0),
+                "maybe": st.get("maybe", 0),
+                "ng": st.get("ng", 0),
+                "answers": cells,
+            }
+        )
+    return {
+        "title": detail["event"]["title"],
+        "description": detail["event"].get("description"),
+        "participants": participants,
+        "rows": rows,
+    }
+
+
+def heuristic_recommend(detail: dict[str, Any]) -> dict[str, Any]:
+    """LLM なしのフォールバック: ○多く ×少ない順。"""
+    rows = []
+    for d in detail["dates"]:
+        st = detail["statistics"].get(str(d["id"])) or {}
+        ok = int(st.get("ok", 0))
+        maybe = int(st.get("maybe", 0))
+        ng = int(st.get("ng", 0))
+        score = ok * 2 + maybe - ng * 3
+        rows.append(
+            {
+                "date_id": d["id"],
+                "date_time": d["date_time"],
+                "end_time": d.get("end_time"),
+                "is_all_day": bool(d.get("is_all_day")),
+                "ok": ok,
+                "maybe": maybe,
+                "ng": ng,
+                "score": score,
+            }
+        )
+    rows.sort(key=lambda x: (-x["score"], x["ng"], -x["ok"], x["date_time"]))
+    best = rows[0] if rows else None
+    return {
+        "source": "heuristic",
+        "recommended_date_id": best["date_id"] if best else None,
+        "recommended_date_time": best["date_time"] if best else None,
+        "reasoning": (
+            "回答数に基づく簡易スコア（○×2 + △×1 − ××3）で最有力候補を選びました。"
+            if best
+            else "日程候補がありません。"
+        ),
+        "ranking": rows,
+    }
+
+
+async def recommend_slot(event_id: str) -> dict[str, Any]:
+    detail = store.event_detail(event_id=event_id)
+    if not detail:
+        raise LookupError("イベントが見つかりません")
+    if not detail["dates"]:
+        return heuristic_recommend(detail)
+    if not detail["responses"]:
+        base = heuristic_recommend(detail)
+        base["reasoning"] = "まだ回答がないため、最初の日程候補を仮の候補とします。"
+        return base
+
+    summary = _matrix_summary(detail)
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "あなたは日程調整の補助アシスタントです。"
+                "与えられた出欠マトリクスから最適な候補を選び、JSON のみで答えてください。"
+                "キー: recommended_date_id (整数), reasoning (日本語の短い理由), "
+                "ranking (配列。各要素は date_id, score(0-100), note)。"
+                "○を最重視し、×が多い候補は避けてください。説明文やコードフェンス以外は出力しないでください。"
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                "次の日程調整の結果から最適日を提案してください。\n"
+                f"{summary}"
+            ),
+        },
+    ]
+    try:
+        text = await llm.chat(messages, temperature=0.1)
+        data = llm.extract_json(text)
+        if not isinstance(data, dict):
+            raise ValueError("オブジェクトではありません")
+        rid = data.get("recommended_date_id")
+        valid_ids = {d["id"] for d in detail["dates"]}
+        if rid is not None:
+            try:
+                rid = int(rid)
+            except (TypeError, ValueError) as e:
+                raise ValueError("recommended_date_id が不正です") from e
+            if rid not in valid_ids:
+                raise ValueError("存在しない date_id です")
+        ranking = data.get("ranking") if isinstance(data.get("ranking"), list) else []
+        # date_time を補完
+        id_to_date = {d["id"]: d for d in detail["dates"]}
+        norm_rank = []
+        for item in ranking:
+            if not isinstance(item, dict):
+                continue
+            try:
+                did = int(item.get("date_id"))
+            except (TypeError, ValueError):
+                continue
+            if did not in id_to_date:
+                continue
+            d = id_to_date[did]
+            norm_rank.append(
+                {
+                    "date_id": did,
+                    "date_time": d["date_time"],
+                    "end_time": d.get("end_time"),
+                    "is_all_day": bool(d.get("is_all_day")),
+                    "score": item.get("score"),
+                    "note": item.get("note") or "",
+                }
+            )
+        rec_date = id_to_date.get(rid) if rid is not None else None
+        return {
+            "source": "llm",
+            "recommended_date_id": rid,
+            "recommended_date_time": rec_date["date_time"] if rec_date else None,
+            "reasoning": str(data.get("reasoning") or "").strip()
+            or "モデルが候補を提案しました。",
+            "ranking": norm_rank or heuristic_recommend(detail)["ranking"],
+            "model": llm.CHOSEI_MODEL,
+        }
+    except Exception as e:  # noqa: BLE001
+        fallback = heuristic_recommend(detail)
+        fallback["llm_error"] = str(e)
+        fallback["reasoning"] = (
+            f"LLM 提案に失敗したため簡易集計に切り替えました（{e}）。"
+            + fallback["reasoning"]
+        )
+        return fallback
+
+
+async def parse_dates_from_text(text: str, *, now: datetime | None = None) -> dict[str, Any]:
+    text = (text or "").strip()
+    if not text:
+        raise ValueError("テキストを入力してください")
+    now = now or datetime.now(JST)
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "あなたは日程候補の抽出器です。日本語の要望から候補日時を抽出し、"
+                "JSON オブジェクトのみを1つ返してください。説明やコードフェンスは不要です。"
+                '形式: {"dates":[{"start_time":"YYYY-MM-DDTHH:MM:SS+09:00",'
+                '"end_time":"YYYY-MM-DDTHH:MM:SS+09:00"|null,'
+                '"is_all_day":false,"label":"8/14 12:00"}],"notes":""}。'
+                "タイムゾーンは必ず +09:00。"
+                "候補は最大14件まで。平日連続などは必要な日だけ列挙し、冗長な説明は notes に書かない。"
+                "終日なら is_all_day=true、start_time はその日 00:00:00+09:00、end_time は null。"
+                "必ず完全な JSON で閉じること。"
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"現在日時: {now.isoformat()}\n"
+                f"要望:\n{text}"
+            ),
+        },
+    ]
+    raw = await llm.chat(messages, temperature=0.1, max_tokens=4096)
+    data = llm.extract_json(raw)
+    if not isinstance(data, dict):
+        raise ValueError("モデル応答の形式が不正です")
+    dates_in = data.get("dates") if isinstance(data.get("dates"), list) else []
+    dates: list[dict[str, Any]] = []
+    for item in dates_in:
+        if not isinstance(item, dict) or not item.get("start_time"):
+            continue
+        start = str(item["start_time"]).strip()
+        end = item.get("end_time")
+        end_s = str(end).strip() if end else None
+        dates.append(
+            {
+                "start_time": start,
+                "end_time": end_s,
+                "is_all_day": bool(item.get("is_all_day")),
+                "label": str(item.get("label") or start),
+            }
+        )
+    return {
+        "dates": dates,
+        "notes": str(data.get("notes") or "").strip(),
+        "model": llm.CHOSEI_MODEL,
+        "raw_text": text,
+    }
+
+
+async def draft_invite(event_id: str, *, tone: str = "丁寧") -> dict[str, Any]:
+    detail = store.event_detail(event_id=event_id)
+    if not detail:
+        raise LookupError("イベントが見つかりません")
+    ev = detail["event"]
+    date_lines = []
+    for i, d in enumerate(detail["dates"], 1):
+        line = f"{i}. {d['date_time']}"
+        if d.get("end_time") and not d.get("is_all_day"):
+            line += f" 〜 {d['end_time']}"
+        if d.get("is_all_day"):
+            line += "（終日）"
+        date_lines.append(line)
+    public_url = ev.get("public_url") or ""
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "あなたは自治体・組織向けの事務連絡文案アシスタントです。"
+                "日程調整への回答依頼メール／チャット文を作成し、JSON のみで返してください。"
+                'キー: subject (件名), body (本文), tips (任意の短い注意書き)。'
+                "本文には候補一覧と回答用 URL を必ず含め、誇張や個人情報の捏造はしないでください。"
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"トーン: {tone}\n"
+                f"タイトル: {ev['title']}\n"
+                f"説明: {ev.get('description') or '（なし）'}\n"
+                f"作成者: {ev.get('creator_name') or '（未記入）'}\n"
+                f"候補:\n" + ("\n".join(date_lines) or "（なし）") + "\n"
+                f"回答用URL: {public_url or '（未設定）'}\n"
+            ),
+        },
+    ]
+    text = await llm.chat(messages, temperature=0.4)
+    data = llm.extract_json(text)
+    if not isinstance(data, dict):
+        raise ValueError("モデル応答の形式が不正です")
+    subject = str(data.get("subject") or f"【日程調整】{ev['title']}").strip()
+    body = str(data.get("body") or "").strip()
+    if public_url and public_url not in body:
+        body = (body + f"\n\n回答はこちらからお願いします:\n{public_url}").strip()
+    return {
+        "subject": subject,
+        "body": body,
+        "tips": str(data.get("tips") or "").strip(),
+        "public_url": public_url,
+        "model": llm.CHOSEI_MODEL,
+    }
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()

--- a/chosei-app/app/intauth.py
+++ b/chosei-app/app/intauth.py
@@ -1,0 +1,101 @@
+"""内部サービス間認証（backend → exApp マイクロサービス）。
+
+課題: exApp は同一 Docker ネットワーク内で API キー + `x-user-groups` を信頼する。
+これらは内部到達できる攻撃者に偽装され得るため（管理者機能のバイパス）、backend が
+「利用者ID・グループ・タグ・スコープ・時刻」に対して共有鍵で HMAC 署名を付与し、
+exApp 側で検証する。
+
+- `INTERNAL_SIGNING_SECRET` が未設定なら検証はスキップ（開発時の後方互換）。本番では
+  必ず十分に長いランダム値を backend と全 exApp に同じ値で設定すること。
+- 署名対象にタイムスタンプを含め、`INTERNAL_SIG_MAX_AGE` 秒を超えた署名は無効。
+- `tags`（OpenGENAI 独自の共有タグ）も署名対象に含める。`x-user-tags` の偽装による
+  タグ共有資産へのなりすまし閲覧を防ぐ。未使用時は空文字で全サービス整合。
+
+本ファイルは各サービスの `app/intauth.py` に同一内容で配置する（各コンテナのビルド
+コンテキストが異なり shared/ を共有できないため）。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import time
+
+SECRET = os.environ.get("INTERNAL_SIGNING_SECRET", "")
+MAX_AGE = int(os.environ.get("INTERNAL_SIG_MAX_AGE", "300"))
+
+
+def _norm(values: str | None) -> str:
+    # 順序非依存にするため正規化（空白除去・ソート・空要素除去）
+    return ",".join(sorted(x.strip() for x in (values or "").split(",") if x.strip()))
+
+
+def _canonical(
+    user_id: str | None,
+    groups: str | None,
+    scope: str | None,
+    ts: str,
+    tags: str | None = None,
+) -> str:
+    return f"{user_id or ''}\n{_norm(groups)}\n{scope or ''}\n{_norm(tags)}\n{ts}"
+
+
+def _compute(
+    user_id: str | None,
+    groups: str | None,
+    scope: str | None,
+    ts: str,
+    tags: str | None = None,
+) -> str:
+    return hmac.new(
+        SECRET.encode("utf-8"),
+        _canonical(user_id, groups, scope, ts, tags).encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def sign(
+    user_id: str | None,
+    groups: str | None,
+    scope: str | None = "",
+    tags: str | None = None,
+) -> tuple[str, str]:
+    """(ts, signature) を返す。SECRET 未設定でも ts/sig は返す（検証側で無視）。"""
+    ts = str(int(time.time()))
+    return ts, _compute(user_id, groups, scope, ts, tags)
+
+
+def signed_headers(
+    user_id: str | None,
+    groups: str | None,
+    scope: str | None = "",
+    tags: str | None = None,
+) -> dict[str, str]:
+    ts, sig = sign(user_id, groups, scope, tags)
+    return {"x-user-ts": ts, "x-user-sig": sig}
+
+
+def verify(
+    user_id: str | None,
+    groups: str | None,
+    scope: str | None,
+    ts: str | None,
+    sig: str | None,
+    tags: str | None = None,
+) -> bool:
+    """署名を検証する。SECRET 未設定なら常に True（開発時）。
+
+    scope も署名対象に含めるため、`x-scope` の改ざん（他チームへのなりすまし）も検知する。
+    tags も署名対象に含めるため、`x-user-tags`（共有タグ）の改ざんも検知する。
+    """
+    if not SECRET:
+        return True
+    if not ts or not sig:
+        return False
+    try:
+        if abs(int(time.time()) - int(ts)) > MAX_AGE:
+            return False
+    except ValueError:
+        return False
+    return hmac.compare_digest(_compute(user_id, groups, scope, ts, tags), sig)

--- a/chosei-app/app/llm.py
+++ b/chosei-app/app/llm.py
@@ -1,0 +1,159 @@
+"""OpenAI 互換 chat/completions 呼び出し（Ollama 等）。"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any
+
+import httpx
+
+OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://host.docker.internal:11434").rstrip(
+    "/"
+)
+OPENAI_BASE_URL = (
+    os.environ.get("OPENAI_BASE_URL") or f"{OLLAMA_BASE_URL}/v1"
+).rstrip("/")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY") or "ollama"
+CHOSEI_MODEL = os.environ.get("CHOSEI_MODEL") or os.environ.get("DEFAULT_MODEL") or "qwen2.5:7b"
+REQUEST_TIMEOUT = float(os.environ.get("CHOSEI_LLM_TIMEOUT", "120"))
+DEFAULT_MAX_TOKENS = int(os.environ.get("CHOSEI_LLM_MAX_TOKENS", "2048"))
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {OPENAI_API_KEY}",
+        "Content-Type": "application/json",
+    }
+
+
+async def chat(
+    messages: list[dict[str, str]],
+    *,
+    temperature: float = 0.2,
+    model: str | None = None,
+    max_tokens: int | None = None,
+) -> str:
+    payload: dict[str, Any] = {
+        "model": model or CHOSEI_MODEL,
+        "messages": messages,
+        "stream": False,
+        "temperature": temperature,
+        "max_tokens": max_tokens if max_tokens is not None else DEFAULT_MAX_TOKENS,
+    }
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        res = await client.post(
+            f"{OPENAI_BASE_URL}/chat/completions",
+            json=payload,
+            headers=_headers(),
+        )
+        res.raise_for_status()
+        data = res.json()
+    choices = data.get("choices") or [{}]
+    return ((choices[0].get("message") or {}).get("content") or "").strip()
+
+
+def _strip_fences(raw: str) -> str:
+    fence = re.search(r"```(?:json)?\s*([\s\S]*?)```", raw, re.IGNORECASE)
+    if fence:
+        return fence.group(1).strip()
+    return raw.strip()
+
+
+def salvage_truncated_json(raw: str) -> Any | None:
+    """途中で切れた JSON から、完成している配列要素だけを復元する。
+
+    例: {"dates":[{...},{...不完全  →  完成分の dates だけ返す。
+    """
+    text = _strip_fences(raw)
+    start = text.find("{")
+    if start < 0:
+        start = text.find("[")
+    if start < 0:
+        return None
+    text = text[start:]
+
+    # 完成オブジェクトを後ろから削って再パース
+    for end in range(len(text), 0, -1):
+        chunk = text[:end].rstrip()
+        # 未閉じの文字列・配列・オブジェクトを雑に閉じる
+        candidates = [chunk]
+        # 末尾が不完全な文字列の途中なら、その要素ごと捨てて閉じる
+        if '"' in chunk:
+            # 奇数個の未エスケープ " なら文字列が開いたまま
+            quotes = 0
+            escaped = False
+            for ch in chunk:
+                if escaped:
+                    escaped = False
+                    continue
+                if ch == "\\":
+                    escaped = True
+                    continue
+                if ch == '"':
+                    quotes += 1
+            if quotes % 2 == 1:
+                # 最後の " 以降（不完全値）を捨て、直前のオブジェクト区切りまで戻す
+                last_quote = chunk.rfind('"')
+                # 不完全キー/値ごと削除し、直前の , または [ まで
+                cut = max(chunk.rfind(","), chunk.rfind("["), chunk.rfind("{"))
+                if cut > 0:
+                    trimmed = chunk[:cut]
+                    # [ の直後で切った場合はそのまま
+                    if chunk[cut] == ",":
+                        trimmed = chunk[:cut]
+                    candidates.insert(0, trimmed)
+        for base in candidates:
+            open_sq = base.count("[") - base.count("]")
+            open_cu = base.count("{") - base.count("}")
+            if open_sq < 0 or open_cu < 0:
+                continue
+            trial = base + ("]" * open_sq) + ("}" * open_cu)
+            # 末尾の余分なカンマを除去
+            trial = re.sub(r",\s*([\]}])", r"\1", trial)
+            try:
+                return json.loads(trial)
+            except json.JSONDecodeError:
+                continue
+
+    # dates 配列の完成要素だけ正規表現で拾う（最終手段）
+    objs = re.findall(
+        r'\{\s*"start_time"\s*:\s*"[^"]+"\s*,\s*"end_time"\s*:\s*(?:null|"[^"]*")\s*,'
+        r'\s*"is_all_day"\s*:\s*(?:true|false)\s*,\s*"label"\s*:\s*"[^"]*"\s*\}',
+        text,
+    )
+    if objs:
+        dates = []
+        for o in objs:
+            try:
+                dates.append(json.loads(o))
+            except json.JSONDecodeError:
+                continue
+        if dates:
+            return {"dates": dates, "notes": "応答が途中で切れたため、取得できた候補のみ反映しました。"}
+    return None
+
+
+def extract_json(text: str) -> Any:
+    """モデル出力から JSON を取り出す（```json 囲み・途中切れにも対応）。"""
+    raw = (text or "").strip()
+    if not raw:
+        raise ValueError("空の応答です")
+    body = _strip_fences(raw)
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        pass
+    for open_c, close_c in (("{", "}"), ("[", "]")):
+        start = body.find(open_c)
+        end = body.rfind(close_c)
+        if start >= 0 and end > start:
+            try:
+                return json.loads(body[start : end + 1])
+            except json.JSONDecodeError:
+                continue
+    salvaged = salvage_truncated_json(raw)
+    if salvaged is not None:
+        return salvaged
+    raise ValueError(f"JSON を解析できませんでした: {text[:240]}")

--- a/chosei-app/app/main.py
+++ b/chosei-app/app/main.py
@@ -1,0 +1,618 @@
+"""日程調整マイクロサービス（Open GENAI exApp / 専用ページ向け）。
+
+- 庁内: backend が JWT 検証後、HMAC 署名付きで /events 等へプロキシ
+- 外部: 別ホストの公開プロキシが /public/* のみ upstream（ゲスト回答）
+
+Compose では profiles: ["chosei"] でオプション起動する。
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, Header, Request
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+
+from . import assist, intauth, llm, store
+
+API_KEY = os.environ.get("RAG_API_KEY", "local-rag-key")
+PUBLIC_ENDPOINT = (os.environ.get("CHOSEI_PUBLIC_ENDPOINT") or "").rstrip("/")
+RETENTION_DAYS = int(os.environ.get("CHOSEI_RETENTION_DAYS", "90"))
+CLEANUP_HOUR = int(os.environ.get("CHOSEI_CLEANUP_HOUR", "2"))
+
+PUBLIC_DIR = Path(__file__).resolve().parent.parent / "public"
+
+app = FastAPI(title="Open GENAI Chosei App", version="0.1.0")
+
+
+def _check_key(x_api_key: str | None) -> JSONResponse | None:
+    if API_KEY and x_api_key != API_KEY:
+        return JSONResponse(status_code=401, content={"error": "invalid api key"})
+    return None
+
+
+def _verify_internal(
+    x_api_key: str | None,
+    x_user_id: str | None,
+    x_user_groups: str | None,
+    x_scope: str | None,
+    x_user_ts: str | None,
+    x_user_sig: str | None,
+    x_user_tags: str | None,
+) -> tuple[JSONResponse | None, str]:
+    err = _check_key(x_api_key)
+    if err:
+        return err, ""
+    if not intauth.verify(
+        x_user_id, x_user_groups, x_scope, x_user_ts, x_user_sig, x_user_tags
+    ):
+        return JSONResponse(status_code=401, content={"error": "invalid internal signature"}), ""
+    if not x_user_id:
+        return JSONResponse(status_code=401, content={"error": "認証が必要です"}), ""
+    return None, x_user_id
+
+
+def _normalize_dates(raw: Any) -> tuple[list[dict[str, Any]] | None, str | None]:
+    if not isinstance(raw, list) or len(raw) == 0:
+        return None, "日程候補は必須です"
+    out: list[dict[str, Any]] = []
+    for d in raw:
+        if isinstance(d, str):
+            out.append({"start_time": d, "end_time": None, "is_all_day": False})
+        elif isinstance(d, dict) and d.get("start_time"):
+            out.append(
+                {
+                    "start_time": d["start_time"],
+                    "end_time": d.get("end_time"),
+                    "is_all_day": bool(d.get("is_all_day")),
+                }
+            )
+        else:
+            return None, "日程候補の形式が不正です"
+    return out, None
+
+
+def _cleanup_loop() -> None:
+    """毎日 CLEANUP_HOUR 時頃に古いイベントを削除する簡易スケジューラ。"""
+    while True:
+        try:
+            store.delete_old_events(RETENTION_DAYS)
+        except Exception as e:  # noqa: BLE001
+            print(f"[chosei] cleanup error: {e}")
+        # 次回 CLEANUP_HOUR まで待つ（簡易: 1時間ポーリング）
+        time.sleep(3600)
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    store.init_db()
+    try:
+        n = store.delete_old_events(RETENTION_DAYS)
+        if n:
+            print(f"[chosei] startup cleanup: deleted {n} old events")
+    except Exception as e:  # noqa: BLE001
+        print(f"[chosei] startup cleanup error: {e}")
+    t = threading.Thread(target=_cleanup_loop, name="chosei-cleanup", daemon=True)
+    t.start()
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/config")
+def get_config(
+    x_api_key: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+    x_user_groups: str | None = Header(default=None),
+    x_scope: str | None = Header(default=None),
+    x_user_ts: str | None = Header(default=None),
+    x_user_sig: str | None = Header(default=None),
+    x_user_tags: str | None = Header(default=None),
+) -> JSONResponse:
+    err, _uid = _verify_internal(
+        x_api_key, x_user_id, x_user_groups, x_scope, x_user_ts, x_user_sig, x_user_tags
+    )
+    if err:
+        return err
+    return JSONResponse(
+        content={
+            "public_endpoint": PUBLIC_ENDPOINT,
+            "retention_days": RETENTION_DAYS,
+            "enabled": True,
+            "llm": {
+                "model": llm.CHOSEI_MODEL,
+                "base_url": llm.OPENAI_BASE_URL,
+            },
+        }
+    )
+
+
+@app.get("/events")
+def list_events(
+    x_api_key: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+    x_user_groups: str | None = Header(default=None),
+    x_scope: str | None = Header(default=None),
+    x_user_ts: str | None = Header(default=None),
+    x_user_sig: str | None = Header(default=None),
+    x_user_tags: str | None = Header(default=None),
+) -> JSONResponse:
+    err, uid = _verify_internal(
+        x_api_key, x_user_id, x_user_groups, x_scope, x_user_ts, x_user_sig, x_user_tags
+    )
+    if err:
+        return err
+    return JSONResponse(content={"events": store.list_events_for_user(uid)})
+
+
+@app.post("/events")
+async def create_event(
+    request: Request,
+    x_api_key: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+    x_user_groups: str | None = Header(default=None),
+    x_scope: str | None = Header(default=None),
+    x_user_ts: str | None = Header(default=None),
+    x_user_sig: str | None = Header(default=None),
+    x_user_tags: str | None = Header(default=None),
+) -> JSONResponse:
+    err, uid = _verify_internal(
+        x_api_key, x_user_id, x_user_groups, x_scope, x_user_ts, x_user_sig, x_user_tags
+    )
+    if err:
+        return err
+    body = await request.json()
+    title = (body.get("title") or "").strip()
+    if not title:
+        return JSONResponse(status_code=400, content={"error": "タイトルは必須です"})
+    dates, derr = _normalize_dates(body.get("dates"))
+    if derr or dates is None:
+        return JSONResponse(status_code=400, content={"error": derr})
+    event_password = body.get("event_password")
+    if event_password:
+        perr = store.validate_pin(event_password)
+        if perr:
+            return JSONResponse(status_code=400, content={"error": perr})
+    detail = store.create_event(
+        title=title,
+        description=(body.get("description") or None),
+        creator_name=(body.get("creator_name") or None),
+        creator_user_id=uid,
+        event_password=event_password,
+        dates=dates,
+    )
+    print(f"[chosei] event created id={detail['event']['id']} by={uid}")
+    return JSONResponse(status_code=201, content=detail)
+
+
+@app.get("/events/{event_id}")
+def get_event(
+    event_id: str,
+    x_api_key: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+    x_user_groups: str | None = Header(default=None),
+    x_scope: str | None = Header(default=None),
+    x_user_ts: str | None = Header(default=None),
+    x_user_sig: str | None = Header(default=None),
+    x_user_tags: str | None = Header(default=None),
+) -> JSONResponse:
+    err, _uid = _verify_internal(
+        x_api_key, x_user_id, x_user_groups, x_scope, x_user_ts, x_user_sig, x_user_tags
+    )
+    if err:
+        return err
+    detail = store.event_detail(event_id=event_id)
+    if not detail:
+        return JSONResponse(status_code=404, content={"error": "イベントが見つかりません"})
+    return JSONResponse(content=detail)
+
+
+@app.put("/events/{event_id}")
+async def update_event(
+    event_id: str,
+    request: Request,
+    x_api_key: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+    x_user_groups: str | None = Header(default=None),
+    x_scope: str | None = Header(default=None),
+    x_user_ts: str | None = Header(default=None),
+    x_user_sig: str | None = Header(default=None),
+    x_user_tags: str | None = Header(default=None),
+) -> JSONResponse:
+    err, uid = _verify_internal(
+        x_api_key, x_user_id, x_user_groups, x_scope, x_user_ts, x_user_sig, x_user_tags
+    )
+    if err:
+        return err
+    body = await request.json()
+    title = (body.get("title") or "").strip()
+    if not title:
+        return JSONResponse(status_code=400, content={"error": "タイトルは必須です"})
+    dates = None
+    if body.get("dates") is not None:
+        dates, derr = _normalize_dates(body.get("dates"))
+        if derr or dates is None:
+            return JSONResponse(status_code=400, content={"error": derr})
+    detail, msg = store.update_event(
+        event_id,
+        title=title,
+        description=(body.get("description") or None),
+        creator_name=(body.get("creator_name") or None),
+        dates=dates,
+        event_password=body.get("event_password"),
+        actor_user_id=uid,
+    )
+    if msg:
+        code = 404 if "見つかりません" in msg else 403
+        return JSONResponse(status_code=code, content={"error": msg})
+    return JSONResponse(content=detail)
+
+
+@app.delete("/events/{event_id}")
+async def delete_event(
+    event_id: str,
+    request: Request,
+    x_api_key: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+    x_user_groups: str | None = Header(default=None),
+    x_scope: str | None = Header(default=None),
+    x_user_ts: str | None = Header(default=None),
+    x_user_sig: str | None = Header(default=None),
+    x_user_tags: str | None = Header(default=None),
+) -> JSONResponse:
+    err, uid = _verify_internal(
+        x_api_key, x_user_id, x_user_groups, x_scope, x_user_ts, x_user_sig, x_user_tags
+    )
+    if err:
+        return err
+    body = {}
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        body = {}
+    msg = store.delete_event(
+        event_id, event_password=body.get("event_password"), actor_user_id=uid
+    )
+    if msg:
+        code = 404 if "見つかりません" in msg else 403
+        return JSONResponse(status_code=code, content={"error": msg})
+    print(f"[chosei] event deleted id={event_id} by={uid}")
+    return JSONResponse(content={"message": "イベントが削除されました"})
+
+
+@app.post("/events/{event_id}/responses")
+async def submit_response_auth(
+    event_id: str,
+    request: Request,
+    x_api_key: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+    x_user_groups: str | None = Header(default=None),
+    x_scope: str | None = Header(default=None),
+    x_user_ts: str | None = Header(default=None),
+    x_user_sig: str | None = Header(default=None),
+    x_user_tags: str | None = Header(default=None),
+) -> JSONResponse:
+    err, uid = _verify_internal(
+        x_api_key, x_user_id, x_user_groups, x_scope, x_user_ts, x_user_sig, x_user_tags
+    )
+    if err:
+        return err
+    body = await request.json()
+    name = (body.get("participant_name") or "").strip()
+    responses = body.get("responses")
+    if not name or not isinstance(responses, list):
+        return JSONResponse(status_code=400, content={"error": "参加者名と回答は必須です"})
+    result, msg = store.submit_response(
+        event_id=event_id,
+        participant_name=name,
+        responses=responses,
+        password=body.get("password"),
+        participant_user_id=uid,
+    )
+    if msg:
+        code = 404 if "見つかりません" in msg else 403 if "正しくありません" in msg else 400
+        return JSONResponse(status_code=code, content={"error": msg})
+    return JSONResponse(status_code=201, content=result)
+
+
+@app.delete("/events/{event_id}/participants/{participant_name}")
+async def delete_participant_auth(
+    event_id: str,
+    participant_name: str,
+    request: Request,
+    x_api_key: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+    x_user_groups: str | None = Header(default=None),
+    x_scope: str | None = Header(default=None),
+    x_user_ts: str | None = Header(default=None),
+    x_user_sig: str | None = Header(default=None),
+    x_user_tags: str | None = Header(default=None),
+) -> JSONResponse:
+    err, uid = _verify_internal(
+        x_api_key, x_user_id, x_user_groups, x_scope, x_user_ts, x_user_sig, x_user_tags
+    )
+    if err:
+        return err
+    body = {}
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        body = {}
+    msg = store.delete_participant(
+        event_id=event_id,
+        participant_name=participant_name,
+        password=body.get("password"),
+        actor_user_id=uid,
+    )
+    if msg:
+        code = 404 if "見つかりません" in msg else 403 if "正しくありません" in msg else 400
+        return JSONResponse(status_code=code, content={"error": msg})
+    return JSONResponse(content={"message": "参加者と回答を削除しました"})
+
+
+@app.get("/events/{event_id}/carrier")
+def event_carrier(
+    event_id: str,
+    format: str = "txt",
+    x_api_key: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+    x_user_groups: str | None = Header(default=None),
+    x_scope: str | None = Header(default=None),
+    x_user_ts: str | None = Header(default=None),
+    x_user_sig: str | None = Header(default=None),
+    x_user_tags: str | None = Header(default=None),
+) -> JSONResponse:
+    """外部共有 URL を記載したリンクファイル本文を返す（LGWAN carrier 向け）。"""
+    err, _uid = _verify_internal(
+        x_api_key, x_user_id, x_user_groups, x_scope, x_user_ts, x_user_sig, x_user_tags
+    )
+    if err:
+        return err
+    detail = store.event_detail(event_id=event_id)
+    if not detail:
+        return JSONResponse(status_code=404, content={"error": "イベントが見つかりません"})
+    ev = detail["event"]
+    url = ev["public_url"]
+    title = ev["title"]
+    fmt = (format or "txt").lower()
+    if fmt == "html":
+        body = (
+            "<!DOCTYPE html><html lang='ja'><head><meta charset='utf-8'>"
+            f"<title>{title} - 日程調整リンク</title></head><body>"
+            f"<h1>{title}</h1><p>外部から回答するURL:</p>"
+            f"<p><a href='{url}'>{url}</a></p>"
+            "<p>LGWAN 端末から開けない場合は、このファイルを持ち出して"
+            "インターネット接続端末で開いてください。</p></body></html>"
+        )
+        filename = f"{title}_chosei_link.html"
+    else:
+        body = (
+            f"日程調整: {title}\n\n"
+            f"外部から回答するURL:\n{url}\n\n"
+            "LGWAN 端末から開けない場合は、このファイルを持ち出して"
+            "インターネット接続端末で開いてください。\n"
+        )
+        filename = f"{title}_chosei_link.txt"
+    return JSONResponse(
+        content={"filename": filename, "content": body, "public_url": url, "format": fmt}
+    )
+
+
+# ---------------------------------------------------------------------------
+# LLM アシスト（庁内のみ・HMAC 必須。ゲスト公開面には出さない）
+# ---------------------------------------------------------------------------
+@app.post("/assist/parse-dates")
+async def assist_parse_dates(
+    request: Request,
+    x_api_key: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+    x_user_groups: str | None = Header(default=None),
+    x_scope: str | None = Header(default=None),
+    x_user_ts: str | None = Header(default=None),
+    x_user_sig: str | None = Header(default=None),
+    x_user_tags: str | None = Header(default=None),
+) -> JSONResponse:
+    err, _uid = _verify_internal(
+        x_api_key, x_user_id, x_user_groups, x_scope, x_user_ts, x_user_sig, x_user_tags
+    )
+    if err:
+        return err
+    body = await request.json()
+    text = (body.get("text") or "").strip()
+    try:
+        result = await assist.parse_dates_from_text(text)
+    except ValueError as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
+    except Exception as e:  # noqa: BLE001
+        return JSONResponse(
+            status_code=502,
+            content={"error": f"日程の解釈に失敗しました: {e}"},
+        )
+    return JSONResponse(content=result)
+
+
+@app.post("/events/{event_id}/assist/recommend")
+async def assist_recommend(
+    event_id: str,
+    x_api_key: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+    x_user_groups: str | None = Header(default=None),
+    x_scope: str | None = Header(default=None),
+    x_user_ts: str | None = Header(default=None),
+    x_user_sig: str | None = Header(default=None),
+    x_user_tags: str | None = Header(default=None),
+) -> JSONResponse:
+    err, _uid = _verify_internal(
+        x_api_key, x_user_id, x_user_groups, x_scope, x_user_ts, x_user_sig, x_user_tags
+    )
+    if err:
+        return err
+    try:
+        result = await assist.recommend_slot(event_id)
+    except LookupError as e:
+        return JSONResponse(status_code=404, content={"error": str(e)})
+    except Exception as e:  # noqa: BLE001
+        return JSONResponse(
+            status_code=502,
+            content={"error": f"最適日の提案に失敗しました: {e}"},
+        )
+    return JSONResponse(content=result)
+
+
+@app.post("/events/{event_id}/assist/invite")
+async def assist_invite(
+    event_id: str,
+    request: Request,
+    x_api_key: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+    x_user_groups: str | None = Header(default=None),
+    x_scope: str | None = Header(default=None),
+    x_user_ts: str | None = Header(default=None),
+    x_user_sig: str | None = Header(default=None),
+    x_user_tags: str | None = Header(default=None),
+) -> JSONResponse:
+    err, _uid = _verify_internal(
+        x_api_key, x_user_id, x_user_groups, x_scope, x_user_ts, x_user_sig, x_user_tags
+    )
+    if err:
+        return err
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        body = {}
+    tone = (body.get("tone") or "丁寧").strip() or "丁寧"
+    try:
+        result = await assist.draft_invite(event_id, tone=tone)
+    except LookupError as e:
+        return JSONResponse(status_code=404, content={"error": str(e)})
+    except Exception as e:  # noqa: BLE001
+        return JSONResponse(
+            status_code=502,
+            content={"error": f"案内文の作成に失敗しました: {e}"},
+        )
+    return JSONResponse(content=result)
+
+
+@app.post("/admin/cleanup")
+def admin_cleanup(
+    x_api_key: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+    x_user_groups: str | None = Header(default=None),
+    x_scope: str | None = Header(default=None),
+    x_user_ts: str | None = Header(default=None),
+    x_user_sig: str | None = Header(default=None),
+    x_user_tags: str | None = Header(default=None),
+) -> JSONResponse:
+    err, _uid = _verify_internal(
+        x_api_key, x_user_id, x_user_groups, x_scope, x_user_ts, x_user_sig, x_user_tags
+    )
+    if err:
+        return err
+    deleted = store.delete_old_events(RETENTION_DAYS)
+    return JSONResponse(
+        content={
+            "success": True,
+            "deleted_count": deleted,
+            "message": f"{deleted}件の古いイベントを削除しました",
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# 公開面（ゲスト）。公開プロキシはここだけ upstream すること。
+# ---------------------------------------------------------------------------
+@app.get("/public/api/events/{guest_token}")
+def public_get_event(guest_token: str) -> JSONResponse:
+    detail = store.event_detail(guest_token=guest_token)
+    if not detail:
+        return JSONResponse(status_code=404, content={"error": "イベントが見つかりません"})
+    # 内部識別子はゲストに出さない
+    ev = dict(detail["event"])
+    ev.pop("creator_user_id", None)
+    ev.pop("id", None)
+    return JSONResponse(
+        content={
+            "event": ev,
+            "dates": detail["dates"],
+            "responses": [
+                {
+                    "participant_name": r["participant_name"],
+                    "event_date_id": r["event_date_id"],
+                    "status": r["status"],
+                    "date_time": r["date_time"],
+                }
+                for r in detail["responses"]
+            ],
+            "statistics": detail["statistics"],
+        }
+    )
+
+
+@app.post("/public/api/events/{guest_token}/responses")
+async def public_submit_response(guest_token: str, request: Request) -> JSONResponse:
+    body = await request.json()
+    name = (body.get("participant_name") or "").strip()
+    responses = body.get("responses")
+    if not name or not isinstance(responses, list):
+        return JSONResponse(status_code=400, content={"error": "参加者名と回答は必須です"})
+    result, msg = store.submit_response(
+        guest_token=guest_token,
+        participant_name=name,
+        responses=responses,
+        password=body.get("password"),
+        participant_user_id=None,
+    )
+    if msg:
+        code = 404 if "見つかりません" in msg else 403 if "正しくありません" in msg else 400
+        return JSONResponse(status_code=code, content={"error": msg})
+    return JSONResponse(status_code=201, content=result)
+
+
+@app.delete("/public/api/events/{guest_token}/participants/{participant_name}")
+async def public_delete_participant(
+    guest_token: str, participant_name: str, request: Request
+) -> JSONResponse:
+    body = {}
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        body = {}
+    msg = store.delete_participant(
+        guest_token=guest_token,
+        participant_name=participant_name,
+        password=body.get("password"),
+        actor_user_id=None,
+    )
+    if msg:
+        code = 404 if "見つかりません" in msg else 403 if "正しくありません" in msg else 400
+        return JSONResponse(status_code=code, content={"error": msg})
+    return JSONResponse(content={"message": "参加者と回答を削除しました"})
+
+
+@app.get("/public/e/{guest_token}", response_model=None)
+def public_event_page(guest_token: str) -> FileResponse | HTMLResponse:
+    path = PUBLIC_DIR / "event.html"
+    if path.is_file():
+        return FileResponse(path, media_type="text/html; charset=utf-8")
+    return HTMLResponse("<p>ゲスト UI が未配置です</p>", status_code=500)
+
+
+@app.get("/public/", response_class=HTMLResponse)
+@app.get("/public", response_class=HTMLResponse)
+def public_index() -> HTMLResponse:
+    return HTMLResponse(
+        "<!DOCTYPE html><html lang='ja'><head><meta charset='utf-8'>"
+        "<title>日程調整</title></head><body>"
+        "<p>イベントの共有リンクからアクセスしてください。</p></body></html>"
+    )
+
+
+if PUBLIC_DIR.is_dir():
+    app.mount("/public/assets", StaticFiles(directory=str(PUBLIC_DIR)), name="public-assets")

--- a/chosei-app/app/store.py
+++ b/chosei-app/app/store.py
@@ -1,0 +1,500 @@
+"""日程調整の SQLite 永続化。"""
+
+from __future__ import annotations
+
+import os
+import re
+import secrets
+import sqlite3
+import threading
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import bcrypt
+
+DB_PATH = os.environ.get("CHOSEI_DB_PATH", "/data/chosei.db")
+RETENTION_DAYS = int(os.environ.get("CHOSEI_RETENTION_DAYS", "90"))
+PUBLIC_ENDPOINT = (os.environ.get("CHOSEI_PUBLIC_ENDPOINT") or "").rstrip("/")
+
+_PIN_RE = re.compile(r"^\d{4}$")
+_lock = threading.Lock()
+_db: sqlite3.Connection | None = None
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def hash_pin(pin: str) -> str:
+    return bcrypt.hashpw(pin.encode("utf-8"), bcrypt.gensalt()).decode("ascii")
+
+
+def verify_pin(pin: str, hashed: str | None) -> bool:
+    if not hashed or not pin:
+        return False
+    try:
+        return bcrypt.checkpw(pin.encode("utf-8"), hashed.encode("ascii"))
+    except (ValueError, TypeError):
+        return False
+
+
+def validate_pin(pin: str | None) -> str | None:
+    """不正ならエラーメッセージ、正しければ None。"""
+    if not pin:
+        return "暗証番号は必須です（4桁の数字）"
+    if not _PIN_RE.match(pin):
+        return "暗証番号は4桁の数字である必要があります"
+    return None
+
+
+def connect() -> sqlite3.Connection:
+    global _db
+    if _db is not None:
+        return _db
+    os.makedirs(os.path.dirname(DB_PATH) or ".", exist_ok=True)
+    conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    _db = conn
+    return conn
+
+
+def init_db() -> None:
+    db = connect()
+    with _lock:
+        db.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS events (
+              id TEXT PRIMARY KEY,
+              guest_token TEXT NOT NULL UNIQUE,
+              title TEXT NOT NULL,
+              description TEXT,
+              creator_name TEXT,
+              creator_user_id TEXT,
+              event_password_hash TEXT,
+              created_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS event_dates (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              event_id TEXT NOT NULL,
+              date_time TEXT NOT NULL,
+              end_time TEXT,
+              is_all_day INTEGER DEFAULT 0,
+              created_at TEXT NOT NULL,
+              FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
+            );
+            CREATE TABLE IF NOT EXISTS responses (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              event_date_id INTEGER NOT NULL,
+              participant_name TEXT NOT NULL,
+              participant_user_id TEXT,
+              status TEXT NOT NULL CHECK (status IN ('ok', 'ng', 'maybe')),
+              created_at TEXT NOT NULL,
+              FOREIGN KEY (event_date_id) REFERENCES event_dates(id) ON DELETE CASCADE,
+              UNIQUE(event_date_id, participant_name)
+            );
+            CREATE TABLE IF NOT EXISTS participant_passwords (
+              event_id TEXT NOT NULL,
+              participant_name TEXT NOT NULL,
+              participant_user_id TEXT,
+              password_hash TEXT NOT NULL,
+              created_at TEXT NOT NULL,
+              PRIMARY KEY (event_id, participant_name),
+              FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_event_dates_event_id ON event_dates(event_id);
+            CREATE INDEX IF NOT EXISTS idx_responses_event_date_id ON responses(event_date_id);
+            CREATE INDEX IF NOT EXISTS idx_events_creator ON events(creator_user_id);
+            CREATE INDEX IF NOT EXISTS idx_events_guest_token ON events(guest_token);
+            """
+        )
+        db.commit()
+
+
+def _row_to_event(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "id": row["id"],
+        "guest_token": row["guest_token"],
+        "title": row["title"],
+        "description": row["description"],
+        "creator_name": row["creator_name"],
+        "creator_user_id": row["creator_user_id"],
+        "has_event_password": bool(row["event_password_hash"]),
+        "created_at": row["created_at"],
+        "public_url": public_url_for(row["guest_token"]),
+    }
+
+
+def public_url_for(guest_token: str) -> str:
+    if not PUBLIC_ENDPOINT:
+        return f"/public/e/{guest_token}"
+    return f"{PUBLIC_ENDPOINT}/public/e/{guest_token}"
+
+
+def _get_dates(db: sqlite3.Connection, event_id: str) -> list[dict[str, Any]]:
+    rows = db.execute(
+        "SELECT id, date_time, end_time, is_all_day, created_at "
+        "FROM event_dates WHERE event_id = ? ORDER BY date_time",
+        (event_id,),
+    ).fetchall()
+    return [
+        {
+            "id": r["id"],
+            "date_time": r["date_time"],
+            "end_time": r["end_time"],
+            "is_all_day": bool(r["is_all_day"]),
+            "created_at": r["created_at"],
+        }
+        for r in rows
+    ]
+
+
+def _get_responses(db: sqlite3.Connection, event_id: str) -> list[dict[str, Any]]:
+    rows = db.execute(
+        """
+        SELECT r.id, r.participant_name, r.participant_user_id, r.event_date_id,
+               r.status, ed.date_time
+        FROM responses r
+        JOIN event_dates ed ON r.event_date_id = ed.id
+        WHERE ed.event_id = ?
+        ORDER BY r.participant_name, ed.date_time
+        """,
+        (event_id,),
+    ).fetchall()
+    return [
+        {
+            "id": r["id"],
+            "participant_name": r["participant_name"],
+            "participant_user_id": r["participant_user_id"],
+            "event_date_id": r["event_date_id"],
+            "status": r["status"],
+            "date_time": r["date_time"],
+        }
+        for r in rows
+    ]
+
+
+def _statistics(dates: list[dict[str, Any]], responses: list[dict[str, Any]]) -> dict[str, Any]:
+    stats: dict[str, Any] = {}
+    for d in dates:
+        stats[str(d["id"])] = {
+            "date_time": d["date_time"],
+            "ok": 0,
+            "ng": 0,
+            "maybe": 0,
+            "participants": [],
+        }
+    for r in responses:
+        key = str(r["event_date_id"])
+        st = stats.get(key)
+        if not st:
+            continue
+        st[r["status"]] = st.get(r["status"], 0) + 1
+        if r["participant_name"] not in st["participants"]:
+            st["participants"].append(r["participant_name"])
+    return stats
+
+
+def event_detail(event_id: str | None = None, guest_token: str | None = None) -> dict[str, Any] | None:
+    db = connect()
+    with _lock:
+        if guest_token:
+            row = db.execute(
+                "SELECT * FROM events WHERE guest_token = ?", (guest_token,)
+            ).fetchone()
+        else:
+            row = db.execute("SELECT * FROM events WHERE id = ?", (event_id,)).fetchone()
+        if not row:
+            return None
+        dates = _get_dates(db, row["id"])
+        responses = _get_responses(db, row["id"])
+        return {
+            "event": _row_to_event(row),
+            "dates": dates,
+            "responses": responses,
+            "statistics": _statistics(dates, responses),
+        }
+
+
+def list_events_for_user(user_id: str) -> list[dict[str, Any]]:
+    db = connect()
+    with _lock:
+        rows = db.execute(
+            """
+            SELECT * FROM events
+            WHERE creator_user_id = ?
+               OR id IN (
+                 SELECT DISTINCT ed.event_id FROM event_dates ed
+                 JOIN responses r ON r.event_date_id = ed.id
+                 WHERE r.participant_user_id = ?
+               )
+            ORDER BY created_at DESC
+            """,
+            (user_id, user_id),
+        ).fetchall()
+        return [_row_to_event(r) for r in rows]
+
+
+def create_event(
+    *,
+    title: str,
+    description: str | None,
+    creator_name: str | None,
+    creator_user_id: str,
+    event_password: str | None,
+    dates: list[dict[str, Any]],
+) -> dict[str, Any]:
+    event_id = str(uuid.uuid4())
+    guest_token = secrets.token_urlsafe(24)
+    now = _now_iso()
+    pw_hash = hash_pin(event_password) if event_password else None
+    db = connect()
+    with _lock:
+        db.execute(
+            "INSERT INTO events (id, guest_token, title, description, creator_name, "
+            "creator_user_id, event_password_hash, created_at) VALUES (?,?,?,?,?,?,?,?)",
+            (
+                event_id,
+                guest_token,
+                title,
+                description,
+                creator_name,
+                creator_user_id,
+                pw_hash,
+                now,
+            ),
+        )
+        for d in dates:
+            db.execute(
+                "INSERT INTO event_dates (event_id, date_time, end_time, is_all_day, created_at) "
+                "VALUES (?,?,?,?,?)",
+                (
+                    event_id,
+                    d["start_time"],
+                    d.get("end_time"),
+                    1 if d.get("is_all_day") else 0,
+                    now,
+                ),
+            )
+        db.commit()
+    detail = event_detail(event_id=event_id)
+    assert detail is not None
+    return detail
+
+
+def update_event(
+    event_id: str,
+    *,
+    title: str,
+    description: str | None,
+    creator_name: str | None,
+    dates: list[dict[str, Any]] | None,
+    event_password: str | None,
+    actor_user_id: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    db = connect()
+    with _lock:
+        row = db.execute("SELECT * FROM events WHERE id = ?", (event_id,)).fetchone()
+        if not row:
+            return None, "イベントが見つかりません"
+        is_creator = row["creator_user_id"] == actor_user_id
+        if not is_creator:
+            if not row["event_password_hash"]:
+                return None, "このイベントには暗証番号が設定されていないため、編集できません"
+            if not event_password or not verify_pin(event_password, row["event_password_hash"]):
+                return None, "イベントの暗証番号が正しくありません"
+        now = _now_iso()
+        db.execute(
+            "UPDATE events SET title = ?, description = ?, creator_name = ? WHERE id = ?",
+            (title, description, creator_name, event_id),
+        )
+        if dates is not None and len(dates) > 0:
+            db.execute("DELETE FROM event_dates WHERE event_id = ?", (event_id,))
+            for d in dates:
+                db.execute(
+                    "INSERT INTO event_dates (event_id, date_time, end_time, is_all_day, created_at) "
+                    "VALUES (?,?,?,?,?)",
+                    (
+                        event_id,
+                        d["start_time"],
+                        d.get("end_time"),
+                        1 if d.get("is_all_day") else 0,
+                        now,
+                    ),
+                )
+        db.commit()
+    return event_detail(event_id=event_id), None
+
+
+def delete_event(
+    event_id: str, *, event_password: str | None, actor_user_id: str
+) -> str | None:
+    db = connect()
+    with _lock:
+        row = db.execute("SELECT * FROM events WHERE id = ?", (event_id,)).fetchone()
+        if not row:
+            return "イベントが見つかりません"
+        is_creator = row["creator_user_id"] == actor_user_id
+        if not is_creator:
+            if not row["event_password_hash"]:
+                return "このイベントには暗証番号が設定されていないため、削除できません"
+            if not event_password or not verify_pin(event_password, row["event_password_hash"]):
+                return "イベントの暗証番号が正しくありません"
+        db.execute("DELETE FROM events WHERE id = ?", (event_id,))
+        db.commit()
+    return None
+
+
+def submit_response(
+    *,
+    event_id: str | None = None,
+    guest_token: str | None = None,
+    participant_name: str,
+    responses: list[dict[str, Any]],
+    password: str | None,
+    participant_user_id: str | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    db = connect()
+    with _lock:
+        if guest_token:
+            event = db.execute(
+                "SELECT id FROM events WHERE guest_token = ?", (guest_token,)
+            ).fetchone()
+        else:
+            event = db.execute("SELECT id FROM events WHERE id = ?", (event_id,)).fetchone()
+        if not event:
+            return None, "イベントが見つかりません"
+        eid = event["id"]
+
+        existing = db.execute(
+            "SELECT password_hash, participant_user_id FROM participant_passwords "
+            "WHERE event_id = ? AND participant_name = ?",
+            (eid, participant_name),
+        ).fetchone()
+
+        # 認証ユーザーで同一 user_id の既存参加者がいれば PIN 不要で上書き可
+        auth_owned = False
+        if participant_user_id and existing and existing["participant_user_id"] == participant_user_id:
+            auth_owned = True
+
+        if existing and not auth_owned:
+            err = validate_pin(password)
+            if err:
+                return None, err
+            if not verify_pin(password or "", existing["password_hash"]):
+                return None, "暗証番号が正しくありません"
+        elif not existing:
+            err = validate_pin(password)
+            if err:
+                return None, err
+
+        now = _now_iso()
+        if not existing:
+            db.execute(
+                "INSERT INTO participant_passwords "
+                "(event_id, participant_name, participant_user_id, password_hash, created_at) "
+                "VALUES (?,?,?,?,?)",
+                (eid, participant_name, participant_user_id, hash_pin(password or ""), now),
+            )
+        elif participant_user_id and not existing["participant_user_id"]:
+            db.execute(
+                "UPDATE participant_passwords SET participant_user_id = ? "
+                "WHERE event_id = ? AND participant_name = ?",
+                (participant_user_id, eid, participant_name),
+            )
+
+        db.execute(
+            """
+            DELETE FROM responses
+            WHERE event_date_id IN (SELECT id FROM event_dates WHERE event_id = ?)
+              AND participant_name = ?
+            """,
+            (eid, participant_name),
+        )
+        for r in responses:
+            status = r.get("status")
+            date_id = r.get("event_date_id")
+            if status not in ("ok", "ng", "maybe") or date_id is None:
+                continue
+            # 日程がこのイベントのものか確認
+            owned = db.execute(
+                "SELECT 1 FROM event_dates WHERE id = ? AND event_id = ?",
+                (date_id, eid),
+            ).fetchone()
+            if not owned:
+                continue
+            db.execute(
+                "INSERT INTO responses "
+                "(event_date_id, participant_name, participant_user_id, status, created_at) "
+                "VALUES (?,?,?,?,?)",
+                (date_id, participant_name, participant_user_id, status, now),
+            )
+        db.commit()
+    return {
+        "message": "回答が送信されました",
+        "is_new_participant": existing is None,
+    }, None
+
+
+def delete_participant(
+    *,
+    event_id: str | None = None,
+    guest_token: str | None = None,
+    participant_name: str,
+    password: str | None,
+    actor_user_id: str | None = None,
+) -> str | None:
+    db = connect()
+    with _lock:
+        if guest_token:
+            event = db.execute(
+                "SELECT id FROM events WHERE guest_token = ?", (guest_token,)
+            ).fetchone()
+        else:
+            event = db.execute("SELECT id FROM events WHERE id = ?", (event_id,)).fetchone()
+        if not event:
+            return "イベントが見つかりません"
+        eid = event["id"]
+        existing = db.execute(
+            "SELECT password_hash, participant_user_id FROM participant_passwords "
+            "WHERE event_id = ? AND participant_name = ?",
+            (eid, participant_name),
+        ).fetchone()
+        if not existing:
+            return "参加者が見つかりません"
+        auth_owned = (
+            actor_user_id
+            and existing["participant_user_id"]
+            and existing["participant_user_id"] == actor_user_id
+        )
+        if not auth_owned:
+            err = validate_pin(password)
+            if err:
+                return err
+            if not verify_pin(password or "", existing["password_hash"]):
+                return "暗証番号が正しくありません"
+        db.execute(
+            """
+            DELETE FROM responses
+            WHERE event_date_id IN (SELECT id FROM event_dates WHERE event_id = ?)
+              AND participant_name = ?
+            """,
+            (eid, participant_name),
+        )
+        db.execute(
+            "DELETE FROM participant_passwords WHERE event_id = ? AND participant_name = ?",
+            (eid, participant_name),
+        )
+        db.commit()
+    return None
+
+
+def delete_old_events(retention_days: int | None = None) -> int:
+    days = retention_days if retention_days is not None else RETENTION_DAYS
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).replace(microsecond=0).isoformat()
+    db = connect()
+    with _lock:
+        cur = db.execute("DELETE FROM events WHERE created_at < ?", (cutoff,))
+        db.commit()
+        return cur.rowcount

--- a/chosei-app/public/event.html
+++ b/chosei-app/public/event.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>日程調整</title>
+    <link rel="stylesheet" href="/public/assets/style.css" />
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="brand">Open GENAI · 日程調整</div>
+      <div id="root">
+        <p class="hint">読み込み中...</p>
+      </div>
+    </div>
+    <script src="/public/assets/guest.js"></script>
+  </body>
+</html>

--- a/chosei-app/public/guest.js
+++ b/chosei-app/public/guest.js
@@ -1,0 +1,268 @@
+(function () {
+  const root = document.getElementById("root");
+  const parts = location.pathname.split("/").filter(Boolean);
+  // /public/e/{token}
+  const tokenIdx = parts.indexOf("e");
+  const token = tokenIdx >= 0 ? parts[tokenIdx + 1] : "";
+
+  if (!token) {
+    root.innerHTML = "<p class='error'>共有リンクが不正です。</p>";
+    return;
+  }
+
+  const statusLabel = { ok: "参加可", maybe: "検討中", ng: "不可" };
+  const statusMark = { ok: "○", maybe: "△", ng: "×" };
+
+  function fmtDate(iso, end, allDay) {
+    try {
+      const d = new Date(iso);
+      const opts = allDay
+        ? { year: "numeric", month: "short", day: "numeric", weekday: "short" }
+        : {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+            weekday: "short",
+            hour: "2-digit",
+            minute: "2-digit",
+          };
+      let s = d.toLocaleString("ja-JP", opts);
+      if (end && !allDay) {
+        const e = new Date(end);
+        s +=
+          " 〜 " +
+          e.toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" });
+      }
+      return s;
+    } catch {
+      return iso;
+    }
+  }
+
+  function esc(s) {
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function participantsOf(data) {
+    const names = [];
+    const seen = new Set();
+    for (const r of data.responses || []) {
+      if (!seen.has(r.participant_name)) {
+        seen.add(r.participant_name);
+        names.push(r.participant_name);
+      }
+    }
+    return names;
+  }
+
+  function answerMap(data) {
+    // name -> { dateId -> status }
+    const map = {};
+    for (const r of data.responses || []) {
+      if (!map[r.participant_name]) map[r.participant_name] = {};
+      map[r.participant_name][r.event_date_id] = r.status;
+    }
+    return map;
+  }
+
+  function matrixHtml(data) {
+    const dates = data.dates || [];
+    const names = participantsOf(data);
+    const answers = answerMap(data);
+
+    if (dates.length === 0) {
+      return "<p class='hint'>日程候補がありません。</p>";
+    }
+
+    const headNames = names
+      .map(function (n) {
+        return '<th class="col-person">' + esc(n) + "</th>";
+      })
+      .join("");
+
+    const body = dates
+      .map(function (d) {
+        const st = (data.statistics && data.statistics[String(d.id)]) || {};
+        const personCells = names
+          .map(function (n) {
+            const status = answers[n] && answers[n][d.id];
+            const mark = status ? statusMark[status] : "—";
+            const cls = status ? "mark mark-" + status : "mark mark-empty";
+            return (
+              '<td class="col-person ' +
+              cls +
+              '" title="' +
+              esc(status ? statusLabel[status] : "未回答") +
+              '">' +
+              mark +
+              "</td>"
+            );
+          })
+          .join("");
+        return (
+          "<tr><th scope='row' class='col-date'>" +
+          esc(fmtDate(d.date_time, d.end_time, d.is_all_day)) +
+          (d.is_all_day ? "（終日）" : "") +
+          "</th>" +
+          '<td class="col-sum">' +
+          (st.ok || 0) +
+          "</td>" +
+          '<td class="col-sum">' +
+          (st.maybe || 0) +
+          "</td>" +
+          '<td class="col-sum">' +
+          (st.ng || 0) +
+          "</td>" +
+          personCells +
+          "</tr>"
+        );
+      })
+      .join("");
+
+    return (
+      '<div class="matrix-wrap">' +
+      '<table class="matrix">' +
+      "<thead><tr>" +
+      '<th class="col-date">日程</th>' +
+      '<th class="col-sum" title="参加可">○</th>' +
+      '<th class="col-sum" title="検討中">△</th>' +
+      '<th class="col-sum" title="不可">×</th>' +
+      headNames +
+      "</tr></thead><tbody>" +
+      body +
+      "</tbody></table></div>" +
+      (names.length === 0
+        ? "<p class='hint'>まだ回答がありません。下のフォームから回答できます。</p>"
+        : "")
+    );
+  }
+
+  async function load() {
+    const res = await fetch("/public/api/events/" + encodeURIComponent(token));
+    const data = await res.json();
+    if (!res.ok) {
+      root.innerHTML =
+        "<p class='error'>" + esc(data.error || "読み込みに失敗しました") + "</p>";
+      return;
+    }
+    render(data);
+  }
+
+  function render(data) {
+    const ev = data.event;
+    const dates = data.dates || [];
+    const names = participantsOf(data);
+    document.title = ev.title + " · 日程調整";
+
+    let dateRows = dates
+      .map((d) => {
+        return (
+          '<div class="row" data-date-id="' +
+          d.id +
+          '">' +
+          '<div class="date-label">' +
+          esc(fmtDate(d.date_time, d.end_time, d.is_all_day)) +
+          (d.is_all_day ? "（終日）" : "") +
+          "</div>" +
+          '<div class="statuses">' +
+          ["ok", "maybe", "ng"]
+            .map(
+              (st) =>
+                "<label><input type='radio' name='st-" +
+                d.id +
+                "' value='" +
+                st +
+                "' /> " +
+                statusMark[st] +
+                " " +
+                statusLabel[st] +
+                "</label>"
+            )
+            .join("") +
+          "</div></div>"
+        );
+      })
+      .join("");
+
+    root.innerHTML =
+      "<h1>" +
+      esc(ev.title) +
+      "</h1>" +
+      "<p class='hint'>回答者" +
+      names.length +
+      "名</p>" +
+      (ev.creator_name
+        ? "<p class='hint'>作成者: " + esc(ev.creator_name) + "</p>"
+        : "") +
+      (ev.description
+        ? "<p class='meta'>" + esc(ev.description) + "</p>"
+        : "") +
+      "<div class='card stats'><h2 style='margin-top:0;font-size:1.1rem'>日程候補・回答一覧</h2>" +
+      "<p class='hint'>行が日程、列が回答者です。○参加可 / △検討中 / ×不可</p>" +
+      matrixHtml(data) +
+      "</div>" +
+      "<div class='card'><h2 style='margin-top:0;font-size:1.1rem'>出欠を入力する</h2>" +
+      "<label for='name'>お名前</label>" +
+      "<input id='name' type='text' autocomplete='name' />" +
+      "<label for='pin'>暗証番号（4桁）</label>" +
+      "<input id='pin' type='password' inputmode='numeric' maxlength='4' autocomplete='off' />" +
+      "<p class='hint'>初回は暗証番号を設定します。再回答・削除時に同じ番号が必要です。</p>" +
+      dateRows +
+      "<p id='msg' class='error' style='display:none'></p>" +
+      "<div style='margin-top:1rem;display:flex;gap:0.5rem;flex-wrap:wrap'>" +
+      "<button type='button' id='submit'>回答を送信</button>" +
+      "<button type='button' class='secondary' id='reload'>再読み込み</button>" +
+      "</div></div>";
+
+    document.getElementById("reload").onclick = load;
+    document.getElementById("submit").onclick = async function () {
+      const name = document.getElementById("name").value.trim();
+      const pin = document.getElementById("pin").value.trim();
+      const msg = document.getElementById("msg");
+      msg.style.display = "none";
+      if (!name) {
+        msg.textContent = "お名前を入力してください";
+        msg.style.display = "block";
+        return;
+      }
+      const responses = dates.map((d) => {
+        const checked = document.querySelector(
+          'input[name="st-' + d.id + '"]:checked'
+        );
+        return {
+          event_date_id: d.id,
+          status: checked ? checked.value : "ng",
+        };
+      });
+      const res = await fetch(
+        "/public/api/events/" + encodeURIComponent(token) + "/responses",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            participant_name: name,
+            password: pin,
+            responses: responses,
+          }),
+        }
+      );
+      const body = await res.json();
+      if (!res.ok) {
+        msg.textContent = body.error || "送信に失敗しました";
+        msg.style.display = "block";
+        return;
+      }
+      await load();
+      alert(body.message || "送信しました");
+    };
+  }
+
+  load().catch(function (e) {
+    root.innerHTML =
+      "<p class='error'>読み込みに失敗しました: " + esc(String(e)) + "</p>";
+  });
+})();

--- a/chosei-app/public/style.css
+++ b/chosei-app/public/style.css
@@ -1,0 +1,257 @@
+:root {
+  --blue-900: #0017c1;
+  --blue-1000: #000082;
+  --solid-gray-50: #f8f8fb;
+  --solid-gray-300: #d8d8d8;
+  --solid-gray-420: #b4b4b4;
+  --solid-gray-600: #767676;
+  --solid-gray-700: #626262;
+  --solid-gray-900: #222222;
+  --error: #c41a1a;
+  --ok-bg: #e8f5e9;
+  --maybe-bg: #fff8e1;
+  --ng-bg: #fce4ec;
+  --font: "Noto Sans JP", "Hiragino Sans", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font);
+  color: var(--solid-gray-900);
+  background: linear-gradient(180deg, #eef1f8 0%, var(--solid-gray-50) 40%, #fff 100%);
+  min-height: 100vh;
+  line-height: 1.7;
+}
+
+.wrap {
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: 1.5rem 1.25rem 3rem;
+}
+
+h1 {
+  font-size: 1.35rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+}
+
+.brand {
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--blue-900);
+  margin-bottom: 1rem;
+}
+
+.meta {
+  color: var(--solid-gray-700);
+  margin-bottom: 1.5rem;
+  white-space: pre-wrap;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid var(--solid-gray-300);
+  border-radius: 8px;
+  padding: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+label {
+  display: block;
+  font-weight: 700;
+  font-size: 0.9rem;
+  margin-bottom: 0.35rem;
+}
+
+input[type="text"],
+input[type="password"] {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--solid-gray-420);
+  border-radius: 4px;
+  font: inherit;
+  margin-bottom: 1rem;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--solid-gray-300);
+}
+
+.row:last-child {
+  border-bottom: none;
+}
+
+.date-label {
+  flex: 1 1 12rem;
+  font-size: 0.95rem;
+}
+
+.statuses {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.statuses label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: 500;
+  margin: 0;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--solid-gray-300);
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.statuses input {
+  margin: 0;
+}
+
+.statuses label:has(input[value="ok"]:checked) {
+  background: var(--ok-bg);
+  border-color: #81c784;
+}
+.statuses label:has(input[value="maybe"]:checked) {
+  background: var(--maybe-bg);
+  border-color: #ffd54f;
+}
+.statuses label:has(input[value="ng"]:checked) {
+  background: var(--ng-bg);
+  border-color: #f48fb1;
+}
+
+button {
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 0.65rem 1.25rem;
+  border: 4px double transparent;
+  background: var(--blue-900);
+  color: #fff;
+}
+
+button:hover {
+  background: var(--blue-1000);
+  text-decoration: underline;
+}
+
+button.secondary {
+  background: #fff;
+  color: var(--blue-900);
+  border: 1px solid var(--blue-900);
+}
+
+.error {
+  color: var(--error);
+  margin: 0.75rem 0;
+}
+
+.stats table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.stats th,
+.stats td {
+  border-bottom: 1px solid var(--solid-gray-300);
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.hint {
+  font-size: 0.85rem;
+  color: var(--solid-gray-600);
+}
+
+/* 調整さん風：日程×回答者マトリクス */
+.matrix-wrap {
+  overflow-x: auto;
+  margin-top: 0.75rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+table.matrix {
+  width: max-content;
+  min-width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+table.matrix th,
+table.matrix td {
+  border: 1px solid var(--solid-gray-300);
+  padding: 0.55rem 0.65rem;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+table.matrix thead th {
+  background: var(--solid-gray-50);
+  font-weight: 700;
+}
+
+table.matrix .col-date {
+  text-align: left;
+  min-width: 10rem;
+  position: sticky;
+  left: 0;
+  background: #fff;
+  z-index: 1;
+}
+
+table.matrix thead .col-date {
+  background: var(--solid-gray-50);
+  z-index: 2;
+}
+
+table.matrix .col-sum {
+  min-width: 2.5rem;
+  color: var(--solid-gray-700);
+  font-variant-numeric: tabular-nums;
+}
+
+table.matrix .col-person {
+  min-width: 4.5rem;
+  max-width: 8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+table.matrix .mark {
+  font-size: 1.15rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+table.matrix .mark-ok {
+  color: #1b5e20;
+}
+
+table.matrix .mark-maybe {
+  color: #e65100;
+}
+
+table.matrix .mark-ng {
+  color: var(--solid-gray-600);
+}
+
+table.matrix .mark-empty {
+  color: var(--solid-gray-420);
+  font-weight: 500;
+}

--- a/chosei-app/requirements.txt
+++ b/chosei-app/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.139.0
+uvicorn[standard]==0.34.0
+bcrypt==4.2.1
+httpx==0.28.1

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -79,6 +79,9 @@ services:
       - NGWORD_APP_URL=${NGWORD_APP_URL:-http://ngword-app:8008/invoke}
       - NGWORD_DB_PATH=/data/ngwords.db
       - PROMPT_APP_URL=${PROMPT_APP_URL:-http://prompt-app:8009/invoke}
+      # 日程調整（profiles: ["chosei"] で起動。未起動時は専用ページが案内を表示）
+      - CHOSEI_APP_URL=${CHOSEI_APP_URL:-http://chosei-app:8010/invoke}
+      - CHOSEI_PUBLIC_ENDPOINT=${CHOSEI_PUBLIC_ENDPOINT:-}
       # 内部サービス間署名の共有鍵（x-user-* 偽装対策）。全 exApp と同一値・必須。
       - INTERNAL_SIGNING_SECRET=${INTERNAL_SIGNING_SECRET:?INTERNAL_SIGNING_SECRET を設定してください}
       # 成果物取得(SSRF 対策): 許可ホスト(カンマ区切り)とサイズ上限。既知の生成元のみ許可を推奨。
@@ -366,6 +369,31 @@ services:
       - backend_data:/data
     restart: unless-stopped
 
+  # 任意: 日程調整（`COMPOSE_PROFILES=chosei` または `--profile chosei`）
+  # ホストポートは公開しない。外部ゲストは別プロキシで /public のみ露出すること。
+  chosei-app:
+    profiles: ["chosei"]
+    build: ./chosei-app
+    container_name: open-genai-chosei-app
+    environment:
+      - RAG_API_KEY=${RAG_API_KEY:-local-rag-key}
+      - INTERNAL_SIGNING_SECRET=${INTERNAL_SIGNING_SECRET:?INTERNAL_SIGNING_SECRET を設定してください}
+      - CHOSEI_DB_PATH=/data/chosei.db
+      # profile 有効時は外部公開 URL を必ず設定すること（例: https://chosei.example.lg.jp）
+      - CHOSEI_PUBLIC_ENDPOINT=${CHOSEI_PUBLIC_ENDPOINT:-}
+      - CHOSEI_RETENTION_DAYS=${CHOSEI_RETENTION_DAYS:-90}
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-ollama}
+      - CHOSEI_MODEL=${CHOSEI_MODEL:-${DEFAULT_MODEL:-qwen2.5:7b}}
+    volumes:
+      - chosei_app_data:/data
+    expose:
+      - "8010"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
   # 成果物ファイル配信用の自前オブジェクトストレージ（OSS・S3互換）。
   # 本番: 利用者がインターネットから取得するため、別途 TLS 付きの公開経路
   #       （S3_PUBLIC_ENDPOINT）へ 8333 を露出する構成にすること。
@@ -397,3 +425,4 @@ volumes:
   dify_app_data:
   rag_app_data:
   seaweedfs_data:
+  chosei_app_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,9 @@ services:
       - NGWORD_DB_PATH=/data/ngwords.db
       # プロンプトテンプレート「AI アプリ」連携先（全ユーザー利用可）
       - PROMPT_APP_URL=${PROMPT_APP_URL:-http://prompt-app:8009/invoke}
+      # 日程調整（profiles: ["chosei"] で起動。未起動時は専用ページが案内を表示）
+      - CHOSEI_APP_URL=${CHOSEI_APP_URL:-http://chosei-app:8010/invoke}
+      - CHOSEI_PUBLIC_ENDPOINT=${CHOSEI_PUBLIC_ENDPOINT:-http://localhost:8010}
       # 内部サービス間署名の共有鍵（x-user-* 偽装対策）。全 exApp と同一値。本番は必ず変更。
       - INTERNAL_SIGNING_SECRET=${INTERNAL_SIGNING_SECRET:-dev-internal-secret-change-me}
       # 成果物取得(SSRF 対策): 許可ホスト(カンマ区切り, 空=内部宛先のみ拒否)とサイズ上限
@@ -378,6 +381,33 @@ services:
       - ollama_data:/root/.ollama
     restart: unless-stopped
 
+  # 任意: 日程調整 (`docker compose --profile chosei up -d` または COMPOSE_PROFILES=chosei)
+  # 庁内は backend → 本サービス。外部ゲストは CHOSEI_PUBLIC_ENDPOINT（開発時は :8010）へ。
+  # 本番の外部公開は /public のみを別プロキシで露出すること（proxy/chosei.public.conf.example）。
+  chosei-app:
+    profiles: ["chosei"]
+    build: ./chosei-app
+    container_name: open-genai-chosei-app
+    environment:
+      - RAG_API_KEY=${RAG_API_KEY:-local-rag-key}
+      - INTERNAL_SIGNING_SECRET=${INTERNAL_SIGNING_SECRET:-dev-internal-secret-change-me}
+      - CHOSEI_DB_PATH=/data/chosei.db
+      - CHOSEI_PUBLIC_ENDPOINT=${CHOSEI_PUBLIC_ENDPOINT:-http://localhost:8010}
+      - CHOSEI_RETENTION_DAYS=${CHOSEI_RETENTION_DAYS:-90}
+      # LLM アシスト（最適日提案・自然文日程・案内文）。未指定なら Ollama /v1
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-ollama}
+      - CHOSEI_MODEL=${CHOSEI_MODEL:-${DEFAULT_MODEL:-qwen2.5:7b}}
+    volumes:
+      - chosei_app_data:/data
+    ports:
+      # 開発用: ゲスト UI/API（/public）をホストから直接確認。本番はホスト公開せず別プロキシへ。
+      - "${CHOSEI_PUBLIC_PORT:-8010}:8010"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
 volumes:
   backend_data:
   web_node_modules:
@@ -392,3 +422,4 @@ volumes:
   rag_app_data:
   seaweedfs_data:
   ollama_data:
+  chosei_app_data:

--- a/docs/chosei.md
+++ b/docs/chosei.md
@@ -1,0 +1,64 @@
+# 日程調整（chosei）
+
+庁内・外部参加者向けの日程調整機能です。Compose の **profile `chosei`** でオプション起動します。
+
+## 起動
+
+```bash
+# 開発
+docker compose --profile chosei up -d --build
+
+# または .env に
+# COMPOSE_PROFILES=chosei
+```
+
+本番も同様に `COMPOSE_PROFILES=chosei` または `--profile chosei` を付けます。`CHOSEI_PUBLIC_ENDPOINT` に外部公開 URL を設定してください。
+
+## 構成
+
+| 経路 | 用途 |
+|------|------|
+| Open GENAI `/chosei` | 認証済みの作成・回答・集計（DADS 専用画面） |
+| `CHOSEI_PUBLIC_ENDPOINT/public/...` | ゲスト回答（別ホストのリバースプロキシ） |
+
+- マイクロサービス: `chosei-app`（FastAPI + SQLite）
+- backend は `/chosei/*` を HMAC 付きでプロキシ（`depends_on` なし）
+- 未起動時は専用ページが有効化手順を表示し、exApp 一覧は `/health` 失敗で非表示
+
+## 外部公開（デュアルイングレス）
+
+Open GENAI 本体の nginx からゲスト API を晒さないでください。別ホストで [`proxy/chosei.public.conf.example`](../proxy/chosei.public.conf.example) を参考に **`/public` のみ** upstream します。
+
+開発時は `chosei-app` のホストポート（既定 `8010`）でゲスト UI を直接確認できます。
+
+LGWAN から外部 URL に届かない場合は、イベント画面の「リンクファイル」を持ち出して別端末で開きます。
+
+## データ保持
+
+- 既定で作成から **90 日**経過したイベントを自動削除（`CHOSEI_RETENTION_DAYS`）
+- データはボリューム `chosei_app_data`（`/data/chosei.db`）
+- バックアップは当該ボリュームまたは DB ファイルのコピーで行う
+
+## LLM アシスト（庁内のみ）
+
+OpenAI 互換 API（既定は Ollama）を使い、次を提供します（ゲスト公開面には出しません）。
+
+| 機能 | API | UI |
+|------|-----|-----|
+| 最適日の提案 | `POST /chosei/events/{id}/assist/recommend` | イベント詳細 |
+| 自然文→日程候補 | `POST /chosei/assist/parse-dates` | 作成画面 |
+| 案内文の下書き | `POST /chosei/events/{id}/assist/invite` | イベント詳細 |
+
+LLM 失敗時、最適日提案は ○△× の簡易スコアにフォールバックします。
+
+## 環境変数
+
+| 変数 | 説明 | 例 |
+|------|------|-----|
+| `COMPOSE_PROFILES` | `chosei` を含めると起動 | `chosei` |
+| `CHOSEI_APP_URL` | backend → サービス | `http://chosei-app:8010/invoke` |
+| `CHOSEI_PUBLIC_ENDPOINT` | 外部共有 URL のホスト | `https://chosei.example.lg.jp` |
+| `CHOSEI_PUBLIC_PORT` | 開発時ホスト公開ポート | `8010` |
+| `CHOSEI_RETENTION_DAYS` | 保持日数 | `90` |
+| `CHOSEI_MODEL` | アシスト用モデル | `qwen2.5:7b`（未設定時は `DEFAULT_MODEL`） |
+| `OLLAMA_BASE_URL` / `OPENAI_BASE_URL` | LLM エンドポイント | 他サービスと同様 |

--- a/genai-web/OPENGENAI_PATCHES.md
+++ b/genai-web/OPENGENAI_PATCHES.md
@@ -53,6 +53,19 @@ upstream のバージョンアップ後は、本ファイルの差分箇所を�
 | `packages/web/src/routes.tsx` | `/prompts` ルート追加、`/apps/:teamId/prompt` → `/prompts` リダイレクト |
 | `packages/web/src/layout/navItems.ts` | おすすめに「プロンプトテンプレート」、`pinnedAppHref` で `prompt` を `/prompts` に振替 |
 
+### 日程調整専用ページ（Open GENAI 拡張・オプション）
+
+回答マトリクスと外部共有のため専用ページ（`/chosei`）を提供する。Compose
+`profiles: ["chosei"]` 未起動時は有効化案内を表示。外部ゲストは別ホストの `/public`
+のみ（`chosei-app`）。旧 `/apps/:teamId/chosei` は `/chosei` へリダイレクトする。
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `packages/web/src/routes.tsx` | `/chosei` 系ルート追加、`/apps/:teamId/chosei` → `/chosei` リダイレクト |
+| `packages/web/src/layout/navItems.ts` | おすすめに「日程調整」、`pinnedAppHref` で `chosei` を `/chosei` に振替 |
+| `packages/web/src/open-genai/chosei/` | 専用ページ（作成・詳細・編集） |
+| `packages/web/src/lib/fetcher.ts` | `teamApi.delete` が任意ボディを送れるよう拡張（イベント削除の暗証番号用） |
+
 ### 監査ログ専用ページ（Open GENAI 拡張・管理者限定）
 
 管理系の第一弾。汎用 exApp フォーム（Markdown 出力）では詳細確認・全文閲覧・エクスポート

--- a/genai-web/packages/web/src/layout/navItems.ts
+++ b/genai-web/packages/web/src/layout/navItems.ts
@@ -19,6 +19,12 @@ export const PROMPT_TEMPLATES_PATH = '/prompts';
 /** プロンプトテンプレート exApp の識別子（専用ページへ振り替える対象） */
 export const PROMPT_EXAPP_ID = 'prompt';
 
+/** 日程調整は汎用 exApp フォームではなく専用ページで提供する */
+export const CHOSEI_PATH = '/chosei';
+
+/** 日程調整 exApp の識別子（専用ページへ振り替える対象） */
+export const CHOSEI_EXAPP_ID = 'chosei';
+
 /** 監査ログは管理者限定の専用ページで提供する */
 export const AUDIT_ADMIN_PATH = '/admin/audit';
 
@@ -107,6 +113,12 @@ export const useRecommendedNavItems = (): NavLinkItem[] => {
     });
 
     items.push({
+      label: '日程調整',
+      to: CHOSEI_PATH,
+      description: '庁内・外部向けの日程調整（要 profile chosei）',
+    });
+
+    items.push({
       label: 'ナレッジ管理',
       to: KNOWLEDGE_PATH,
       description: '共有・所属チームの資料を登録／管理（検索は「ナレッジ検索」）',
@@ -129,6 +141,10 @@ export const pinnedAppHref = (item: PinnedAppItem): string => {
   // プロンプトテンプレートは専用ページへ振り替える（汎用 exApp URL を使わない）
   if (item.app.value === PROMPT_EXAPP_ID) {
     return PROMPT_TEMPLATES_PATH;
+  }
+  // 日程調整は専用ページへ振り替える
+  if (item.app.value === CHOSEI_EXAPP_ID) {
+    return CHOSEI_PATH;
   }
   // 監査ログは管理者限定の専用ページへ振り替える
   if (item.app.value === AUDIT_EXAPP_ID) {

--- a/genai-web/packages/web/src/lib/fetcher.ts
+++ b/genai-web/packages/web/src/lib/fetcher.ts
@@ -145,8 +145,8 @@ const createApiClient = (baseURL: string) => {
       request<T>('POST', path, body, options),
     put: <T>(path: string, body?: unknown, options?: RequestOptions) =>
       request<T>('PUT', path, body, options),
-    delete: <T>(path: string, options?: RequestOptions) =>
-      request<T>('DELETE', path, undefined, options),
+    delete: <T>(path: string, body?: unknown, options?: RequestOptions) =>
+      request<T>('DELETE', path, body, options),
   };
 };
 

--- a/genai-web/packages/web/src/open-genai/chosei/ChoseiEditPage.tsx
+++ b/genai-web/packages/web/src/open-genai/chosei/ChoseiEditPage.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useState, type FormEvent } from 'react';
+import { Link, useNavigate, useParams } from 'react-router';
+import { BreadcrumbsNav } from '@/components/ui/BreadcrumbsNav';
+import { Button } from '@/components/ui/dads/Button';
+import { Label } from '@/components/ui/dads/Label';
+import { PageTitle } from '@/components/PageTitle';
+import { LayoutBody } from '@/layout/LayoutBody';
+import type { ChoseiDateInput } from './types';
+import { useChoseiActions, useChoseiEvent } from './useChosei';
+
+type DateRow = { id: string; start: string; end: string; allDay: boolean };
+
+const toLocalInput = (iso: string, allDay: boolean): string => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  if (allDay) {
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  }
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+};
+
+export const ChoseiEditPage = () => {
+  const { eventId } = useParams<{ eventId: string }>();
+  const navigate = useNavigate();
+  const { detail, isLoading, loadError } = useChoseiEvent(eventId);
+  const { update, submitting, error, setError } = useChoseiActions();
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [creatorName, setCreatorName] = useState('');
+  const [eventPassword, setEventPassword] = useState('');
+  const [dates, setDates] = useState<DateRow[]>([]);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!detail || ready) return;
+    setTitle(detail.event.title);
+    setDescription(detail.event.description || '');
+    setCreatorName(detail.event.creator_name || '');
+    setDates(
+      detail.dates.map((d) => ({
+        id: String(d.id),
+        start: toLocalInput(d.date_time, d.is_all_day),
+        end: d.end_time ? toLocalInput(d.end_time, false) : '',
+        allDay: d.is_all_day,
+      })),
+    );
+    setReady(true);
+  }, [detail, ready]);
+
+  if (isLoading || !ready) {
+    return (
+      <LayoutBody>
+        <PageTitle title='日程調整の編集' />
+        <div className='p-8 text-solid-gray-600'>読み込み中...</div>
+      </LayoutBody>
+    );
+  }
+
+  if (loadError || !detail || !eventId) {
+    return (
+      <LayoutBody>
+        <PageTitle title='日程調整の編集' />
+        <div className='p-8 text-error-1'>{loadError || 'イベントが見つかりません'}</div>
+      </LayoutBody>
+    );
+  }
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const normalized: ChoseiDateInput[] = dates
+      .filter((d) => d.start)
+      .map((d) => ({
+        start_time: new Date(d.start).toISOString(),
+        end_time: d.end && !d.allDay ? new Date(d.end).toISOString() : null,
+        is_all_day: d.allDay,
+      }));
+    if (!title.trim() || normalized.length === 0) {
+      setError('タイトルと日程候補を入力してください。');
+      return;
+    }
+    const updated = await update(eventId, {
+      title: title.trim(),
+      description: description.trim() || undefined,
+      creator_name: creatorName.trim() || undefined,
+      event_password: eventPassword.trim() || undefined,
+      dates: normalized,
+    });
+    if (updated) {
+      navigate(`/chosei/events/${eventId}`);
+    }
+  };
+
+  return (
+    <LayoutBody>
+      <PageTitle title='日程調整の編集' />
+      <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-6 p-6 lg:p-8'>
+        <BreadcrumbsNav
+          items={[
+            { label: 'ホーム', to: '/' },
+            { label: '日程調整', to: '/chosei' },
+            { label: detail.event.title, to: `/chosei/events/${eventId}` },
+            { label: '編集' },
+          ]}
+        />
+        <h1 className='text-std-20B-160'>イベントを編集</h1>
+        <p className='text-dns-14N-130 text-solid-gray-600'>
+          作成者本人以外はイベント暗証番号が必要です。日程を変更すると既存の回答は削除されます。
+        </p>
+        <form onSubmit={onSubmit} className='flex flex-col gap-4'>
+          <div>
+            <Label htmlFor='edit-title' size='sm'>
+              タイトル
+            </Label>
+            <input
+              id='edit-title'
+              className='mt-1 w-full rounded-4 border border-solid-gray-420 px-3 py-2'
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor='edit-desc' size='sm'>
+              説明
+            </Label>
+            <textarea
+              id='edit-desc'
+              className='mt-1 w-full rounded-4 border border-solid-gray-420 px-3 py-2'
+              rows={3}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2'>
+            <div>
+              <Label htmlFor='edit-creator' size='sm'>
+                作成者名
+              </Label>
+              <input
+                id='edit-creator'
+                className='mt-1 w-full rounded-4 border border-solid-gray-420 px-3 py-2'
+                value={creatorName}
+                onChange={(e) => setCreatorName(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor='edit-pin' size='sm'>
+                イベント暗証番号（作成者以外）
+              </Label>
+              <input
+                id='edit-pin'
+                className='mt-1 w-full rounded-4 border border-solid-gray-420 px-3 py-2'
+                inputMode='numeric'
+                maxLength={4}
+                value={eventPassword}
+                onChange={(e) => setEventPassword(e.target.value)}
+              />
+            </div>
+          </div>
+          <div className='flex flex-col gap-3'>
+            <Label size='sm'>日程候補</Label>
+            {dates.map((d) => (
+              <div
+                key={d.id}
+                className='flex flex-col gap-2 rounded-8 border border-solid-gray-300 p-3 md:flex-row md:items-end'
+              >
+                <div className='flex-1'>
+                  <input
+                    type={d.allDay ? 'date' : 'datetime-local'}
+                    className='w-full rounded-4 border border-solid-gray-420 px-3 py-2'
+                    value={d.start}
+                    onChange={(e) =>
+                      setDates((prev) =>
+                        prev.map((x) => (x.id === d.id ? { ...x, start: e.target.value } : x)),
+                      )
+                    }
+                  />
+                </div>
+                {!d.allDay && (
+                  <div className='flex-1'>
+                    <input
+                      type='datetime-local'
+                      className='w-full rounded-4 border border-solid-gray-420 px-3 py-2'
+                      value={d.end}
+                      onChange={(e) =>
+                        setDates((prev) =>
+                          prev.map((x) => (x.id === d.id ? { ...x, end: e.target.value } : x)),
+                        )
+                      }
+                    />
+                  </div>
+                )}
+                <label className='flex items-center gap-2 text-std-14N-160'>
+                  <input
+                    type='checkbox'
+                    checked={d.allDay}
+                    onChange={(e) =>
+                      setDates((prev) =>
+                        prev.map((x) =>
+                          x.id === d.id ? { ...x, allDay: e.target.checked } : x,
+                        ),
+                      )
+                    }
+                  />
+                  終日
+                </label>
+              </div>
+            ))}
+            <Button
+              type='button'
+              variant='outline'
+              size='sm'
+              onClick={() =>
+                setDates((p) => [
+                  ...p,
+                  { id: crypto.randomUUID(), start: '', end: '', allDay: false },
+                ])
+              }
+            >
+              日程を追加
+            </Button>
+          </div>
+          {error && (
+            <p className='text-error-1' role='alert'>
+              {error}
+            </p>
+          )}
+          <div className='flex flex-wrap gap-3'>
+            <Button type='submit' variant='solid-fill' size='md' aria-disabled={submitting}>
+              {submitting ? '保存中...' : '保存する'}
+            </Button>
+            <Link to={`/chosei/events/${eventId}`}>
+              <Button type='button' variant='text' size='md'>
+                キャンセル
+              </Button>
+            </Link>
+          </div>
+        </form>
+      </div>
+    </LayoutBody>
+  );
+};

--- a/genai-web/packages/web/src/open-genai/chosei/ChoseiEventPage.tsx
+++ b/genai-web/packages/web/src/open-genai/chosei/ChoseiEventPage.tsx
@@ -1,0 +1,476 @@
+import { useMemo, useState, type FormEvent } from 'react';
+import { Link, useNavigate, useParams } from 'react-router';
+import { BreadcrumbsNav } from '@/components/ui/BreadcrumbsNav';
+import { Button } from '@/components/ui/dads/Button';
+import { Label } from '@/components/ui/dads/Label';
+import { PageTitle } from '@/components/PageTitle';
+import { LayoutBody } from '@/layout/LayoutBody';
+import { formatDateTime, STATUS_LABEL, STATUS_MARK } from './format';
+import type { InviteDraftResult, RecommendResult, ResponseStatus } from './types';
+import {
+  downloadChoseiCarrier,
+  useChoseiActions,
+  useChoseiAssist,
+  useChoseiEvent,
+} from './useChosei';
+
+export const ChoseiEventPage = () => {
+  const { eventId } = useParams<{ eventId: string }>();
+  const navigate = useNavigate();
+  const { detail, isLoading, loadError, mutate } = useChoseiEvent(eventId);
+  const { submitResponse, remove, submitting, error, setError } = useChoseiActions();
+  const {
+    recommend,
+    draftInvite,
+    busy: assistBusy,
+    error: assistError,
+    setError: setAssistError,
+  } = useChoseiAssist();
+
+  const [name, setName] = useState('');
+  const [pin, setPin] = useState('');
+  const [answers, setAnswers] = useState<Record<number, ResponseStatus>>({});
+  const [deletePin, setDeletePin] = useState('');
+  const [copied, setCopied] = useState(false);
+  const [recommendation, setRecommendation] = useState<RecommendResult | null>(null);
+  const [invite, setInvite] = useState<InviteDraftResult | null>(null);
+
+  const dates = detail?.dates ?? [];
+
+  const participantNames = useMemo(() => {
+    const names: string[] = [];
+    const seen = new Set<string>();
+    for (const r of detail?.responses ?? []) {
+      if (!seen.has(r.participant_name)) {
+        seen.add(r.participant_name);
+        names.push(r.participant_name);
+      }
+    }
+    return names;
+  }, [detail]);
+
+  const statusByParticipant = useMemo(() => {
+    const map = new Map<string, Record<number, ResponseStatus>>();
+    for (const r of detail?.responses ?? []) {
+      const cur = map.get(r.participant_name) ?? {};
+      cur[r.event_date_id] = r.status;
+      map.set(r.participant_name, cur);
+    }
+    return map;
+  }, [detail]);
+
+  if (isLoading) {
+    return (
+      <LayoutBody>
+        <PageTitle title='日程調整' />
+        <div className='p-8 text-solid-gray-600'>読み込み中...</div>
+      </LayoutBody>
+    );
+  }
+
+  if (loadError || !detail) {
+    return (
+      <LayoutBody>
+        <PageTitle title='日程調整' />
+        <div className='mx-auto max-w-(--page-width) p-8'>
+          <p className='text-error-1' role='alert'>
+            {loadError || 'イベントが見つかりません'}
+          </p>
+          <Link to='/chosei' className='mt-4 inline-block text-blue-900 underline'>
+            一覧へ戻る
+          </Link>
+        </div>
+      </LayoutBody>
+    );
+  }
+
+  const ev = detail.event;
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!eventId || !name.trim()) {
+      setError('お名前を入力してください。');
+      return;
+    }
+    const responses = dates.map((d) => ({
+      event_date_id: d.id,
+      status: answers[d.id] ?? ('ng' as ResponseStatus),
+    }));
+    const ok = await submitResponse(eventId, {
+      participant_name: name.trim(),
+      password: pin.trim() || undefined,
+      responses,
+    });
+    if (ok) {
+      await mutate();
+      setPin('');
+    }
+  };
+
+  const onDelete = async () => {
+    if (!eventId) return;
+    if (!window.confirm('このイベントを削除しますか？')) return;
+    const ok = await remove(eventId, deletePin.trim() || undefined);
+    if (ok) navigate('/chosei');
+  };
+
+  const copyPublic = async () => {
+    try {
+      await navigator.clipboard.writeText(ev.public_url);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError('コピーに失敗しました。URL を手動で選択してください。');
+    }
+  };
+
+  return (
+    <LayoutBody>
+      <PageTitle title={ev.title} />
+      <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-6 p-6 lg:p-8'>
+        <BreadcrumbsNav
+          items={[
+            { label: 'ホーム', to: '/' },
+            { label: '日程調整', to: '/chosei' },
+            { label: ev.title },
+          ]}
+        />
+        <div className='flex flex-wrap items-start justify-between gap-3'>
+          <div>
+            <h1 className='text-std-20B-160 lg:text-std-24B-150'>{ev.title}</h1>
+            <p className='mt-1 text-dns-14N-130 text-solid-gray-600'>
+              回答者{participantNames.length}名
+              {ev.creator_name ? ` · 作成者: ${ev.creator_name}` : ''}
+            </p>
+            {ev.description && (
+              <p className='mt-3 whitespace-pre-wrap text-std-16N-170 text-solid-gray-700'>
+                {ev.description}
+              </p>
+            )}
+          </div>
+          <div className='flex flex-wrap gap-2'>
+            <Button
+              type='button'
+              variant='outline'
+              size='sm'
+              onClick={() => navigate(`/chosei/events/${ev.id}/edit`)}
+            >
+              編集
+            </Button>
+          </div>
+        </div>
+
+        <section className='rounded-8 border border-solid-gray-300 bg-solid-gray-50 p-4'>
+          <h2 className='text-std-16B-150'>外部共有 URL</h2>
+          <p className='mt-1 break-all text-dns-14N-130 text-blue-900'>{ev.public_url}</p>
+          <div className='mt-3 flex flex-wrap gap-2'>
+            <Button type='button' variant='solid-fill' size='sm' onClick={copyPublic}>
+              {copied ? 'コピーしました' : 'URL をコピー'}
+            </Button>
+            <Button
+              type='button'
+              variant='outline'
+              size='sm'
+              onClick={() => downloadChoseiCarrier(ev.id, 'txt')}
+            >
+              リンクファイル (.txt)
+            </Button>
+            <Button
+              type='button'
+              variant='outline'
+              size='sm'
+              onClick={() => downloadChoseiCarrier(ev.id, 'html')}
+            >
+              リンクファイル (.html)
+            </Button>
+          </div>
+          <p className='mt-2 text-dns-14N-130 text-solid-gray-600'>
+            LGWAN から外部 URL に届かない場合はリンクファイルを持ち出してください。
+          </p>
+        </section>
+
+        <section>
+          <h2 className='mb-1 text-std-18B-160'>日程候補・回答一覧</h2>
+          <p className='mb-3 text-dns-14N-130 text-solid-gray-600'>
+            行が日程、列が回答者です。○参加可 / △検討中 / ×不可
+          </p>
+          <div className='overflow-x-auto'>
+            <table className='w-max min-w-full border-collapse text-dns-14N-130'>
+              <thead>
+                <tr className='bg-solid-gray-50'>
+                  <th className='sticky left-0 z-1 border border-solid-gray-300 bg-solid-gray-50 px-3 py-2 text-left'>
+                    日程
+                  </th>
+                  <th className='border border-solid-gray-300 px-3 py-2 text-center' title='参加可'>
+                    ○
+                  </th>
+                  <th className='border border-solid-gray-300 px-3 py-2 text-center' title='検討中'>
+                    △
+                  </th>
+                  <th className='border border-solid-gray-300 px-3 py-2 text-center' title='不可'>
+                    ×
+                  </th>
+                  {participantNames.map((pname) => (
+                    <th
+                      key={pname}
+                      className='max-w-32 truncate border border-solid-gray-300 px-3 py-2 text-center'
+                      title={pname}
+                    >
+                      {pname}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {dates.map((d) => {
+                  const st = detail.statistics[String(d.id)] || {
+                    ok: 0,
+                    maybe: 0,
+                    ng: 0,
+                  };
+                  return (
+                    <tr key={d.id}>
+                      <th
+                        scope='row'
+                        className='sticky left-0 z-1 border border-solid-gray-300 bg-white px-3 py-2 text-left font-normal'
+                      >
+                        {formatDateTime(d.date_time, d.end_time, d.is_all_day)}
+                        {d.is_all_day ? '（終日）' : ''}
+                      </th>
+                      <td className='border border-solid-gray-300 px-3 py-2 text-center tabular-nums text-solid-gray-700'>
+                        {st.ok}
+                      </td>
+                      <td className='border border-solid-gray-300 px-3 py-2 text-center tabular-nums text-solid-gray-700'>
+                        {st.maybe}
+                      </td>
+                      <td className='border border-solid-gray-300 px-3 py-2 text-center tabular-nums text-solid-gray-700'>
+                        {st.ng}
+                      </td>
+                      {participantNames.map((pname) => {
+                        const status = statusByParticipant.get(pname)?.[d.id];
+                        return (
+                          <td
+                            key={pname}
+                            className='border border-solid-gray-300 px-3 py-2 text-center text-std-16B-150'
+                            title={status ? STATUS_LABEL[status] : '未回答'}
+                          >
+                            <span
+                              className={
+                                status === 'ok'
+                                  ? 'text-green-800'
+                                  : status === 'maybe'
+                                    ? 'text-orange-800'
+                                    : status === 'ng'
+                                      ? 'text-solid-gray-600'
+                                      : 'text-solid-gray-420'
+                              }
+                            >
+                              {status ? STATUS_MARK[status] : '—'}
+                            </span>
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          {participantNames.length === 0 && (
+            <p className='mt-3 text-dns-14N-130 text-solid-gray-600'>
+              まだ回答がありません。下のフォームから回答できます。
+            </p>
+          )}
+
+          <div className='mt-4 flex flex-wrap items-start gap-3'>
+            <Button
+              type='button'
+              variant='outline'
+              size='sm'
+              aria-disabled={assistBusy}
+              onClick={async () => {
+                if (!eventId) return;
+                setAssistError(null);
+                const res = await recommend(eventId);
+                if (res) setRecommendation(res);
+              }}
+            >
+              {assistBusy ? '提案中...' : '最適日を提案（LLM）'}
+            </Button>
+            <Button
+              type='button'
+              variant='outline'
+              size='sm'
+              aria-disabled={assistBusy}
+              onClick={async () => {
+                if (!eventId) return;
+                setAssistError(null);
+                const res = await draftInvite(eventId, '丁寧');
+                if (res) setInvite(res);
+              }}
+            >
+              {assistBusy ? '作成中...' : '案内文を下書き（LLM）'}
+            </Button>
+          </div>
+          {assistError && (
+            <p className='mt-2 text-error-1' role='alert'>
+              {assistError}
+            </p>
+          )}
+          {recommendation && (
+            <div className='mt-3 rounded-8 border border-solid-gray-300 bg-solid-gray-50 p-4'>
+              <p className='text-std-16B-150'>最適日の提案</p>
+              <p className='mt-1 text-std-16N-170'>
+                {recommendation.recommended_date_time
+                  ? formatDateTime(recommendation.recommended_date_time)
+                  : '（候補なし）'}
+                <span className='ml-2 text-dns-14N-130 text-solid-gray-600'>
+                  （{recommendation.source === 'llm' ? 'LLM' : '簡易集計'}
+                  {recommendation.model ? ` / ${recommendation.model}` : ''}）
+                </span>
+              </p>
+              <p className='mt-2 whitespace-pre-wrap text-dns-14N-130 text-solid-gray-700'>
+                {recommendation.reasoning}
+              </p>
+            </div>
+          )}
+          {invite && (
+            <div className='mt-3 rounded-8 border border-solid-gray-300 p-4'>
+              <div className='flex flex-wrap items-center justify-between gap-2'>
+                <p className='text-std-16B-150'>案内文下書き</p>
+                <Button
+                  type='button'
+                  variant='text'
+                  size='sm'
+                  onClick={async () => {
+                    const text = `${invite.subject}\n\n${invite.body}`;
+                    try {
+                      await navigator.clipboard.writeText(text);
+                    } catch {
+                      setAssistError('コピーに失敗しました。');
+                    }
+                  }}
+                >
+                  件名＋本文をコピー
+                </Button>
+              </div>
+              <p className='mt-2 text-dns-14N-130 text-solid-gray-600'>件名</p>
+              <p className='text-std-16N-170'>{invite.subject}</p>
+              <p className='mt-3 text-dns-14N-130 text-solid-gray-600'>本文</p>
+              <pre className='mt-1 whitespace-pre-wrap rounded-4 bg-solid-gray-50 p-3 text-dns-14N-130 text-solid-gray-800'>
+                {invite.body}
+              </pre>
+              {invite.tips && (
+                <p className='mt-2 text-dns-14N-130 text-solid-gray-600'>{invite.tips}</p>
+              )}
+            </div>
+          )}
+        </section>
+
+        <section>
+          <h2 className='mb-3 text-std-18B-160'>出欠を入力する</h2>
+          <form onSubmit={onSubmit} className='flex flex-col gap-4'>
+            <div className='grid gap-4 md:grid-cols-2'>
+              <div>
+                <Label htmlFor='res-name' size='sm'>
+                  お名前
+                </Label>
+                <input
+                  id='res-name'
+                  className='mt-1 w-full rounded-4 border border-solid-gray-420 px-3 py-2'
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <Label htmlFor='res-pin' size='sm'>
+                  暗証番号（4桁）
+                </Label>
+                <input
+                  id='res-pin'
+                  className='mt-1 w-full rounded-4 border border-solid-gray-420 px-3 py-2'
+                  inputMode='numeric'
+                  maxLength={4}
+                  value={pin}
+                  onChange={(e) => setPin(e.target.value)}
+                  placeholder='初回は設定、再回答時は同じ番号'
+                />
+              </div>
+            </div>
+            <ul className='divide-y divide-solid-gray-300 border-y border-solid-gray-300'>
+              {dates.map((d) => (
+                <li
+                  key={d.id}
+                  className='flex flex-col gap-2 py-3 md:flex-row md:items-center md:justify-between'
+                >
+                  <span className='text-std-16N-170'>
+                    {formatDateTime(d.date_time, d.end_time, d.is_all_day)}
+                    {d.is_all_day ? '（終日）' : ''}
+                  </span>
+                  <div className='flex flex-wrap gap-2'>
+                    {(['ok', 'maybe', 'ng'] as ResponseStatus[]).map((st) => (
+                      <label
+                        key={st}
+                        className={`cursor-pointer rounded-4 border px-3 py-1 text-dns-14N-130 ${
+                          (answers[d.id] ?? 'ng') === st
+                            ? 'border-blue-900 bg-blue-50 text-blue-900'
+                            : 'border-solid-gray-300'
+                        }`}
+                      >
+                        <input
+                          type='radio'
+                          className='sr-only'
+                          name={`st-${d.id}`}
+                          checked={(answers[d.id] ?? 'ng') === st}
+                          onChange={() => setAnswers((prev) => ({ ...prev, [d.id]: st }))}
+                        />
+                        {STATUS_MARK[st]} {STATUS_LABEL[st]}
+                      </label>
+                    ))}
+                  </div>
+                </li>
+              ))}
+            </ul>
+            {error && (
+              <p className='text-error-1' role='alert'>
+                {error}
+              </p>
+            )}
+            <div>
+              <Button type='submit' variant='solid-fill' size='md' aria-disabled={submitting}>
+                {submitting ? '送信中...' : '回答を送信'}
+              </Button>
+            </div>
+          </form>
+        </section>
+
+        <section className='border-t border-solid-gray-300 pt-6'>
+          <h2 className='mb-2 text-std-16B-150 text-solid-gray-700'>イベントを削除</h2>
+          <p className='mb-3 text-dns-14N-130 text-solid-gray-600'>
+            作成者本人以外はイベント暗証番号が必要です。
+          </p>
+          <div className='flex flex-wrap items-end gap-3'>
+            <div>
+              <Label htmlFor='del-pin' size='sm'>
+                イベント暗証番号
+              </Label>
+              <input
+                id='del-pin'
+                className='mt-1 w-40 rounded-4 border border-solid-gray-420 px-3 py-2'
+                inputMode='numeric'
+                maxLength={4}
+                value={deletePin}
+                onChange={(e) => setDeletePin(e.target.value)}
+              />
+            </div>
+            <Button type='button' variant='outline' size='sm' onClick={onDelete}>
+              削除する
+            </Button>
+          </div>
+        </section>
+      </div>
+    </LayoutBody>
+  );
+};

--- a/genai-web/packages/web/src/open-genai/chosei/ChoseiPage.tsx
+++ b/genai-web/packages/web/src/open-genai/chosei/ChoseiPage.tsx
@@ -1,0 +1,375 @@
+import { useState, type FormEvent } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { PiBookOpenBold, PiCalendarBlankBold } from 'react-icons/pi';
+import { BreadcrumbsNav } from '@/components/ui/BreadcrumbsNav';
+import { Button } from '@/components/ui/dads/Button';
+import { Disclosure, DisclosureSummary } from '@/components/ui/dads/Disclosure';
+import { Label } from '@/components/ui/dads/Label';
+import { PageTitle } from '@/components/PageTitle';
+import { LayoutBody } from '@/layout/LayoutBody';
+import { toLocalInputValue } from './format';
+import type { ChoseiDateInput } from './types';
+import {
+  useChoseiActions,
+  useChoseiAssist,
+  useChoseiConfig,
+  useChoseiEvents,
+} from './useChosei';
+
+type DateRow = { id: string; start: string; end: string; allDay: boolean };
+
+const newRow = (): DateRow => ({
+  id: crypto.randomUUID(),
+  start: '',
+  end: '',
+  allDay: false,
+});
+
+/**
+ * 日程調整専用ページ（OpenGENAI 拡張）。
+ * Compose profiles: ["chosei"] 未起動時は有効化手順を案内する。
+ */
+export const ChoseiPage = () => {
+  const navigate = useNavigate();
+  const { config, isLoading: configLoading, unavailable } = useChoseiConfig();
+  const { events, isLoading, loadError, mutate } = useChoseiEvents();
+  const { create, submitting, error, setError } = useChoseiActions();
+  const {
+    parseDates,
+    busy: assistBusy,
+    error: assistError,
+    setError: setAssistError,
+  } = useChoseiAssist();
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [creatorName, setCreatorName] = useState('');
+  const [eventPassword, setEventPassword] = useState('');
+  const [dates, setDates] = useState<DateRow[]>([newRow()]);
+  const [nlText, setNlText] = useState('');
+  const [nlNotes, setNlNotes] = useState<string | null>(null);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const normalized: ChoseiDateInput[] = dates
+      .filter((d) => d.start)
+      .map((d) => ({
+        start_time: new Date(d.start).toISOString(),
+        end_time: d.end && !d.allDay ? new Date(d.end).toISOString() : null,
+        is_all_day: d.allDay,
+      }));
+    if (!title.trim() || normalized.length === 0) {
+      setError('タイトルと日程候補を入力してください。');
+      return;
+    }
+    const detail = await create({
+      title: title.trim(),
+      description: description.trim() || undefined,
+      creator_name: creatorName.trim() || undefined,
+      event_password: eventPassword.trim() || undefined,
+      dates: normalized,
+    });
+    if (detail) {
+      await mutate();
+      navigate(`/chosei/events/${detail.event.id}`);
+    }
+  };
+
+  return (
+    <LayoutBody>
+      <PageTitle title='日程調整' />
+      <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-6 p-6 lg:p-8'>
+        <div className='flex flex-col gap-4'>
+          <BreadcrumbsNav
+            items={[
+              { label: 'ホーム', to: '/' },
+              { label: 'AIアプリ', to: '/apps' },
+              { label: '日程調整' },
+            ]}
+          />
+          <h1 className='text-std-20B-160 lg:text-std-24B-150'>日程調整</h1>
+          <p className='text-std-16N-170 text-solid-gray-700'>
+            庁内利用者と外部参加者の日程を調整します。外部には別 URL（公開エンドポイント）で回答してもらえます。
+          </p>
+          <Disclosure className='rounded-8 border border-solid-gray-420 bg-solid-gray-50 px-4 py-3'>
+            <DisclosureSummary>
+              <span className='flex items-center text-std-16B-150'>
+                <PiBookOpenBold className='mr-2 size-5 flex-none' />
+                使い方（クリックで開閉）
+              </span>
+            </DisclosureSummary>
+            <div className='mt-3 flex flex-col gap-1.5 text-std-16N-170 text-solid-gray-700'>
+              <p>・イベントを作成すると庁内用ページと外部共有 URL が発行されます。</p>
+              <p>・外部 URL は LGWAN から届かない場合、リンクファイルを持ち出して別端末で開いてください。</p>
+              <p>
+                ・有効化: <code>docker compose --profile chosei up -d</code> または{' '}
+                <code>COMPOSE_PROFILES=chosei</code>
+              </p>
+              {config?.retention_days != null && (
+                <p>・作成から {config.retention_days} 日経過したイベントは自動削除されます。</p>
+              )}
+            </div>
+          </Disclosure>
+        </div>
+
+        {(unavailable || (!configLoading && config?.enabled === false)) && (
+          <div
+            className='rounded-8 border border-solid-gray-420 bg-solid-gray-50 px-4 py-4 text-std-16N-170'
+            role='status'
+          >
+            <p className='text-std-16B-150 text-solid-gray-900'>日程調整は現在有効化されていません</p>
+            <p className='mt-2 text-solid-gray-700'>
+              {config?.error ||
+                'コンテナを profiles: ["chosei"] で起動してください。'}
+            </p>
+            <pre className='mt-3 overflow-x-auto rounded-4 bg-white p-3 text-dns-14N-130 text-solid-gray-800'>
+              docker compose --profile chosei up -d{'\n'}
+              # または .env に COMPOSE_PROFILES=chosei
+            </pre>
+          </div>
+        )}
+
+        {!unavailable && (
+          <>
+            <section className='flex flex-col gap-4'>
+              <h2 className='flex items-center gap-2 text-std-18B-160'>
+                <PiCalendarBlankBold className='size-5' />
+                新しいイベント
+              </h2>
+              <form onSubmit={onSubmit} className='flex flex-col gap-4'>
+                <div>
+                  <Label htmlFor='chosei-title' size='sm'>
+                    タイトル
+                  </Label>
+                  <input
+                    id='chosei-title'
+                    className='mt-1 w-full rounded-4 border border-solid-gray-420 px-3 py-2 text-std-16N-170'
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    required
+                  />
+                </div>
+                <div>
+                  <Label htmlFor='chosei-desc' size='sm'>
+                    説明（任意）
+                  </Label>
+                  <textarea
+                    id='chosei-desc'
+                    className='mt-1 w-full rounded-4 border border-solid-gray-420 px-3 py-2 text-std-16N-170'
+                    rows={3}
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                  />
+                </div>
+                <div className='grid gap-4 md:grid-cols-2'>
+                  <div>
+                    <Label htmlFor='chosei-creator' size='sm'>
+                      作成者名（任意）
+                    </Label>
+                    <input
+                      id='chosei-creator'
+                      className='mt-1 w-full rounded-4 border border-solid-gray-420 px-3 py-2 text-std-16N-170'
+                      value={creatorName}
+                      onChange={(e) => setCreatorName(e.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor='chosei-pin' size='sm'>
+                      イベント暗証番号（4桁・任意）
+                    </Label>
+                    <input
+                      id='chosei-pin'
+                      className='mt-1 w-full rounded-4 border border-solid-gray-420 px-3 py-2 text-std-16N-170'
+                      inputMode='numeric'
+                      maxLength={4}
+                      value={eventPassword}
+                      onChange={(e) => setEventPassword(e.target.value)}
+                      placeholder='作成者以外が編集するときに使用'
+                    />
+                  </div>
+                </div>
+
+                <div className='flex flex-col gap-2 rounded-8 border border-solid-gray-300 bg-solid-gray-50 p-4'>
+                  <Label htmlFor='chosei-nl' size='sm'>
+                    自然文から日程候補を作成（LLM）
+                  </Label>
+                  <textarea
+                    id='chosei-nl'
+                    className='w-full rounded-4 border border-solid-gray-420 bg-white px-3 py-2 text-std-16N-170'
+                    rows={2}
+                    value={nlText}
+                    onChange={(e) => setNlText(e.target.value)}
+                    placeholder='例: 来週の火・水・木の午後2時から1時間ずつ'
+                  />
+                  <p className='text-dns-14N-130 text-solid-gray-600'>
+                    モデル: {config?.llm?.model || '（未設定）'}。生成後に下の候補を確認・編集できます。
+                  </p>
+                  {(assistError || nlNotes) && (
+                    <p
+                      className={
+                        assistError ? 'text-dns-14N-130 text-error-1' : 'text-dns-14N-130 text-solid-gray-700'
+                      }
+                      role={assistError ? 'alert' : undefined}
+                    >
+                      {assistError || nlNotes}
+                    </p>
+                  )}
+                  <div>
+                    <Button
+                      type='button'
+                      variant='outline'
+                      size='sm'
+                      aria-disabled={assistBusy || !nlText.trim()}
+                      onClick={async () => {
+                        setAssistError(null);
+                        setNlNotes(null);
+                        const res = await parseDates(nlText.trim());
+                        if (!res) return;
+                        if (!res.dates.length) {
+                          setNlNotes(res.notes || '候補を抽出できませんでした。');
+                          return;
+                        }
+                        setDates(
+                          res.dates.map((d) => ({
+                            id: crypto.randomUUID(),
+                            start: toLocalInputValue(d.start_time, !!d.is_all_day),
+                            end:
+                              d.end_time && !d.is_all_day
+                                ? toLocalInputValue(d.end_time, false)
+                                : '',
+                            allDay: !!d.is_all_day,
+                          })),
+                        );
+                        setNlNotes(res.notes || `${res.dates.length}件の候補を反映しました。`);
+                      }}
+                    >
+                      {assistBusy ? '解釈中...' : '日程候補に反映'}
+                    </Button>
+                  </div>
+                </div>
+
+                <div className='flex flex-col gap-3'>
+                  <Label size='sm'>日程候補</Label>
+                  {dates.map((d, idx) => (
+                    <div
+                      key={d.id}
+                      className='flex flex-col gap-2 rounded-8 border border-solid-gray-300 p-3 md:flex-row md:items-end'
+                    >
+                      <div className='flex-1'>
+                        <Label htmlFor={`start-${d.id}`} size='sm'>
+                          開始
+                        </Label>
+                        <input
+                          id={`start-${d.id}`}
+                          type={d.allDay ? 'date' : 'datetime-local'}
+                          className='mt-1 w-full rounded-4 border border-solid-gray-420 px-3 py-2'
+                          value={d.start}
+                          onChange={(e) =>
+                            setDates((prev) =>
+                              prev.map((x) =>
+                                x.id === d.id ? { ...x, start: e.target.value } : x,
+                              ),
+                            )
+                          }
+                        />
+                      </div>
+                      {!d.allDay && (
+                        <div className='flex-1'>
+                          <Label htmlFor={`end-${d.id}`} size='sm'>
+                            終了（任意）
+                          </Label>
+                          <input
+                            id={`end-${d.id}`}
+                            type='datetime-local'
+                            className='mt-1 w-full rounded-4 border border-solid-gray-420 px-3 py-2'
+                            value={d.end}
+                            onChange={(e) =>
+                              setDates((prev) =>
+                                prev.map((x) =>
+                                  x.id === d.id ? { ...x, end: e.target.value } : x,
+                                ),
+                              )
+                            }
+                          />
+                        </div>
+                      )}
+                      <label className='flex items-center gap-2 text-std-14N-160'>
+                        <input
+                          type='checkbox'
+                          checked={d.allDay}
+                          onChange={(e) =>
+                            setDates((prev) =>
+                              prev.map((x) =>
+                                x.id === d.id ? { ...x, allDay: e.target.checked } : x,
+                              ),
+                            )
+                          }
+                        />
+                        終日
+                      </label>
+                      {dates.length > 1 && (
+                        <Button
+                          type='button'
+                          variant='text'
+                          size='sm'
+                          onClick={() => setDates((prev) => prev.filter((x) => x.id !== d.id))}
+                        >
+                          削除
+                        </Button>
+                      )}
+                      <span className='sr-only'>候補 {idx + 1}</span>
+                    </div>
+                  ))}
+                  <Button type='button' variant='outline' size='sm' onClick={() => setDates((p) => [...p, newRow()])}>
+                    日程を追加
+                  </Button>
+                </div>
+
+                {error && (
+                  <p className='text-dns-16N-130 text-error-1' role='alert'>
+                    {error}
+                  </p>
+                )}
+                <div>
+                  <Button type='submit' variant='solid-fill' size='md' aria-disabled={submitting}>
+                    {submitting ? '作成中...' : '日程調整を作成'}
+                  </Button>
+                </div>
+              </form>
+            </section>
+
+            <section className='flex flex-col gap-3'>
+              <h2 className='text-std-18B-160'>自分のイベント</h2>
+              {isLoading ? (
+                <p className='text-solid-gray-600'>読み込み中...</p>
+              ) : loadError ? (
+                <p className='text-error-1' role='alert'>
+                  {loadError}
+                </p>
+              ) : events.length === 0 ? (
+                <p className='text-solid-gray-600'>まだイベントがありません。</p>
+              ) : (
+                <ul className='divide-y divide-solid-gray-300 border-y border-solid-gray-300'>
+                  {events.map((ev) => (
+                    <li key={ev.id} className='py-3'>
+                      <Link
+                        to={`/chosei/events/${ev.id}`}
+                        className='text-std-16B-150 text-blue-900 underline-offset-2 hover:underline'
+                      >
+                        {ev.title}
+                      </Link>
+                      <p className='text-dns-14N-130 text-solid-gray-600'>
+                        {new Date(ev.created_at).toLocaleString('ja-JP')}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          </>
+        )}
+      </div>
+    </LayoutBody>
+  );
+};

--- a/genai-web/packages/web/src/open-genai/chosei/format.ts
+++ b/genai-web/packages/web/src/open-genai/chosei/format.ts
@@ -1,0 +1,59 @@
+/** ISO → datetime-local / date 入力用 */
+export const toLocalInputValue = (iso: string, allDay: boolean): string => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  if (allDay) {
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  }
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+};
+
+export const formatDateTime = (
+  iso: string,
+  end?: string | null,
+  allDay?: boolean,
+): string => {
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    if (allDay) {
+      return d.toLocaleDateString('ja-JP', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        weekday: 'short',
+      });
+    }
+    let s = d.toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      weekday: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+    if (end) {
+      const e = new Date(end);
+      if (!Number.isNaN(e.getTime())) {
+        s += ` 〜 ${e.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' })}`;
+      }
+    }
+    return s;
+  } catch {
+    return iso;
+  }
+};
+
+export const STATUS_LABEL = {
+  ok: '参加可',
+  maybe: '検討中',
+  ng: '不可',
+} as const;
+
+/** 調整さん風の記号表示 */
+export const STATUS_MARK = {
+  ok: '○',
+  maybe: '△',
+  ng: '×',
+} as const;

--- a/genai-web/packages/web/src/open-genai/chosei/types.ts
+++ b/genai-web/packages/web/src/open-genai/chosei/types.ts
@@ -1,0 +1,94 @@
+export type ResponseStatus = 'ok' | 'ng' | 'maybe';
+
+export type ChoseiDateInput = {
+  start_time: string;
+  end_time?: string | null;
+  is_all_day?: boolean;
+};
+
+export type ChoseiDate = {
+  id: number;
+  date_time: string;
+  end_time?: string | null;
+  is_all_day: boolean;
+  created_at: string;
+};
+
+export type ChoseiEventSummary = {
+  id: string;
+  guest_token: string;
+  title: string;
+  description?: string | null;
+  creator_name?: string | null;
+  creator_user_id?: string | null;
+  has_event_password: boolean;
+  created_at: string;
+  public_url: string;
+};
+
+export type ChoseiResponse = {
+  id?: number;
+  participant_name: string;
+  participant_user_id?: string | null;
+  event_date_id: number;
+  status: ResponseStatus;
+  date_time?: string;
+};
+
+export type ChoseiStatistics = Record<
+  string,
+  {
+    date_time: string;
+    ok: number;
+    ng: number;
+    maybe: number;
+    participants: string[];
+  }
+>;
+
+export type ChoseiEventDetail = {
+  event: ChoseiEventSummary;
+  dates: ChoseiDate[];
+  responses: ChoseiResponse[];
+  statistics: ChoseiStatistics;
+};
+
+export type ChoseiConfig = {
+  public_endpoint?: string;
+  retention_days?: number;
+  enabled?: boolean;
+  error?: string;
+  llm?: { model?: string; base_url?: string };
+};
+
+export type ParsedDatesResult = {
+  dates: (ChoseiDateInput & { label?: string })[];
+  notes?: string;
+  model?: string;
+};
+
+export type RecommendResult = {
+  source: 'llm' | 'heuristic';
+  recommended_date_id: number | null;
+  recommended_date_time?: string | null;
+  reasoning: string;
+  ranking?: Array<{
+    date_id: number;
+    date_time?: string;
+    score?: number;
+    note?: string;
+    ok?: number;
+    maybe?: number;
+    ng?: number;
+  }>;
+  model?: string;
+  llm_error?: string;
+};
+
+export type InviteDraftResult = {
+  subject: string;
+  body: string;
+  tips?: string;
+  public_url?: string;
+  model?: string;
+};

--- a/genai-web/packages/web/src/open-genai/chosei/useChosei.ts
+++ b/genai-web/packages/web/src/open-genai/chosei/useChosei.ts
@@ -1,0 +1,273 @@
+import { useCallback, useState } from 'react';
+import useSWR from 'swr';
+import { ApiError, teamApi, teamApiFetcher } from '@/lib/fetcher';
+import type {
+  ChoseiConfig,
+  ChoseiDateInput,
+  ChoseiEventDetail,
+  ChoseiEventSummary,
+  InviteDraftResult,
+  ParsedDatesResult,
+  RecommendResult,
+  ResponseStatus,
+} from './types';
+
+const errorMessage = (e: unknown, fallback: string): string => {
+  if (e instanceof ApiError) {
+    const data = e.data as { error?: string } | undefined;
+    if (data?.error) {
+      return data.error;
+    }
+  }
+  return fallback;
+};
+
+export const useChoseiConfig = () => {
+  const { data, error, isLoading } = useSWR<ChoseiConfig>(
+    'chosei/config',
+    async () => {
+      try {
+        return await teamApiFetcher<ChoseiConfig>('chosei/config');
+      } catch (e) {
+        if (e instanceof ApiError && (e.status === 503 || e.status === 502)) {
+          const data = e.data as ChoseiConfig | undefined;
+          return {
+            enabled: false,
+            error: data?.error || errorMessage(e, '日程調整サービスに接続できません'),
+          };
+        }
+        throw e;
+      }
+    },
+    { revalidateOnFocus: false, shouldRetryOnError: false },
+  );
+
+  return {
+    config: data,
+    isLoading,
+    loadError: error
+      ? '日程調整の設定取得に失敗しました。時間をおいて再度お試しください。'
+      : null,
+    unavailable: data?.enabled === false || (!!data?.error && data.enabled === false),
+  };
+};
+
+export const useChoseiEvents = () => {
+  const { data, error, isLoading, mutate } = useSWR<{ events: ChoseiEventSummary[] }>(
+    'chosei/events',
+    teamApiFetcher,
+    { revalidateOnFocus: false, shouldRetryOnError: false },
+  );
+
+  return {
+    events: data?.events ?? [],
+    isLoading,
+    loadError: error ? errorMessage(error, 'イベント一覧の取得に失敗しました。') : null,
+    mutate,
+  };
+};
+
+export const useChoseiEvent = (eventId: string | undefined) => {
+  const key = eventId ? `chosei/events/${encodeURIComponent(eventId)}` : null;
+  const { data, error, isLoading, mutate } = useSWR<ChoseiEventDetail>(
+    key,
+    teamApiFetcher,
+    { revalidateOnFocus: false, shouldRetryOnError: false },
+  );
+
+  return {
+    detail: data ?? null,
+    isLoading,
+    loadError: error ? errorMessage(error, 'イベントの取得に失敗しました。') : null,
+    mutate,
+  };
+};
+
+export const useChoseiActions = () => {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const create = useCallback(
+    async (input: {
+      title: string;
+      description?: string;
+      creator_name?: string;
+      event_password?: string;
+      dates: ChoseiDateInput[];
+    }): Promise<ChoseiEventDetail | null> => {
+      setSubmitting(true);
+      setError(null);
+      try {
+        const res = await teamApi.post<ChoseiEventDetail>('chosei/events', input);
+        return res.data ?? null;
+      } catch (e) {
+        setError(errorMessage(e, 'イベントの作成に失敗しました。'));
+        return null;
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [],
+  );
+
+  const update = useCallback(
+    async (
+      eventId: string,
+      input: {
+        title: string;
+        description?: string;
+        creator_name?: string;
+        event_password?: string;
+        dates?: ChoseiDateInput[];
+      },
+    ): Promise<ChoseiEventDetail | null> => {
+      setSubmitting(true);
+      setError(null);
+      try {
+        const res = await teamApi.put<ChoseiEventDetail>(
+          `chosei/events/${encodeURIComponent(eventId)}`,
+          input,
+        );
+        return res.data ?? null;
+      } catch (e) {
+        setError(errorMessage(e, 'イベントの更新に失敗しました。'));
+        return null;
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [],
+  );
+
+  const remove = useCallback(async (eventId: string, eventPassword?: string): Promise<boolean> => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await teamApi.delete(`chosei/events/${encodeURIComponent(eventId)}`, {
+        event_password: eventPassword,
+      });
+      return true;
+    } catch (e) {
+      setError(errorMessage(e, 'イベントの削除に失敗しました。'));
+      return false;
+    } finally {
+      setSubmitting(false);
+    }
+  }, []);
+
+  const submitResponse = useCallback(
+    async (
+      eventId: string,
+      input: {
+        participant_name: string;
+        password?: string;
+        responses: { event_date_id: number; status: ResponseStatus }[];
+      },
+    ): Promise<boolean> => {
+      setSubmitting(true);
+      setError(null);
+      try {
+        await teamApi.post(`chosei/events/${encodeURIComponent(eventId)}/responses`, input);
+        return true;
+      } catch (e) {
+        setError(errorMessage(e, '回答の送信に失敗しました。'));
+        return false;
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [],
+  );
+
+  return { create, update, remove, submitResponse, submitting, error, setError };
+};
+
+const parseFilename = (disposition: string | null): string | null => {
+  if (!disposition) return null;
+  const utf8 = /filename\*=UTF-8''([^;]+)/i.exec(disposition);
+  if (utf8?.[1]) {
+    try {
+      return decodeURIComponent(utf8[1]);
+    } catch {
+      return utf8[1];
+    }
+  }
+  const ascii = /filename="?([^";]+)"?/i.exec(disposition);
+  return ascii?.[1] ?? null;
+};
+
+/** 外部共有 URL のリンクファイルをダウンロード（LGWAN carrier）。 */
+export const downloadChoseiCarrier = async (
+  eventId: string,
+  format: 'txt' | 'html' = 'txt',
+): Promise<void> => {
+  const { blob, disposition } = await teamApi.getBlob(
+    `chosei/events/${encodeURIComponent(eventId)}/carrier`,
+    { params: { format } },
+  );
+  const filename = parseFilename(disposition) ?? `chosei_link.${format}`;
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  window.setTimeout(() => window.URL.revokeObjectURL(url), 1000);
+};
+
+export const useChoseiAssist = () => {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const parseDates = useCallback(async (text: string): Promise<ParsedDatesResult | null> => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await teamApi.post<ParsedDatesResult>('chosei/assist/parse-dates', { text });
+      return res.data ?? null;
+    } catch (e) {
+      setError(errorMessage(e, '日程の解釈に失敗しました。'));
+      return null;
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const recommend = useCallback(async (eventId: string): Promise<RecommendResult | null> => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await teamApi.post<RecommendResult>(
+        `chosei/events/${encodeURIComponent(eventId)}/assist/recommend`,
+        {},
+      );
+      return res.data ?? null;
+    } catch (e) {
+      setError(errorMessage(e, '最適日の提案に失敗しました。'));
+      return null;
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const draftInvite = useCallback(
+    async (eventId: string, tone = '丁寧'): Promise<InviteDraftResult | null> => {
+      setBusy(true);
+      setError(null);
+      try {
+        const res = await teamApi.post<InviteDraftResult>(
+          `chosei/events/${encodeURIComponent(eventId)}/assist/invite`,
+          { tone },
+        );
+        return res.data ?? null;
+      } catch (e) {
+        setError(errorMessage(e, '案内文の作成に失敗しました。'));
+        return null;
+      } finally {
+        setBusy(false);
+      }
+    },
+    [],
+  );
+
+  return { parseDates, recommend, draftInvite, busy, error, setError };
+};

--- a/genai-web/packages/web/src/routes.tsx
+++ b/genai-web/packages/web/src/routes.tsx
@@ -25,6 +25,9 @@ import { AuditLogsPage } from '@/open-genai/admin-audit/AuditLogsPage';
 import { ModelPolicyPage } from '@/open-genai/admin-modelpolicy/ModelPolicyPage';
 import { NgWordPage } from '@/open-genai/admin-ngword/NgWordPage';
 import { UserMgmtPage } from '@/open-genai/admin-usermgmt/UserMgmtPage';
+import { ChoseiEditPage } from '@/open-genai/chosei/ChoseiEditPage';
+import { ChoseiEventPage } from '@/open-genai/chosei/ChoseiEventPage';
+import { ChoseiPage } from '@/open-genai/chosei/ChoseiPage';
 import { PromptTemplatesPage } from '@/open-genai/prompt-templates/PromptTemplatesPage';
 import { NotFound } from '@/NotFound';
 import { ApiRequestDataFormatPage } from '@/pages/ApiRequestDataFormat';
@@ -74,6 +77,11 @@ export const createRoutes = (): RouteObject[] => {
     // リダイレクトする（ピン留め・ブックマーク・履歴リンクの互換のため）。
     { path: 'prompts', element: <PromptTemplatesPage /> },
     { path: 'apps/:teamId/prompt', element: <Navigate to='/prompts' replace /> },
+    // 日程調整は専用ページへ（Compose profiles: ["chosei"]）。
+    { path: 'chosei', element: <ChoseiPage /> },
+    { path: 'chosei/events/:eventId', element: <ChoseiEventPage /> },
+    { path: 'chosei/events/:eventId/edit', element: <ChoseiEditPage /> },
+    { path: 'apps/:teamId/chosei', element: <Navigate to='/chosei' replace /> },
     // 監査ログは管理者限定の専用ページへ。旧 exApp URL（/apps/:teamId/audit）は
     // リダイレクトする（ピン留め・ブックマーク・履歴リンクの互換のため）。
     { path: 'admin/audit', element: <AuditLogsPage /> },

--- a/proxy/chosei.public.conf.example
+++ b/proxy/chosei.public.conf.example
@@ -1,0 +1,41 @@
+# 日程調整の外部公開用 nginx 設定例（Open GENAI 本体とは別ホストで運用）
+#
+# 重要:
+#   - /public のみを chosei-app へ upstream すること
+#   - Open GENAI の /api・Keycloak・庁内 UI をこのホストから到達可能にしないこと
+#
+# 起動例（chosei-app が Docker ネットワーク上にある場合）:
+#   upstream を open-genai-chosei-app:8010 に向け、この conf を別プロキシで読む。
+#
+# CHOSEI_PUBLIC_ENDPOINT にはこのプロキシの公開 URL（例: https://chosei.example.lg.jp）を設定する。
+
+upstream chosei_app {
+    server open-genai-chosei-app:8010;
+}
+
+server {
+    listen 443 ssl;
+    server_name chosei.example.lg.jp;
+
+    # ssl_certificate     /path/to/fullchain.pem;
+    # ssl_certificate_key /path/to/privkey.pem;
+
+    # ゲスト UI・API のみ
+    location /public/ {
+        proxy_pass http://chosei_app;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /public {
+        return 302 /public/;
+    }
+
+    # それ以外は拒否（誤って内部 API を晒さない）
+    location / {
+        return 404;
+    }
+}


### PR DESCRIPTION
## Summary
- Compose `profiles: ["chosei"]` でオプトイン起動する `chosei-app`（FastAPI + SQLite）を追加
- 庁内は専用画面 `/chosei`（DADS）、外部ゲストは `CHOSEI_PUBLIC_ENDPOINT` の `/public` のみ（デュアルイングレス）
- LLM アシスト（庁内のみ）: 自然文からの日程候補、最適日提案、案内文下書き

## Test plan
- [ ] `docker compose --profile chosei up -d --build` で chosei-app が起動すること
- [ ] `/chosei` でイベント作成・回答マトリクス表示ができること
- [ ] ゲスト URL（開発時 `:8010/public/e/...`）から回答できること
- [ ] 自然文「来週の平日の12:00-13:00」が日程候補に反映されること
- [ ] 最適日提案・案内文下書きが動作すること（Ollama 等）
- [ ] profile なしでは既存スタックに影響しないこと


Made with [Cursor](https://cursor.com)