### PR TITLE
fix(patchform): cryptography を 50.0.1 に更新し既知脆弱性を解消

### DIFF
--- a/patchform-app/requirements.txt
+++ b/patchform-app/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.139.0
 uvicorn[standard]==0.34.0
 bcrypt==4.2.1
 httpx==0.28.1
-cryptography==44.0.2
+cryptography==50.0.1
 pypdf==6.15.0
 python-docx==1.1.2
 openpyxl==3.1.5


### PR DESCRIPTION
## 概要
pip-audit（Python dependency audit）が `patchform-app/requirements.txt` の `cryptography==44.0.2` に7件の既知脆弱性を検出していたため、全修正版を満たす `50.0.1` へ更新。

## 検出されていた脆弱性
- PYSEC-2026-35 / PYSEC-2026-2141 / PYSEC-2026-3552 / PYSEC-2026-3553 / PYSEC-2026-3554 / GHSA-537c-gmf6-5ccf

## 確認
- `pip-audit -r patchform-app/requirements.txt` → No known vulnerabilities found
- コンテナ再ビルド・起動 OK（cryptography 50.0.1）
- Fernet の暗号化/復号ラウンドトリップ OK

Made with [Cursor](https://cursor.com)