### PR TITLE
fix(web): chosei unavailable 判定の TS2367 を修正

### DIFF
--- a/genai-web/packages/web/src/open-genai/chosei/useChosei.ts
+++ b/genai-web/packages/web/src/open-genai/chosei/useChosei.ts
@@ -48,7 +48,9 @@ export const useChoseiConfig = () => {
     loadError: error
       ? '日程調整の設定取得に失敗しました。時間をおいて再度お試しください。'
       : null,
-    unavailable: data?.enabled === false || (!!data?.error && data.enabled === false),
+    // enabled === false（503 時など）のみを「未起動」。|| 右側で再度 === false すると
+    // TS が左辺失敗後に enabled を true|undefined に絞り TS2367 になる。
+    unavailable: data?.enabled === false,
   };
 };
 


### PR DESCRIPTION
## Summary
- `useChoseiConfig` の `unavailable` 判定で、`enabled === false` を `||` の両辺に書いていたため、本番静的ビルド（`tsc`）が TS2367 で失敗していた
- 意味の通る `data?.enabled === false` のみに簡略化し、`web` の本番ビルドが通ることを確認した

## Test plan
- [x] `docker compose -f docker-compose.prod.yml ... build --no-cache web` が成功すること
- [ ] `/chosei` で chosei 未起動時に有効化案内が出ること
- [ ] chosei 起動時にイベント一覧が表示されること


Made with [Cursor](https://cursor.com)