### PR TITLE
fix(web): 未起動の書類読取・フォームをおすすめから外す

### DIFF
--- a/genai-web/packages/web/src/layout/navItems.ts
+++ b/genai-web/packages/web/src/layout/navItems.ts
@@ -2,6 +2,10 @@ import { useMemo } from 'react';
 import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
 import type { PinnedAppItem } from '@/open-genai/app-pins/types';
 import { useImageAvailable } from '@/open-genai/image-health/useImageAvailable';
+import {
+  useDoccheckAvailable,
+  usePatchformAvailable,
+} from '@/open-genai/optional-app-health/useOptionalAppAvailable';
 import { isUseCaseEnabled } from '@/utils/isUseCaseEnabled';
 
 /** Open GENAI の文字起こしは Amazon Transcribe ではなく Whisper exApp */
@@ -69,9 +73,11 @@ export type NavLinkItem = {
   description?: string;
 };
 
-/** おすすめ（組み込みユースケース）リンク。画像は health を見て出し分け。 */
+/** おすすめ（組み込みユースケース）リンク。任意起動アプリは health を見て出し分け。 */
 export const useRecommendedNavItems = (): NavLinkItem[] => {
   const imageAvailable = useImageAvailable();
+  const doccheckAvailable = useDoccheckAvailable();
+  const patchformAvailable = usePatchformAvailable();
 
   return useMemo(() => {
     const items: NavLinkItem[] = [
@@ -130,17 +136,22 @@ export const useRecommendedNavItems = (): NavLinkItem[] => {
       description: '庁内・外部参加者向けの日程調整。専用画面で作成・回答・集計できます。',
     });
 
-    items.push({
-      label: '書類読取とチェック',
-      to: DOCCHECK_PATH,
-      description: '申請書類の領域分割 OCR と分散チェック。専用画面で投入・配信・合意形成できます。',
-    });
+    if (doccheckAvailable) {
+      items.push({
+        label: '書類読取とチェック',
+        to: DOCCHECK_PATH,
+        description:
+          '申請書類の領域分割 OCR と分散チェック。専用画面で投入・配信・合意形成できます。',
+      });
+    }
 
-    items.push({
-      label: 'フォーム',
-      to: PATCHFORM_PATH,
-      description: '庁内・外部向けのオンラインフォーム。専用画面で作成・回答・集計できます。',
-    });
+    if (patchformAvailable) {
+      items.push({
+        label: 'フォーム',
+        to: PATCHFORM_PATH,
+        description: '庁内・外部向けのオンラインフォーム。専用画面で作成・回答・集計できます。',
+      });
+    }
 
     items.push({
       label: 'ナレッジ管理',
@@ -149,7 +160,7 @@ export const useRecommendedNavItems = (): NavLinkItem[] => {
     });
 
     return items;
-  }, [imageAvailable]);
+  }, [imageAvailable, doccheckAvailable, patchformAvailable]);
 };
 
 export const ALL_APPS_NAV_ITEM: NavLinkItem = {

--- a/genai-web/packages/web/src/open-genai/optional-app-health/useOptionalAppAvailable.ts
+++ b/genai-web/packages/web/src/open-genai/optional-app-health/useOptionalAppAvailable.ts
@@ -1,0 +1,34 @@
+import useSWR from 'swr';
+import { ApiError, teamApiFetcher } from '@/lib/fetcher';
+
+type Config = { enabled?: boolean };
+
+const fetchConfigAvailable = async (path: string): Promise<boolean> => {
+  try {
+    const data = await teamApiFetcher<Config>(path);
+    return data.enabled === true;
+  } catch (e) {
+    if (e instanceof ApiError && (e.status === 502 || e.status === 503)) {
+      return false;
+    }
+    return false;
+  }
+};
+
+/**
+ * Compose profile 任意起動アプリが利用可能か。
+ * 未起動（502/503 / enabled=false）は非表示。取得前も出さない（ちらつき防止）。
+ */
+const useOptionalAppAvailable = (path: string): boolean => {
+  const { data } = useSWR<boolean>(path, () => fetchConfigAvailable(path), {
+    suspense: false,
+    revalidateOnFocus: false,
+    refreshInterval: 60_000,
+    shouldRetryOnError: false,
+  });
+  return data === true;
+};
+
+export const useDoccheckAvailable = (): boolean => useOptionalAppAvailable('doccheck/config');
+
+export const usePatchformAvailable = (): boolean => useOptionalAppAvailable('patchform/config');


### PR DESCRIPTION
## Summary
- `doccheck` / `patchform` コンテナが未起動のとき、おすすめとサイドバーから「書類読取とチェック」「フォーム」を出さない
- 画像生成の health 出し分けと同じく、`/doccheck/config` と `/patchform/config` の `enabled` を見る
- 専用ページへ直接行った場合の有効化案内はそのまま

## Test plan
- [ ] 両コンテナ未起動時、トップのおすすめとサイドバーに両カードが出ないこと
- [ ] `docker compose --profile doccheck up -d` 後に再読み込みすると「書類読取とチェック」が出ること
- [ ] `docker compose --profile patchform up -d` 後に再読み込みすると「フォーム」が出ること
- [ ] 日程調整（起動中）はおすすめに残ること


Made with [Cursor](https://cursor.com)