### PR TITLE
feat(exapp): Dify チャットのストリーミング表示と過去会話の復元

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,8 @@ AI アプリ一覧（`/apps`）は各 exApp の `/health` を確認し、**起�
 
 - `dify-app` は源内の AI アプリ・プロトコル（同期 `{inputs}` → `{outputs}`）を、Dify の API（`/v1/workflows/run` または `/v1/chat-messages`）に変換します。
 - **UI は種別で出し分きます**。`dify_app_type` が `workflow` のアプリは従来の**フォーム実行型 UI**、`chat` のアプリは**対話型 UI**（吹き出し形式のチャット画面）で開きます。どちらも「AI アプリ」一覧に並びます。
-- Dify の **blocking モードには既知の不具合**（1.4.1〜1.13 系で blocking 指定でも `text/event-stream` を返す）があるため、`dify-app` は常に **streaming で受信してサーバ側で集約**し、源内には同期 `outputs` として返します。
+- `dify-app` は Dify API を常に **streaming（SSE）で受信**します。**チャットフロー（`chat`）は、そのトークンをブラウザまで NDJSON で中継**し、対話 UI がタイプライター表示で逐次描画します（`/exapps/invoke/stream`）。**ワークフロー（`workflow`）は従来どおりサーバ側で集約**して同期 `outputs` として返します。
+  - streaming を採用する理由: Dify は長時間実行やプロキシ切断への耐性から streaming を推奨しており、Agent 系フローは streaming のみ対応です。加えて 1.4.1〜1.13 系には blocking 指定でも `text/event-stream` を返す既知の不具合がありました（1.16 系で修正）。
 - Dify 本体は本リポジトリには含めません（**既存/外部の Dify** に接続します）。セルフホスト版は `host.docker.internal` 経由でホスト上の Dify にも接続できます。**Dify クラウド版** は `dify_base_url` に `https://api.dify.ai/v1` を指定します（後述）。
 - ワークフロー用アプリとチャットフロー用アプリはエンドポイントが同じ（`dify-app`）でも問題ありません。**APIキー**（ワークフロー用 / チャット用）と `dify_app_type` で区別します。
 
@@ -1062,7 +1063,7 @@ S3_PUBLIC_ENDPOINT=https://files.example.lg.jp
 
 ### 制約
 
-- 呼び出しは**同期形式**です（Dify 側は streaming で受信して集約）。非同期ポーリング形式は未対応です。
+- **チャットフロー**は NDJSON ストリーミングでトークンを逐次表示します（`/exapps/invoke/stream`）。**ワークフロー / フォーム実行型は同期形式**（`{inputs}` → `{outputs}`）で、完了後に一括表示します。いずれも非同期ポーリング形式は未対応です。
 - 会話継続は**チャットフロー**が対象です（ワークフローは状態を持ちません）。
 
 ## チーム / AI アプリ管理
@@ -1186,7 +1187,7 @@ docker restart open-genai-proxy
 ## 制限事項（ローカル版）
 
 - 画像生成は源内 Web の **「画像を生成」**（`/image`）を利用します。ホストで A1111 互換 SD サーバ（または `scripts/mock-sd-server.py`）が必要です。
-- AI アプリの呼び出しは同期形式のみ対応（非同期のポーリング形式は未対応）
+- AI アプリの呼び出しは、Dify チャットフローが NDJSON ストリーミング、それ以外（ワークフロー / フォーム実行型）は同期形式（非同期のポーリング形式は未対応）
 - 添付のうち **動画** はローカル LLM が直接扱えないため未対応（画像・ドキュメントは対応）
 - 認証は SAML（Keycloak）で行います。開発用は HTTP・既定パスワードです。
   **閉域・本番**では `docker-compose.prod.yml`、TLS 証明書、`INTERNAL_SIGNING_SECRET`、

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2340,6 +2340,242 @@ async def invoke_exapp(request: Request) -> JSONResponse:
     )
 
 
+def _derive_stream_endpoint(endpoint: str) -> str:
+    """同期 invoke の endpoint URL から、ストリーミング用 URL を導出する。
+
+    例: http://dify-app:8004/invoke -> http://dify-app:8004/invoke/stream
+    """
+    base = (endpoint or "").rstrip("/")
+    if base.endswith("/invoke"):
+        return base + "/stream"
+    return base + "/invoke/stream"
+
+
+@app.post("/exapps/invoke/stream")
+async def invoke_exapp_stream(request: Request) -> Any:
+    """AI アプリ実行を NDJSON でストリーミング中継する（Dify chat 種別専用）。
+
+    dify-app の /invoke/stream からの NDJSON をそのままクライアントへ流し、
+    `done` 到達時に成果物を自前ストレージへ再ホストして差し替える。履歴・監査は
+    ストリーム完了時に 1 件記録する。chat 以外や未対応 endpoint は 400 を返す。
+    """
+    claims = _claims_from_request(request)
+    user_id = _user_id(claims)
+    body = await request.json()
+    team_id = body.get("teamId", "")
+    ex_app_id = body.get("exAppId", "")
+    inputs = body.get("inputs", {})
+    session_id = body.get("sessionId", "")
+
+    app_def = teams_store.get_exapp(team_id, ex_app_id)
+    if not app_def:
+        return JSONResponse(status_code=404, content={"error": "AI アプリが見つかりません"})
+
+    if ex_app_id in ADMIN_ONLY_EXAPP_IDS and not _is_system_admin(claims):
+        return _forbidden("このアプリの実行には管理者権限が必要です")
+
+    if (
+        team_id != COMMON_TEAM_ID
+        and not _is_system_admin(claims)
+        and not teams_store.is_team_member(team_id, user_id)
+    ):
+        return _forbidden("このアプリを実行する権限がありません")
+
+    if ex_app_id not in ADMIN_ONLY_EXAPP_IDS:
+        ng = _ngword_denied(request, _texts_from_inputs(inputs), usecase=f"exapp:{ex_app_id}")
+        if ng:
+            return JSONResponse(status_code=403, content={"error": ng})
+
+    # ストリーミングは Dify chat 種別のみ対応（フォーム型 workflow は同期 /exapps/invoke）
+    try:
+        _cfg = json.loads(app_def.get("config") or "{}")
+    except (json.JSONDecodeError, TypeError):
+        _cfg = {}
+    if not isinstance(_cfg, dict) or (
+        str(_cfg.get("dify_app_type") or "").strip().lower() != "chat"
+    ):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "このアプリはストリーミングに対応していません。",
+                "error_code": "INVALID_INPUT",
+            },
+        )
+
+    stream_endpoint = _derive_stream_endpoint(app_def["endpoint"])
+
+    started = _now_iso()
+    _groups_str = ",".join(claims.get("groups") or [])
+    _team_ids = _user_team_ids_str(user_id)
+    _teams_hdr = _user_teams_header(user_id)
+    _invoke_headers = {
+        "x-api-key": app_def.get("apiKey", ""),
+        "x-user-id": user_id,
+        "x-user-groups": _groups_str,
+        "x-user-tags": _team_ids,
+        "x-user-teams": _teams_hdr,
+        "x-scope": team_id,
+        "x-app-config": _header_config_value(app_def.get("config")),
+        "x-session-id": session_id,
+        **intauth.signed_headers(user_id, _groups_str, team_id, _team_ids),
+        "Content-Type": "application/json",
+    }
+
+    def _persist_invoke(
+        *,
+        outputs: str,
+        status: str,
+        artifacts: Any = None,
+        audit_status: int,
+    ) -> None:
+        team = teams_store.get_team(team_id)
+        try:
+            teams_store.create_exapp_history(
+                {
+                    "teamId": team_id,
+                    "teamName": team["teamName"] if team else "",
+                    "exAppId": ex_app_id,
+                    "exAppName": app_def.get("exAppName", ""),
+                    "userId": user_id,
+                    "inputs": inputs,
+                    "outputs": outputs,
+                    "status": status,
+                    "progress": "",
+                    "artifacts": artifacts,
+                    "sessionId": session_id or None,
+                }
+            )
+        except Exception as e:  # noqa: BLE001 - 履歴保存失敗で実行結果は返す
+            print(f"[exapps] 履歴の保存に失敗(stream): {e}")
+        try:
+            audit.record(
+                request,
+                action="exapp.invoke",
+                teamId=team_id,
+                exAppId=ex_app_id,
+                session_id=session_id or None,
+                status=audit_status,
+                input_text=(
+                    json.dumps(_redact_for_audit(inputs), ensure_ascii=False)
+                    if inputs
+                    else ""
+                ),
+                output_text=outputs if isinstance(outputs, str) else json.dumps(
+                    outputs, ensure_ascii=False
+                ),
+            )
+        except Exception as e:  # noqa: BLE001
+            print(f"[exapps] 監査ログの記録に失敗(stream): {e}")
+
+    async def _gen():
+        def _line(obj: dict[str, Any]) -> str:
+            return json.dumps(obj, ensure_ascii=False) + "\n"
+
+        parts: list[str] = []
+        final_outputs: Any = ""
+        final_artifacts: Any = None
+        status = "COMPLETED"
+        audit_status = 200
+        got_done = False
+        terminal = False  # done または error を送出済み
+        try:
+            async with httpx.AsyncClient(timeout=600) as client:
+                async with client.stream(
+                    "POST",
+                    stream_endpoint,
+                    json={"inputs": inputs},
+                    headers=_invoke_headers,
+                ) as res:
+                    if res.status_code != 200:
+                        raw = (await res.aread()).decode("utf-8", "replace")
+                        try:
+                            data = json.loads(raw)
+                            if not isinstance(data, dict):
+                                data = {}
+                        except (json.JSONDecodeError, TypeError):
+                            data = {}
+                        sc, message, code = _normalize_exapp_error(
+                            data.get("error_code"), http_status=res.status_code
+                        )
+                        status = "ERROR"
+                        audit_status = sc
+                        final_outputs = message
+                        terminal = True
+                        yield _line(
+                            {"event": "error", "error": message, "error_code": code}
+                        )
+                        return
+                    async for line in res.aiter_lines():
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            obj = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        event = obj.get("event")
+                        if event == "delta":
+                            parts.append(obj.get("text", ""))
+                            yield line + "\n"
+                        elif event == "done":
+                            got_done = True
+                            outputs = obj.get("outputs", "")
+                            artifacts = obj.get("artifacts")
+                            try:
+                                outputs, artifacts = await _rehost_artifacts(
+                                    request, user_id, outputs, artifacts
+                                )
+                            except Exception as e:  # noqa: BLE001
+                                print(f"[exapps] 成果物の再ホストに失敗(stream): {e}")
+                            final_outputs = outputs
+                            final_artifacts = artifacts
+                            done: dict[str, Any] = {"event": "done", "outputs": outputs}
+                            if artifacts:
+                                done["artifacts"] = artifacts
+                            terminal = True
+                            yield _line(done)
+                        elif event == "error":
+                            status = "ERROR"
+                            audit_status = 502
+                            final_outputs = obj.get("error", "")
+                            terminal = True
+                            yield line + "\n"
+        except httpx.HTTPError as e:
+            print(f"[exapps] AI アプリ接続失敗(stream): {e}")
+            sc, message, code = _normalize_exapp_error("CONNECTION")
+            status = "ERROR"
+            audit_status = sc
+            final_outputs = message
+            if not terminal:
+                terminal = True
+                yield _line({"event": "error", "error": message, "error_code": code})
+        except Exception as e:  # noqa: BLE001
+            print(f"[exapps] ストリーム中継で予期せぬエラー: {e}")
+            sc, message, code = _normalize_exapp_error("WORKFLOW_ERROR")
+            status = "ERROR"
+            audit_status = sc
+            final_outputs = message
+            if not terminal:
+                terminal = True
+                yield _line({"event": "error", "error": message, "error_code": code})
+        finally:
+            # done が来ずに接続が途切れた場合は、受信済みの断片を成果として残す
+            if status == "COMPLETED" and not got_done:
+                final_outputs = "".join(parts)
+            _persist_invoke(
+                outputs=(
+                    final_outputs
+                    if isinstance(final_outputs, str)
+                    else json.dumps(final_outputs, ensure_ascii=False)
+                ),
+                status=status,
+                artifacts=final_artifacts,
+                audit_status=audit_status,
+            )
+
+    return StreamingResponse(_gen(), media_type="application/x-ndjson")
+
+
 @app.post("/exapps/schema")
 async def get_exapp_schema(request: Request) -> JSONResponse:
     """AI アプリの入力フォーム定義(placeholder)を取得する。

--- a/dify-app/app/main.py
+++ b/dify-app/app/main.py
@@ -34,10 +34,15 @@ from typing import Any
 
 import httpx
 from fastapi import FastAPI, Header, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
 try:
-    from .errors import AppInvokeError, classify_provider_error, error_response
+    from .errors import (
+        AppInvokeError,
+        classify_provider_error,
+        error_body,
+        error_response,
+    )
 except ImportError:  # pragma: no cover - 単体読み込み（pytest の file location import）
     import sys
     from pathlib import Path
@@ -45,7 +50,12 @@ except ImportError:  # pragma: no cover - 単体読み込み（pytest の file l
     _app_dir = str(Path(__file__).resolve().parent)
     if _app_dir not in sys.path:
         sys.path.insert(0, _app_dir)
-    from errors import AppInvokeError, classify_provider_error, error_response
+    from errors import (
+        AppInvokeError,
+        classify_provider_error,
+        error_body,
+        error_response,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -846,10 +856,15 @@ async def _run_chat(
     user: str,
     conversation_id: str,
     files: list[dict[str, Any]],
+    session_id: str = "",
 ) -> tuple[str, str, list[dict[str, Any]], list[dict[str, Any]]]:
     """チャットフローを実行する。
 
     戻り値: (answer, conversation_id, file_objs, citation_artifacts)
+
+    `session_id` が渡された場合、新規会話IDが判明した時点で session→conversation
+    を即保存する（生成途中でタイムアウトしても会話継続を失わないため。呼び出し側
+    は完了後にも保存するが冪等）。
     """
     payload: dict[str, Any] = {
         "query": query,
@@ -867,6 +882,7 @@ async def _run_chat(
     retriever_resources: list[Any] = []
     tool_citations: list[dict[str, Any]] = []
     new_conv_id = conversation_id
+    conv_saved = False
     error: str | None = None
 
     async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
@@ -899,6 +915,14 @@ async def _run_chat(
                     continue
                 if obj.get("conversation_id"):
                     new_conv_id = obj["conversation_id"]
+                    # 新規会話が採番された時点で即保存（done を待たずに継続性を確保）。
+                    if (
+                        not conv_saved
+                        and session_id
+                        and new_conv_id != conversation_id
+                    ):
+                        conv_saved = True
+                        _save_conversation_id(session_id, new_conv_id)
                 event = obj.get("event")
                 if event in ("message", "agent_message"):
                     answer_parts.append(obj.get("answer", ""))
@@ -947,6 +971,131 @@ async def _run_chat(
     _merge_citation_arts(citations, tool_citations)
     citations = _filter_citations_cited_in_answer(answer, citations)
     return (answer, new_conv_id, out_files, citations)
+
+
+async def _run_chat_stream(
+    base: str,
+    api_key: str,
+    query: str,
+    inputs: dict[str, Any],
+    user: str,
+    conversation_id: str,
+    files: list[dict[str, Any]],
+):
+    """チャットフローを streaming 実行し、回答の断片を逐次 yield する。
+
+    yield するイベント（dict）:
+      {"type": "conversation", "conversation_id": str}  会話ID判明時（早期・1回）
+      {"type": "delta", "text": "..."}                 回答トークンの断片
+      {"type": "done", "answer": str, "conversation_id": str,
+       "files": [...], "citations": [...]}             完了（全文と成果物）
+
+    provider 由来のエラーは `_run_chat` と同様に AppInvokeError を raise する。
+    集計ロジックは `_run_chat` と同一で、違いは `message`/`agent_message`
+    到着時に断片を即 yield する点、及び会話IDが判明した時点で `conversation`
+    を先に yield する点（生成途中でタイムアウトしても会話継続を失わないため）。
+    """
+    payload: dict[str, Any] = {
+        "query": query,
+        "inputs": inputs,
+        "response_mode": "streaming",
+        "user": user,
+    }
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    if files:
+        payload["files"] = files
+
+    answer_parts: list[str] = []
+    file_objs: list[dict[str, Any]] = []
+    retriever_resources: list[Any] = []
+    tool_citations: list[dict[str, Any]] = []
+    new_conv_id = conversation_id
+    conv_emitted = False
+    error: str | None = None
+
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        async with client.stream(
+            "POST",
+            f"{base}/chat-messages",
+            json=payload,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+        ) as res:
+            if res.status_code != 200:
+                body = (await res.aread()).decode("utf-8", "replace")
+                raise classify_provider_error(
+                    body,
+                    default_code="CONNECTION",
+                    http_status=res.status_code,
+                )
+            async for line in res.aiter_lines():
+                line = line.strip()
+                if not line.startswith("data:"):
+                    continue
+                payload_str = line[len("data:") :].strip()
+                if not payload_str or payload_str == "[DONE]":
+                    continue
+                try:
+                    obj = json.loads(payload_str)
+                except json.JSONDecodeError:
+                    continue
+                if obj.get("conversation_id"):
+                    new_conv_id = obj["conversation_id"]
+                    # 新規会話が採番された時点で早期通知。生成途中でタイムアウト
+                    # しても、次回リクエストで会話を継続できるよう即保存させる。
+                    if not conv_emitted and new_conv_id != conversation_id:
+                        conv_emitted = True
+                        yield {"type": "conversation", "conversation_id": new_conv_id}
+                event = obj.get("event")
+                if event in ("message", "agent_message"):
+                    chunk = obj.get("answer", "")
+                    if chunk:
+                        answer_parts.append(chunk)
+                        yield {"type": "delta", "text": chunk}
+                elif event == "message_file":
+                    file_objs.append(obj)
+                elif event == "agent_thought":
+                    obs = obj.get("observation")
+                    if obs:
+                        _scavenge_citations(obs, tool_citations)
+                elif event == "agent_log":
+                    _scavenge_citations(obj.get("data"), tool_citations)
+                elif event == "node_finished":
+                    data = obj.get("data") or {}
+                    hits = _extract_knowledge_results(data)
+                    if hits:
+                        retriever_resources.extend(hits)
+                    if isinstance(data, dict):
+                        _scavenge_citations(data.get("outputs"), tool_citations)
+                        _scavenge_citations(data.get("process_data"), tool_citations)
+                elif event == "message_end":
+                    for f in obj.get("files") or []:
+                        if isinstance(f, dict):
+                            file_objs.append(f)
+                    meta = obj.get("metadata") or {}
+                    resources = meta.get("retriever_resources") or []
+                    if isinstance(resources, list) and resources:
+                        retriever_resources = list(resources)
+                elif event == "error":
+                    error = obj.get("message") or "unknown error"
+
+    if error:
+        raise classify_provider_error(error, default_code="WORKFLOW_ERROR")
+    answer = "".join(answer_parts)
+    out_files = _extract_dify_files(file_objs)
+    citations = _citations_to_artifacts(retriever_resources)
+    _merge_citation_arts(citations, tool_citations)
+    citations = _filter_citations_cited_in_answer(answer, citations)
+    yield {
+        "type": "done",
+        "answer": answer,
+        "conversation_id": new_conv_id,
+        "files": out_files,
+        "citations": citations,
+    }
 
 
 # 源内フォームには出さず、invoke 時に自動注入する Dify 入力変数（常時）
@@ -1243,7 +1392,14 @@ async def invoke(
                 dify_inputs[file_var] = all_file_refs if is_list else all_file_refs[0]
                 chat_files = []
         answer, new_conv_id, out_files, citations = await _run_chat(
-            base, api_key, query, dify_inputs, user, conversation_id, chat_files
+            base,
+            api_key,
+            query,
+            dify_inputs,
+            user,
+            conversation_id,
+            chat_files,
+            session_id=x_session_id or "",
         )
         if new_conv_id and x_session_id:
             _save_conversation_id(x_session_id, new_conv_id)
@@ -1259,3 +1415,134 @@ async def invoke(
     except Exception as e:  # noqa: BLE001
         logger.exception("dify-app invoke unexpected error")
         return error_response(AppInvokeError("WORKFLOW_ERROR", detail=str(e)))
+
+
+@app.post("/invoke/stream")
+async def invoke_stream(
+    request: Request,
+    x_api_key: str | None = Header(default=None),
+    x_app_config: str | None = Header(default=None),
+    x_session_id: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+    x_scope: str | None = Header(default=None),
+) -> Any:
+    """チャットフローを NDJSON でストリーミングする（chat 種別専用）。
+
+    出力は 1 行 1 JSON（application/x-ndjson）:
+      {"event":"delta","text":"..."}                  回答の断片
+      {"event":"done","outputs":"...","artifacts":[...]}  完了
+      {"event":"error","error":"...","error_code":"..."}  失敗
+
+    workflow 種別は同期の /invoke を使う（このエンドポイントは 400 を返す）。
+    ファイルアップロード・入力解決など、ストリーム開始前に失敗し得る処理は
+    事前に実行し、失敗時は非ストリームの JSON エラーで返す。
+    """
+    err = _check_key(x_api_key)
+    if err:
+        return err
+
+    cfg = _parse_config(x_app_config)
+    base = (cfg.get("dify_base_url") or DEFAULT_DIFY_BASE_URL).rstrip("/")
+    if not base:
+        return error_response(
+            AppInvokeError("CONNECTION", detail="dify_base_url is not configured")
+        )
+
+    app_type = (cfg.get("dify_app_type") or "chat").strip().lower()
+    if app_type != "chat":
+        # ストリーミングは対話型のみ。workflow は同期 /invoke を使う。
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "このアプリはストリーミングに対応していません。",
+                "error_code": "INVALID_INPUT",
+            },
+        )
+
+    query_fields = _normalize_field_names(cfg.get("query_field")) or ["query"]
+    query_field = query_fields[0]
+    api_key = x_api_key or ""
+    user = x_user_id or "open-genai"
+
+    body = await request.json()
+    inputs = _inject_hidden_inputs(
+        body.get("inputs", body) or {},
+        scope=x_scope,
+        cfg=cfg,
+    )
+
+    # ファイルを Dify にアップロードして参照オブジェクト化（ストリーム開始前）
+    file_refs_by_key: dict[str, list[dict[str, Any]]] = {}
+    all_file_refs: list[dict[str, Any]] = []
+    files_meta = _iter_input_files(inputs)
+    if files_meta:
+        try:
+            async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+                for key, filename, content_b64 in files_meta:
+                    ref = await _upload_file(
+                        client, base, api_key, filename, content_b64, user
+                    )
+                    file_refs_by_key.setdefault(key, []).append(ref)
+                    all_file_refs.append(ref)
+        except httpx.HTTPError as e:
+            return error_response(AppInvokeError("UPLOAD_FAILED", detail=str(e)))
+        except Exception as e:  # noqa: BLE001
+            return error_response(AppInvokeError("UPLOAD_FAILED", detail=str(e)))
+
+    query = str(inputs.get(query_field) or inputs.get("question") or "").strip()
+    if not query:
+        return error_response(AppInvokeError("INVALID_INPUT", detail="empty query"))
+
+    dify_inputs = _coerce_dify_input_values(
+        _strip_meta(inputs, query_field, "question")
+    )
+    conversation_id = _get_conversation_id(x_session_id or "")
+    chat_files = all_file_refs
+    if all_file_refs:
+        if cfg.get("file_var"):
+            file_var, is_list = cfg.get("file_var"), True
+        else:
+            file_var, is_list = await _detect_file_input(base, api_key)
+        if file_var:
+            dify_inputs[file_var] = all_file_refs if is_list else all_file_refs[0]
+            chat_files = []
+
+    async def _ndjson():
+        def _line(obj: dict[str, Any]) -> str:
+            return json.dumps(obj, ensure_ascii=False) + "\n"
+
+        try:
+            async for ev in _run_chat_stream(
+                base, api_key, query, dify_inputs, user, conversation_id, chat_files
+            ):
+                if ev["type"] == "delta":
+                    yield _line({"event": "delta", "text": ev["text"]})
+                elif ev["type"] == "conversation":
+                    # 会話ID判明時に即保存（done を待たずに継続性を確保）。
+                    # このイベントは dify-app 内部で消費し、下流には流さない。
+                    if ev["conversation_id"] and x_session_id:
+                        _save_conversation_id(x_session_id, ev["conversation_id"])
+                elif ev["type"] == "done":
+                    if ev["conversation_id"] and x_session_id:
+                        _save_conversation_id(x_session_id, ev["conversation_id"])
+                    arts = _files_to_artifacts(base, ev["files"]) + ev["citations"]
+                    done: dict[str, Any] = {"event": "done", "outputs": ev["answer"]}
+                    if arts:
+                        done["artifacts"] = arts
+                    yield _line(done)
+        except AppInvokeError as e:
+            yield _line({"event": "error", **error_body(e)})
+        except httpx.HTTPError as e:
+            yield _line(
+                {"event": "error", **error_body(AppInvokeError("CONNECTION", detail=str(e)))}
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.exception("dify-app invoke_stream unexpected error")
+            yield _line(
+                {
+                    "event": "error",
+                    **error_body(AppInvokeError("WORKFLOW_ERROR", detail=str(e))),
+                }
+            )
+
+    return StreamingResponse(_ndjson(), media_type="application/x-ndjson")

--- a/dify-app/tests/test_stream.py
+++ b/dify-app/tests/test_stream.py
@@ -1,0 +1,213 @@
+"""チャットフローの streaming 実行（_run_chat_stream）の単体テスト。
+
+Dify への SSE 接続を差し替え、`message` 断片が逐次 delta として yield され、
+最後に集約済みの done（全文・出典・ファイル）が来ることを検証する。エラー
+イベントは `_run_chat` と同じく AppInvokeError に分類されることも確認する。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import httpx
+
+_MAIN = Path(__file__).resolve().parents[1] / "app" / "main.py"
+
+
+def _load_main():
+    spec = importlib.util.spec_from_file_location("dify_app_main", _MAIN)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["dify_app_main"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeStreamResponse:
+    """httpx の streaming レスポンスを模した非同期コンテキストマネージャ。"""
+
+    def __init__(self, status_code: int, lines: list[str]) -> None:
+        self.status_code = status_code
+        self._lines = lines
+
+    async def __aenter__(self) -> "_FakeStreamResponse":
+        return self
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+    async def aread(self) -> bytes:
+        return b""
+
+
+class _FakeAsyncClient:
+    def __init__(self, response: _FakeStreamResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+    def stream(self, *_a: object, **_k: object) -> _FakeStreamResponse:
+        return self._response
+
+
+def _sse(lines: list[str]) -> list[str]:
+    """SSE の data: 行に整形する。"""
+    return [f"data: {ln}" for ln in lines]
+
+
+class RunChatStreamTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.main = _load_main()
+
+    def _patch_httpx(self, status_code: int, lines: list[str]) -> None:
+        response = _FakeStreamResponse(status_code, lines)
+        fake = types.SimpleNamespace(
+            AsyncClient=lambda *a, **k: _FakeAsyncClient(response),
+            HTTPError=httpx.HTTPError,
+        )
+        self._orig_httpx = self.main.httpx
+        self.main.httpx = fake
+        self.addCleanup(lambda: setattr(self.main, "httpx", self._orig_httpx))
+
+    def _collect(self, *, conversation_id: str = "") -> list[dict]:
+        async def _run() -> list[dict]:
+            out: list[dict] = []
+            async for ev in self.main._run_chat_stream(
+                base="https://dify.example/v1",
+                api_key="app-test",
+                query="こんにちは",
+                inputs={},
+                user="u",
+                conversation_id=conversation_id,
+                files=[],
+            ):
+                out.append(ev)
+            return out
+
+        return asyncio.run(_run())
+
+    def test_message_chunks_yield_deltas_then_done(self) -> None:
+        self._patch_httpx(
+            200,
+            _sse(
+                [
+                    '{"event":"workflow_started","conversation_id":"conv-1"}',
+                    '{"event":"message","answer":"大分","conversation_id":"conv-1"}',
+                    '{"event":"message","answer":"市"}',
+                    '{"event":"message","answer":"です"}',
+                    '{"event":"message_end"}',
+                ]
+            ),
+        )
+        events = self._collect()
+        deltas = [e for e in events if e["type"] == "delta"]
+        dones = [e for e in events if e["type"] == "done"]
+        convs = [e for e in events if e["type"] == "conversation"]
+        # 会話IDは delta より前に 1 回だけ早期通知される
+        self.assertEqual(len(convs), 1)
+        self.assertEqual(convs[0]["conversation_id"], "conv-1")
+        self.assertLess(events.index(convs[0]), events.index(deltas[0]))
+        self.assertEqual([d["text"] for d in deltas], ["大分", "市", "です"])
+        self.assertEqual(len(dones), 1)
+        done = dones[0]
+        self.assertEqual(done["answer"], "大分市です")
+        # 会話 ID は SSE 内の conversation_id を引き継ぐ
+        self.assertEqual(done["conversation_id"], "conv-1")
+        self.assertEqual(done["files"], [])
+
+    def test_continuation_does_not_reemit_conversation(self) -> None:
+        # 既存会話の継続（conversation_id 指定済み）では conversation を再通知しない
+        self._patch_httpx(
+            200,
+            _sse(
+                [
+                    '{"event":"message","answer":"A","conversation_id":"conv-x"}',
+                    '{"event":"message_end"}',
+                ]
+            ),
+        )
+        events = self._collect(conversation_id="conv-x")
+        convs = [e for e in events if e["type"] == "conversation"]
+        self.assertEqual(convs, [])
+
+    def test_empty_answer_chunks_are_skipped(self) -> None:
+        self._patch_httpx(
+            200,
+            _sse(
+                [
+                    '{"event":"message","answer":"","conversation_id":"c"}',
+                    '{"event":"message","answer":"A"}',
+                ]
+            ),
+        )
+        events = self._collect()
+        deltas = [e for e in events if e["type"] == "delta"]
+        self.assertEqual([d["text"] for d in deltas], ["A"])
+
+    def test_error_event_raises_app_invoke_error(self) -> None:
+        self._patch_httpx(
+            200,
+            _sse(['{"event":"error","message":"boom"}']),
+        )
+        with self.assertRaises(self.main.AppInvokeError) as ctx:
+            self._collect()
+        self.assertEqual(ctx.exception.code, "WORKFLOW_ERROR")
+
+    def test_non_200_status_raises_connection(self) -> None:
+        self._patch_httpx(502, [])
+        with self.assertRaises(self.main.AppInvokeError) as ctx:
+            self._collect()
+        self.assertEqual(ctx.exception.code, "CONNECTION")
+
+    def test_run_chat_saves_conversation_early(self) -> None:
+        # 同期経路も、会話IDが判明した時点で session→conversation を即保存する
+        self._patch_httpx(
+            200,
+            _sse(
+                [
+                    '{"event":"message","answer":"A","conversation_id":"conv-sync"}',
+                    '{"event":"message","answer":"B"}',
+                    '{"event":"message_end"}',
+                ]
+            ),
+        )
+        saved: list[tuple[str, str]] = []
+        orig = self.main._save_conversation_id
+        self.main._save_conversation_id = lambda s, c: saved.append((s, c))
+        self.addCleanup(lambda: setattr(self.main, "_save_conversation_id", orig))
+
+        async def _run():
+            return await self.main._run_chat(
+                base="https://dify.example/v1",
+                api_key="app-test",
+                query="hi",
+                inputs={},
+                user="u",
+                conversation_id="",
+                files=[],
+                session_id="sess-1",
+            )
+
+        answer, conv_id, _files, _cits = asyncio.run(_run())
+        self.assertEqual(answer, "AB")
+        self.assertEqual(conv_id, "conv-sync")
+        # 早期保存が 1 回だけ行われる（イベント毎の重複保存はしない）
+        self.assertEqual(saved, [("sess-1", "conv-sync")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/genai-web/packages/web/src/features/exapp/components/ExAppChat.tsx
+++ b/genai-web/packages/web/src/features/exapp/components/ExAppChat.tsx
@@ -1,16 +1,19 @@
 import { Artifact, ExApp } from 'genai-web';
 import { KeyboardEvent, useEffect, useRef, useState } from 'react';
 import { Markdown } from '@/components/Markdown';
+import { ButtonCopy } from '@/components/ui/ButtonCopy';
 import { Button } from '@/components/ui/dads/Button';
 import { ProgressIndicator } from '@/components/ui/dads/ProgressIndicator';
 import { Textarea } from '@/components/ui/dads/Textarea';
 import { LoadingButton } from '@/components/ui/LoadingButton';
 import { isApiError } from '@/lib/fetcher';
 import { submitKeyHint, isSubmitKey } from '@/utils/keyboard';
+import { ExAppConversation, useExAppConversations } from '../hooks/useExAppConversations';
 import { useInvokeExApp } from '../hooks/useInvokeExApp';
 import { processFormFiles } from '../utils/processFormFiles';
 import { ExAppArtifactDownloads } from './ExAppArtifactDownloads';
 import { ExAppCitations } from './ExAppCitations';
+import { ExAppConversationList } from './ExAppConversationList';
 
 type ChatMessage = {
   role: 'user' | 'assistant';
@@ -30,14 +33,44 @@ type Props = {
 // dify-app 側の session -> conversation_id 対応に委ねる。
 const ACCEPT = 'image/*,.pdf,.docx,.xlsx,.txt,.md,.csv,.html,.json';
 
+const GENERIC_ERROR =
+  '処理中にエラーが発生しました。時間をおいて再度お試しください。解消しない場合は管理者にお問い合わせください。';
+
+// 履歴の inputs.files（processFormFiles の出力）から添付ファイル名を復元する。
+// 本文（base64）は復元対象外で、表示用のファイル名のみ取り出す。
+const extractFileNames = (inputs: Record<string, unknown>): string[] | undefined => {
+  const files = inputs?.files;
+  if (!Array.isArray(files)) {
+    return undefined;
+  }
+  const names: string[] = [];
+  for (const group of files) {
+    const inner = (group as { files?: unknown })?.files;
+    if (!Array.isArray(inner)) {
+      continue;
+    }
+    for (const file of inner) {
+      const filename = (file as { filename?: unknown })?.filename;
+      if (typeof filename === 'string') {
+        names.push(filename);
+      }
+    }
+  }
+  return names.length > 0 ? names : undefined;
+};
+
 export const ExAppChat = ({ exApp, fileAttachEnabled = false }: Props) => {
-  const { invokeExApp } = useInvokeExApp();
+  const { invokeExAppStream } = useInvokeExApp();
+  const { conversations, mutate: mutateConversations } = useExAppConversations(
+    exApp.teamId,
+    exApp.exAppId,
+  );
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [files, setFiles] = useState<File[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
-  const [sessionId, setSessionId] = useState(() => crypto.randomUUID());
+  const [sessionId, setSessionId] = useState<string>(() => crypto.randomUUID());
   const isComposing = useRef(false);
   const bottomRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -63,37 +96,76 @@ export const ExAppChat = ({ exApp, fileAttachEnabled = false }: Props) => {
       content: text,
       fileNames: sendingFiles.map((f) => f.name),
     };
-    setMessages((prev) => [...prev, userMessage]);
+    // ユーザー発話に続けて、逐次追記する空のアシスタント枠を先に置く。
+    setMessages((prev) => [...prev, userMessage, { role: 'assistant', content: '' }]);
     setInput('');
     setFiles([]);
     setIsLoading(true);
+
+    // 最後のアシスタントメッセージだけを更新するヘルパ。
+    const updateAssistant = (fn: (m: ChatMessage) => ChatMessage) => {
+      setMessages((prev) => {
+        const next = [...prev];
+        const last = next[next.length - 1];
+        if (last && last.role === 'assistant') {
+          next[next.length - 1] = fn(last);
+        }
+        return next;
+      });
+    };
+
+    // 内容が空のアシスタント枠を取り除く（エラー時・空応答時）。
+    const dropEmptyAssistant = () => {
+      setMessages((prev) => {
+        const next = [...prev];
+        const last = next[next.length - 1];
+        if (last && last.role === 'assistant' && !last.content) {
+          next.pop();
+        }
+        return next;
+      });
+    };
 
     try {
       const inputs: Record<string, unknown> = { query: text };
       if (sendingFiles.length > 0) {
         inputs.files = await processFormFiles({ files: sendingFiles });
       }
-      const res = await invokeExApp({
-        teamId: exApp.teamId,
-        exAppId: exApp.exAppId,
-        inputs,
-        sessionId,
-      });
-      setMessages((prev) => [
-        ...prev,
-        { role: 'assistant', content: res.outputs ?? '', artifacts: res.artifacts },
-      ]);
+      await invokeExAppStream(
+        {
+          teamId: exApp.teamId,
+          exAppId: exApp.exAppId,
+          inputs,
+          sessionId,
+        },
+        {
+          onDelta: (chunk) => {
+            updateAssistant((m) => ({ ...m, content: m.content + chunk }));
+          },
+          onDone: ({ outputs, artifacts }) => {
+            // done の outputs が確定値。断片の積み上げを最終全文で置き換える。
+            updateAssistant((m) => ({
+              ...m,
+              content: outputs || m.content,
+              artifacts,
+            }));
+            // 完了時点でサーバ側の履歴保存が済んでいるため、
+            // 「過去の会話」一覧を再取得して今の会話を反映する。
+            void mutateConversations();
+          },
+          onError: (message) => {
+            dropEmptyAssistant();
+            setError(message || GENERIC_ERROR);
+          },
+        },
+      );
     } catch (error: unknown) {
+      dropEmptyAssistant();
       if (isApiError(error)) {
         const data = error.data as { error?: string };
-        setError(
-          data?.error ||
-            '処理中にエラーが発生しました。時間をおいて再度お試しください。解消しない場合は管理者にお問い合わせください。',
-        );
+        setError(data?.error || GENERIC_ERROR);
       } else {
-        setError(
-          '処理中にエラーが発生しました。時間をおいて再度お試しください。解消しない場合は管理者にお問い合わせください。',
-        );
+        setError(GENERIC_ERROR);
       }
     } finally {
       setIsLoading(false);
@@ -115,8 +187,45 @@ export const ExAppChat = ({ exApp, fileAttachEnabled = false }: Props) => {
     setSessionId(crypto.randomUUID());
   };
 
+  // 「過去の会話」を選ぶと、その sessionId とやり取りを復元する。
+  // sessionId を引き継ぐことで dify-app 側の会話（conversation_id）も継続できる。
+  const restoreConversation = (conversation: ExAppConversation) => {
+    const restored: ChatMessage[] = [];
+    for (const history of conversation.histories) {
+      const query = typeof history.inputs?.query === 'string' ? history.inputs.query : '';
+      restored.push({
+        role: 'user',
+        content: query,
+        fileNames: extractFileNames(history.inputs),
+      });
+      if (history.outputs) {
+        restored.push({
+          role: 'assistant',
+          content: history.outputs,
+          artifacts: history.artifacts ?? undefined,
+        });
+      }
+    }
+    setMessages(restored);
+    setSessionId(conversation.sessionId);
+    setInput('');
+    setFiles([]);
+    setError('');
+  };
+
+  // 逐次描画前の空アシスタント枠は描画しない（下のスピナーで代替）。
+  const visibleMessages = messages.filter(
+    (m) => !(m.role === 'assistant' && m.content.length === 0 && !m.artifacts),
+  );
+
   return (
     <div className='flex flex-col gap-4'>
+      <ExAppConversationList
+        conversations={conversations}
+        activeSessionId={sessionId}
+        onSelect={restoreConversation}
+      />
+
       <div className='min-h-[40vh] rounded-8 border border-solid-gray-420 p-4'>
         {messages.length === 0 && !isLoading && (
           <p className='leading-175 text-solid-gray-536'>
@@ -125,7 +234,7 @@ export const ExAppChat = ({ exApp, fileAttachEnabled = false }: Props) => {
         )}
 
         <div className='flex flex-col gap-3'>
-          {messages.map((m, i) => (
+          {visibleMessages.map((m, i) => (
             <div
               key={i}
               className={m.role === 'user' ? 'flex justify-end' : 'flex justify-start'}
@@ -142,6 +251,13 @@ export const ExAppChat = ({ exApp, fileAttachEnabled = false }: Props) => {
                     <Markdown>{m.content}</Markdown>
                     <ExAppCitations artifacts={m.artifacts} />
                     <ExAppArtifactDownloads artifacts={m.artifacts} />
+                    {/* 生成完了後のみコピーを表示（配信途中の部分テキストは対象外） */}
+                    {m.content.length > 0 &&
+                      !(isLoading && i === visibleMessages.length - 1) && (
+                        <div className='mt-1 flex justify-end'>
+                          <ButtonCopy text={m.content} />
+                        </div>
+                      )}
                   </>
                 ) : (
                   <div className='whitespace-pre-wrap break-words text-std-16N-170'>
@@ -157,6 +273,8 @@ export const ExAppChat = ({ exApp, fileAttachEnabled = false }: Props) => {
             </div>
           ))}
 
+          {/* 生成中は常にスピナーを出す。回答がまだ完了していない（続きがある）
+              ことを示すため、トークン到着後も表示し続ける。 */}
           {isLoading && (
             <div className='flex justify-start'>
               <div className='rounded-8 border border-solid-gray-420 bg-white px-4 py-3'>

--- a/genai-web/packages/web/src/features/exapp/components/ExAppConversationList.tsx
+++ b/genai-web/packages/web/src/features/exapp/components/ExAppConversationList.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { formatDateTime } from '@/utils/formatDateTime';
+import { ExAppConversation } from '../hooks/useExAppConversations';
+
+type Props = {
+  conversations: ExAppConversation[];
+  // 現在表示中の会話（sessionId）。一覧上でハイライトする。
+  activeSessionId: string;
+  onSelect: (conversation: ExAppConversation) => void;
+};
+
+// チャット画面の「過去の会話」一覧。sessionId ごとにまとめた会話を選ぶと
+// ExAppChat 側で復元される。会話が 1 件も無いときは何も表示しない。
+export const ExAppConversationList = ({ conversations, activeSessionId, onSelect }: Props) => {
+  const [open, setOpen] = useState(false);
+
+  if (conversations.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className='rounded-8 border border-solid-gray-420'>
+      <button
+        type='button'
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+        className='flex w-full items-center justify-between rounded-8 px-4 py-3 text-left hover:bg-solid-gray-50'
+      >
+        <span className='text-std-16B-160 text-solid-gray-800'>
+          過去の会話（{conversations.length}）
+        </span>
+        <svg
+          aria-hidden={true}
+          className={`size-4 text-blue-1000 transition-transform ${open ? 'rotate-180' : ''}`}
+          width='20'
+          height='20'
+          viewBox='0 0 20 20'
+          fill='none'
+        >
+          <path
+            d='M16.668 5.5L10.0013 12.1667L3.33464 5.5L2.16797 6.66667L10.0013 14.5L17.8346 6.66667L16.668 5.5Z'
+            fill='currentColor'
+          />
+        </svg>
+      </button>
+
+      {open && (
+        <ul className='max-h-[40vh] overflow-y-auto border-t border-solid-gray-420'>
+          {conversations.map((conversation) => {
+            const isActive = conversation.sessionId === activeSessionId;
+            return (
+              <li
+                key={conversation.sessionId}
+                className='border-b border-solid-gray-420 last:border-b-0'
+              >
+                <button
+                  type='button'
+                  onClick={() => onSelect(conversation)}
+                  aria-current={isActive}
+                  className={`flex w-full flex-col gap-0.5 px-4 py-3 text-left hover:bg-blue-50 ${
+                    isActive ? 'bg-blue-50' : ''
+                  }`}
+                >
+                  <span className='line-clamp-1 text-std-16N-170 text-solid-gray-800'>
+                    {conversation.title}
+                  </span>
+                  <span className='text-dns-14N-130 text-solid-gray-536'>
+                    {formatDateTime(conversation.updatedAt)}・{conversation.turnCount}往復
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/genai-web/packages/web/src/features/exapp/hooks/useExAppConversations.ts
+++ b/genai-web/packages/web/src/features/exapp/hooks/useExAppConversations.ts
@@ -1,0 +1,72 @@
+import { InvokeExAppHistory, ListInvokeExAppHistoriesResponse } from 'genai-web';
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { teamApiFetcher } from '@/lib/fetcher';
+
+// チャット（Dify チャットフロー連携）の「過去の会話」1 件分。
+// exapp_histories の各レコードは 1 往復（ユーザー発話 + 回答）に対応するため、
+// 同一 sessionId のレコードをまとめて 1 つの会話として扱う。
+export type ExAppConversation = {
+  sessionId: string;
+  // 会話一覧に表示するタイトル（会話の最初のユーザー発話）。
+  title: string;
+  // 会話内で最も新しいレコードの作成日時（会話一覧の並び順に使う）。
+  updatedAt: string;
+  // 往復数（レコード数）。
+  turnCount: number;
+  // 復元用に古い順（createdDate 昇順）で保持する。
+  histories: InvokeExAppHistory[];
+};
+
+const pickQuery = (history: InvokeExAppHistory): string => {
+  const query = (history.inputs as { query?: unknown })?.query;
+  return typeof query === 'string' ? query.trim() : '';
+};
+
+export const useExAppConversations = (teamId: string, exAppId: string) => {
+  const key =
+    teamId && exAppId
+      ? `exapps/histories?${new URLSearchParams({ teamId, exAppId }).toString()}`
+      : null;
+
+  const { data, isLoading, error, mutate } = useSWR<ListInvokeExAppHistoriesResponse>(
+    key,
+    teamApiFetcher,
+    { revalidateOnFocus: false },
+  );
+
+  const conversations = useMemo<ExAppConversation[]>(() => {
+    const histories = data?.history ?? [];
+
+    const groups = new Map<string, InvokeExAppHistory[]>();
+    for (const history of histories) {
+      const sessionId = history.sessionId;
+      if (!sessionId) {
+        // sessionId を持たない旧レコードは会話として復元できないため除外。
+        continue;
+      }
+      const items = groups.get(sessionId) ?? [];
+      items.push(history);
+      groups.set(sessionId, items);
+    }
+
+    const result: ExAppConversation[] = [];
+    for (const [sessionId, items] of groups) {
+      const asc = [...items].sort((a, b) => a.createdDate.localeCompare(b.createdDate));
+      const title = asc.map(pickQuery).find((q) => q.length > 0) ?? '（無題の会話）';
+      result.push({
+        sessionId,
+        title,
+        updatedAt: asc[asc.length - 1].createdDate,
+        turnCount: asc.length,
+        histories: asc,
+      });
+    }
+
+    // 会話一覧は最新更新順（新しい会話が上）。
+    result.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    return result;
+  }, [data]);
+
+  return { conversations, isLoading, error, mutate };
+};

--- a/genai-web/packages/web/src/features/exapp/hooks/useInvokeExApp.ts
+++ b/genai-web/packages/web/src/features/exapp/hooks/useInvokeExApp.ts
@@ -1,5 +1,18 @@
-import { InvokeExAppRequest, InvokeExAppResponse } from 'genai-web';
-import { teamApi } from '@/lib/fetcher';
+import { Artifact, InvokeExAppRequest, InvokeExAppResponse } from 'genai-web';
+import { ApiError, teamApi } from '@/lib/fetcher';
+import { getIdToken } from '@/local/localAuth';
+
+// dify-app -> backend が流す NDJSON の 1 行に対応するイベント。
+export type ExAppStreamEvent =
+  | { event: 'delta'; text: string }
+  | { event: 'done'; outputs: string; artifacts?: Artifact[] }
+  | { event: 'error'; error: string; error_code?: string };
+
+export type ExAppStreamHandlers = {
+  onDelta: (text: string) => void;
+  onDone: (result: { outputs: string; artifacts?: Artifact[] }) => void;
+  onError: (message: string, code?: string) => void;
+};
 
 export const useInvokeExApp = () => {
   const invokeExApp = async (request: InvokeExAppRequest) => {
@@ -7,7 +20,85 @@ export const useInvokeExApp = () => {
     return response.data;
   };
 
+  /**
+   * Dify チャット種別の AI アプリを NDJSON でストリーミング実行する。
+   * バックエンドの /exapps/invoke/stream が改行区切り JSON を返すため、
+   * 完全な 1 行ごとにパースしてハンドラへ渡す（predictStream と同型）。
+   * ストリーム開始前の失敗（403/400/404 等）は ApiError を throw する。
+   */
+  const invokeExAppStream = async (
+    request: InvokeExAppRequest,
+    handlers: ExAppStreamHandlers,
+  ): Promise<void> => {
+    const token = await getIdToken();
+    const res = await fetch(
+      `${import.meta.env.VITE_APP_TEAM_ACCESS_CONTROL_API_ENDPOINT}/exapps/invoke/stream`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify(request),
+      },
+    );
+
+    if (!res.ok || !res.body) {
+      const text = await res.text();
+      let data: unknown = text;
+      try {
+        data = JSON.parse(text);
+      } catch {
+        // テキストのまま
+      }
+      throw new ApiError(res.status, data);
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder('utf-8');
+    let buffer = '';
+
+    const handleLine = (line: string) => {
+      if (line.trim().length === 0) {
+        return;
+      }
+      let ev: ExAppStreamEvent;
+      try {
+        ev = JSON.parse(line) as ExAppStreamEvent;
+      } catch {
+        return;
+      }
+      if (ev.event === 'delta') {
+        handlers.onDelta(ev.text ?? '');
+      } else if (ev.event === 'done') {
+        handlers.onDone({ outputs: ev.outputs ?? '', artifacts: ev.artifacts });
+      } else if (ev.event === 'error') {
+        handlers.onError(ev.error ?? '', ev.error_code);
+      }
+    };
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      buffer += decoder.decode(value, { stream: true });
+
+      let newlineIndex = buffer.indexOf('\n');
+      while (newlineIndex !== -1) {
+        handleLine(buffer.slice(0, newlineIndex));
+        buffer = buffer.slice(newlineIndex + 1);
+        newlineIndex = buffer.indexOf('\n');
+      }
+    }
+
+    if (buffer.trim().length > 0) {
+      handleLine(buffer);
+    }
+  };
+
   return {
     invokeExApp,
+    invokeExAppStream,
   };
 };

--- a/genai-web/packages/web/src/open-genai/chosei/useChosei.ts
+++ b/genai-web/packages/web/src/open-genai/chosei/useChosei.ts
@@ -48,7 +48,9 @@ export const useChoseiConfig = () => {
     loadError: error
       ? '日程調整の設定取得に失敗しました。時間をおいて再度お試しください。'
       : null,
-    unavailable: data?.enabled === false || (!!data?.error && data.enabled === false),
+    // enabled === false（503 時など）のみを「未起動」。|| 右側で再度 === false すると
+    // TS が左辺失敗後に enabled を true|undefined に絞り TS2367 になる。
+    unavailable: data?.enabled === false,
   };
 };
 

--- a/genai-web/packages/web/tests/features/exapp/components/ExAppChat.test.tsx
+++ b/genai-web/packages/web/tests/features/exapp/components/ExAppChat.test.tsx
@@ -5,7 +5,12 @@ import { ExAppChat } from '../../../../src/features/exapp/components/ExAppChat';
 
 // invoke フックは fetcher に依存するため、描画テストではスタブ化する
 vi.mock('../../../../src/features/exapp/hooks/useInvokeExApp.ts', () => ({
-  useInvokeExApp: () => ({ invokeExApp: vi.fn() }),
+  useInvokeExApp: () => ({ invokeExApp: vi.fn(), invokeExAppStream: vi.fn() }),
+}));
+
+// 過去の会話一覧も fetcher に依存するため、描画テストではスタブ化する
+vi.mock('../../../../src/features/exapp/hooks/useExAppConversations.ts', () => ({
+  useExAppConversations: () => ({ conversations: [], mutate: vi.fn() }),
 }));
 
 describe('ExAppChat file attach button', () => {


### PR DESCRIPTION
## 概要
- Dify チャットフロー連携アプリの応答を、ブロック受信から**ストリーミング（逐次表示）**へ変更しました（`dify-app` → `backend` → フロントを NDJSON で中継）。
- チャット画面に**「過去の会話」一覧**（`GET /exapps/histories` を `sessionId` でグルーピング）を追加し、選択すると `ExAppChat` に会話と `sessionId` を復元して**続きから会話**できます。
- 応答の**コピー**ボタン、生成中の**スピナー維持**など UI/UX を改善しました。
- タイムアウト等で接続が切れても会話が継続できるよう、`conversation_id` を**早期保存**（ストリーム/同期の両経路）しました。

## 主な変更
- `dify-app`: `POST /invoke/stream`（chat のみ NDJSON 中継、`conversation_id` 早期保存）を追加。
- `backend`: `POST /exapps/invoke/stream`（認可・アーティファクト再ホスト・履歴・監査付きプロキシ）を追加。
- フロント: `invokeExAppStream` で逐次描画、`ExAppConversationList` / `useExAppConversations` を追加、`ExAppChat` に一覧・復元・送信後の再取得を実装。
- `chosei` 設定フックの冗長比較（TS2367）を解消し Web ビルドを通す。
- README の Dify 制約説明を更新、ストリーム単体テストを追加。

## セキュリティ / スコープ
- 「過去の会話」一覧は **JWT の userId で絞り込み**、本人の履歴のみ表示（他人の履歴は取得・表示不可）。

## テスト
- `web` 本番イメージ再ビルドで `tsc`（型チェック）＋ `vite build` 成功。
- `ExAppChat` ユニットテスト 3 件パス。
- `dify-app` ストリーム単体テスト追加。

## 動作確認の TODO
- [ ] チャットでストリーミング逐次表示・スピナー・コピーの確認
- [ ] 「過去の会話」を選択して復元・続きの会話ができること
- [ ] タイムアウト後に同一会話が継続できること

Made with [Cursor](https://cursor.com)