### PR TITLE
feat(llm): Anthropic extra_body と公式モデル表示を追加する

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -62,13 +62,15 @@ TITLE_MODE=heuristic
 # LLM_PROVIDERS=[
 #   {"name":"sakura","base_url":"https://api.ai.sakura.ad.jp/v1","api_key_env":"SAKURA_API_KEY","models":["gpt-oss-120b","preview/gemma-4-31B-it"]},
 #   {"name":"ollama","base_url":"http://host.docker.internal:11434/v1","models":["qwen2.5:7b","gemma3:27b"]},
-#   {"name":"openai","base_url":"https://api.openai.com/v1","api_key_env":"OPENAI_PROVIDER_API_KEY","models":["gpt-4o-mini"]},
-#   {"name":"gemini","base_url":"https://generativelanguage.googleapis.com/v1beta/openai","api_key_env":"GEMINI_API_KEY","models":["gemini-2.5-flash"]},
+#   {"name":"openai","base_url":"https://api.openai.com/v1","api_key_env":"OPENAI_PROVIDER_API_KEY","models":["gpt-4.1"]},
+#   {"name":"anthropic","base_url":"https://api.anthropic.com/v1","api_key_env":"ANTHROPIC_API_KEY","models":["claude-sonnet-4-6"],"extra_body":{"max_tokens":8192}},
+#   {"name":"gemini","base_url":"https://generativelanguage.googleapis.com/v1beta/openai","api_key_env":"GEMINI_API_KEY","models":["gemini-3.6-flash"]},
 #   {"name":"azure","base_url":"https://<resource>.openai.azure.com/openai/deployments/<deployment>","api_key_env":"AZURE_OPENAI_API_KEY","auth_header":"api-key","auth_prefix":"","query":{"api-version":"2024-10-21"},"models":["<deployment>"]}
 # ]
 LLM_PROVIDERS=
 SAKURA_API_KEY=
 OPENAI_PROVIDER_API_KEY=
+ANTHROPIC_API_KEY=
 GEMINI_API_KEY=
 AZURE_OPENAI_API_KEY=
 

--- a/backend/app/llm.py
+++ b/backend/app/llm.py
@@ -47,11 +47,15 @@ class Provider:
     query: dict[str, str] = field(default_factory=dict)
     # 明示モデル一覧（空なら /models を照会）。
     models: list[str] = field(default_factory=list)
+    # 追加ヘッダ / リクエスト本文（Anthropic の max_tokens 等）。
+    extra_headers: dict[str, str] = field(default_factory=dict)
+    extra_body: dict[str, Any] = field(default_factory=dict)
 
     def headers(self) -> dict[str, str]:
         h = {"Content-Type": "application/json"}
         if self.api_key:
             h[self.auth_header] = f"{self.auth_prefix}{self.api_key}"
+        h.update(self.extra_headers)
         return h
 
 
@@ -75,6 +79,10 @@ def _build_providers() -> tuple[list[Provider], dict[str, Provider]]:
                     key = os.environ.get(str(e["api_key_env"])) or None
                 elif e.get("api_key"):
                     key = str(e["api_key"]) or None
+                extra_headers = {
+                    str(k): str(v) for k, v in (e.get("extra_headers") or {}).items()
+                }
+                extra_body = dict(e.get("extra_body") or {})
                 providers.append(
                     Provider(
                         name=str(e.get("name") or e["base_url"]),
@@ -88,6 +96,8 @@ def _build_providers() -> tuple[list[Provider], dict[str, Provider]]:
                         ),
                         query={str(k): str(v) for k, v in (e.get("query") or {}).items()},
                         models=[str(m) for m in (e.get("models") or [])],
+                        extra_headers=extra_headers,
+                        extra_body=extra_body,
                     )
                 )
         except (ValueError, TypeError) as exc:  # noqa: BLE001
@@ -140,6 +150,26 @@ def _provider_for(model_id: str) -> Provider:
     return _MODEL_INDEX.get(model_id, _DEFAULT_PROVIDER)
 
 
+def _chat_payload(
+    provider: Provider,
+    model_id: str,
+    messages: list[dict[str, Any]],
+    *,
+    stream: bool,
+    temperature: float | None = None,
+) -> dict[str, Any]:
+    """chat/completions 用ペイロード。provider.extra_body を後勝ちでマージする。"""
+    payload: dict[str, Any] = {
+        "model": model_id,
+        "messages": messages,
+        "stream": stream,
+    }
+    if temperature is not None:
+        payload["temperature"] = temperature
+    payload.update(provider.extra_body)
+    return payload
+
+
 def _data_url(media_type: str, data: str) -> str:
     """base64(prefix有無どちらでも)を data URL に正規化する。"""
     if data.startswith("data:"):
@@ -165,12 +195,9 @@ async def _complete(
 ) -> str:
     """内部利用の非ストリーム補完（添付の要約/読み計画に使う）。"""
     provider = _provider_for(model_id)
-    payload = {
-        "model": model_id,
-        "messages": messages,
-        "stream": False,
-        "temperature": temperature,
-    }
+    payload = _chat_payload(
+        provider, model_id, messages, stream=False, temperature=temperature
+    )
     async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
         res = await client.post(
             f"{provider.base_url}/chat/completions",
@@ -262,11 +289,7 @@ async def chat_once(
     model_id = _resolve_model(model)
     provider = _provider_for(model_id)
     openai_messages, notes = await _prepare_openai_messages(messages, model)
-    payload = {
-        "model": model_id,
-        "messages": openai_messages,
-        "stream": False,
-    }
+    payload = _chat_payload(provider, model_id, openai_messages, stream=False)
     async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
         res = await client.post(
             f"{provider.base_url}/chat/completions",
@@ -327,11 +350,7 @@ async def chat_stream(
     prefix = _notes_prefix(notes)
     if prefix:
         yield json.dumps({"text": prefix}, ensure_ascii=False) + "\n"
-    payload = {
-        "model": model_id,
-        "messages": openai_messages,
-        "stream": True,
-    }
+    payload = _chat_payload(provider, model_id, openai_messages, stream=True)
     try:
         async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
             async with client.stream(

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -58,6 +58,7 @@ services:
       # LLM_PROVIDERS の api_key_env から参照されるプロバイダ別キー
       - SAKURA_API_KEY=${SAKURA_API_KEY:-}
       - OPENAI_PROVIDER_API_KEY=${OPENAI_PROVIDER_API_KEY:-}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - AZURE_OPENAI_API_KEY=${AZURE_OPENAI_API_KEY:-}
       # Ollama Cloud 等を LLM_PROVIDERS の api_key_env=OLLAMA_API_KEY で使う場合に受け渡す
@@ -200,6 +201,7 @@ services:
         # 画像生成の初期 step/cfg（既定 50/7。FastSD/LCM を使うビルドでは 4/1 を指定）
         VITE_APP_IMAGE_DEFAULT_STEP: ${VITE_APP_IMAGE_DEFAULT_STEP:-50}
         VITE_APP_IMAGE_DEFAULT_CFG: ${VITE_APP_IMAGE_DEFAULT_CFG:-7}
+        VITE_APP_MODEL_IDS: ${VITE_APP_MODEL_IDS:-}
     container_name: open-genai-web
     expose:
       - "80"

--- a/genai-web/Dockerfile.prod
+++ b/genai-web/Dockerfile.prod
@@ -20,11 +20,18 @@ ARG VITE_APP_NAV_LAYOUT=header
 # 画像生成の初期 step/cfg（既定 50/7。CPU-only の FastSD/LCM 向けは 4/1 を指定）
 ARG VITE_APP_IMAGE_DEFAULT_STEP=50
 ARG VITE_APP_IMAGE_DEFAULT_CFG=7
+ARG VITE_APP_MODEL_IDS
 ENV VITE_APP_API_ENDPOINT=${VITE_APP_API_ENDPOINT} \
     VITE_APP_TEAM_ACCESS_CONTROL_API_ENDPOINT=${VITE_APP_TEAM_ACCESS_CONTROL_API_ENDPOINT} \
     VITE_APP_NAV_LAYOUT=${VITE_APP_NAV_LAYOUT} \
     VITE_APP_IMAGE_DEFAULT_STEP=${VITE_APP_IMAGE_DEFAULT_STEP} \
     VITE_APP_IMAGE_DEFAULT_CFG=${VITE_APP_IMAGE_DEFAULT_CFG}
+# compose から渡されたモデル一覧があれば .env を上書き（空なら packages/web/.env のまま）
+RUN if [ -n "$VITE_APP_MODEL_IDS" ]; then \
+      grep -v '^VITE_APP_MODEL_IDS=' packages/web/.env > packages/web/.env.tmp && \
+      mv packages/web/.env.tmp packages/web/.env && \
+      printf '%s\n' "VITE_APP_MODEL_IDS=${VITE_APP_MODEL_IDS}" >> packages/web/.env; \
+    fi
 
 RUN npm run web:build
 

--- a/genai-web/packages/common/src/application/model.ts
+++ b/genai-web/packages/common/src/application/model.ts
@@ -513,6 +513,10 @@ export const modelMetadata: Record<string, ModelMetadata> = {
 
   // ==== Open GENAI: 他の OpenAI 互換プロバイダ（LLM_PROVIDERS で併用）====
   // OpenAI
+  'gpt-4.1': {
+    flags: MODEL_FEATURE.TEXT_DOC_IMAGE,
+    displayName: 'GPT-4.1（OpenAI）',
+  },
   'gpt-4o': {
     flags: MODEL_FEATURE.TEXT_DOC_IMAGE,
     displayName: 'GPT-4o（OpenAI）',
@@ -521,7 +525,16 @@ export const modelMetadata: Record<string, ModelMetadata> = {
     flags: { ...MODEL_FEATURE.TEXT_DOC_IMAGE, ...MODEL_FEATURE.LIGHT },
     displayName: 'GPT-4o mini（OpenAI）',
   },
+  // Anthropic（OpenAI 互換エンドポイント）
+  'claude-sonnet-4-6': {
+    flags: MODEL_FEATURE.TEXT_DOC_IMAGE_REASONING,
+    displayName: 'Claude Sonnet 4.6（Anthropic）',
+  },
   // Google Gemini（OpenAI 互換エンドポイント）
+  'gemini-3.6-flash': {
+    flags: MODEL_FEATURE.TEXT_DOC_IMAGE,
+    displayName: 'Gemini 3.6 Flash（Google）',
+  },
   'gemini-2.5-flash': {
     flags: MODEL_FEATURE.TEXT_DOC_IMAGE,
     displayName: 'Gemini 2.5 Flash（Google）',
@@ -530,8 +543,8 @@ export const modelMetadata: Record<string, ModelMetadata> = {
     flags: MODEL_FEATURE.TEXT_DOC_IMAGE,
     displayName: 'Gemini 2.5 Pro（Google）',
   },
-  // Azure OpenAI（modelId はデプロイ名に一致させる）
-  'gpt-4.1': {
+  // Azure OpenAI（modelId はデプロイ名に一致させる。公式 GPT-4.1 と衝突しないよう別名）
+  'gpt-4.1-azure': {
     flags: MODEL_FEATURE.TEXT_DOC_IMAGE,
     displayName: 'GPT-4.1（Azure）',
   },


### PR DESCRIPTION
## Summary
- `LLM_PROVIDERS` に `extra_headers` / `extra_body` を足し、Anthropic の `max_tokens` を送れるようにする
- compose に `ANTHROPIC_API_KEY`、web ビルドに `VITE_APP_MODEL_IDS` を渡す
- 画面メタデータに GPT-4.1 / Claude Sonnet 4.6 / Gemini 3.6 Flash を追加（Azure の GPT-4.1 は `gpt-4.1-azure`）
- `.env.prod.example` の例を更新（キー本体は含まない）

## Test plan
- [ ] `LLM_PROVIDERS` に openai / anthropic / gemini を入れ、チャットのモデル一覧に3つ出ること
- [ ] Claude Sonnet 4.6 で短いメッセージが返ること（`max_tokens` 不足で落ちないこと）
- [ ] GPT-4.1 と Gemini 3.6 Flash でも応答できること
- [ ] `.env.prod` など秘密ファイルが差分に含まれていないこと


Made with [Cursor](https://cursor.com)