### PR TITLE
fix(web): Difyアプリでフッターを隠しストリーミング中のカクつきを防ぐ

### DIFF
--- a/genai-web/packages/web/src/layout/Layout.tsx
+++ b/genai-web/packages/web/src/layout/Layout.tsx
@@ -5,7 +5,10 @@ import { SideNav } from '@/components/ui/SideNav';
 import { isSidebarNavLayout } from '@/constants/navLayout';
 import { useScrollRestoration } from '@/layout/hooks/useScrollRestoration';
 
-const FOOTER_HIDDEN_PATHS = ['/chat', '/image'];
+// ストリーミングで本文が伸びる画面では、文書末のフッターが
+// 自動スクロール（scrollIntoView）と干渉して表示がカクつく。
+// /apps は Dify 対話など exApp（/apps/:teamId/:exAppId）を含む。
+const FOOTER_HIDDEN_PATHS = ['/chat', '/image', '/apps'];
 
 export const Layout = () => {
   const { pathname } = useLocation();

--- a/genai-web/packages/web/tsconfig.json
+++ b/genai-web/packages/web/tsconfig.json
@@ -20,8 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
 
-    "types": ["vitest/globals"],
-
     "paths": {
       "@/*": ["./src/*", "./tests/*"]
     }


### PR DESCRIPTION
## Summary
- Dify / exApp（`/apps`）でも通常チャットと同様に画面最下部のクレジットを出さない
- 回答ストリーミング中に、文書末のフッターと `scrollIntoView` が干渉してカクついていた
- アプリ用 `tsconfig.json` から、ローカル未インストールでも参照されていた `vitest/globals` を外した

## Test plan
- [ ] `/apps/:teamId/:exAppId` の Dify 対話で、画面最下部にクレジットが出ないこと
- [ ] 長めの回答をストリーミングし、表示がカクつかないこと
- [ ] `/chat`・`/image` でも従来どおりフッター非表示のままであること
- [ ] ランディングなど他画面ではフッターが表示されること


Made with [Cursor](https://cursor.com)