### PR TITLE
feat(llm): Qwen 思考オフ・reasoning 読取・構造化出力を汎用化

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -66,4 +66,5 @@ jobs:
             tests/utils/ensureImagePersistTarget.test.ts \
             tests/utils/copyToClipboard.test.ts \
             tests/utils/toAbsoluteUrl.test.ts \
-            tests/features/chat/ChatPage.test.tsx
+            tests/features/chat/ChatPage.test.tsx \
+            tests/features/generate-image/utils/parseAssistantImageContent.test.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 
 - プロンプトテンプレートの「チャットで開く」で入力欄が空になる不具合を修正
 - HTTP/LAN 環境（非セキュアオリジン）向けに UUID 生成とクリップボードコピーのフォールバックを共通化
+- ナレッジ検索・日程調整の回答生成で Qwen 思考モードをオフ（`RAG_EXTRA_BODY` / `CHOSEI_EXTRA_BODY`。空なら `enable_thinking: false`）
+- チャット／RAG／日程調整で `content` が空のとき `reasoning` / `reasoning_content` を本文として読む
+- 画像プロンプトと日程候補を JSON Schema で固定（思考文や会話文で画面が壊れる問題）
 
 ## [0.8.0] - 2026-08-30
 

--- a/backend/app/llm.py
+++ b/backend/app/llm.py
@@ -136,7 +136,12 @@ for _p in _PROVIDERS:
 
 def _resolve_model(model: dict[str, Any] | None) -> str:
     if model and model.get("modelId"):
-        return str(model["modelId"])
+        mid = str(model["modelId"])
+        # フロントに残った旧 modelId は、登録済みならそれを、未登録なら既定へ。
+        if mid in _MODEL_INDEX or not _MODEL_INDEX:
+            return mid
+        print(f"[llm] 未登録モデル '{mid}' → 既定 '{DEFAULT_MODEL}'")
+        return DEFAULT_MODEL
     return DEFAULT_MODEL
 
 
@@ -150,6 +155,71 @@ def _provider_for(model_id: str) -> Provider:
     return _MODEL_INDEX.get(model_id, _DEFAULT_PROVIDER)
 
 
+# 画像生成アシスタントは JSON のみを期待する。Qwen が会話文を返すと UI が落ちる。
+IMAGE_PROMPT_JSON_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "prompt": {"type": "string"},
+        "negativePrompt": {"type": "string"},
+        "comment": {"type": "string"},
+        "recommendedStylePreset": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+    },
+    "required": [
+        "prompt",
+        "negativePrompt",
+        "comment",
+        "recommendedStylePreset",
+    ],
+}
+
+
+def _content_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict):
+                parts.append(str(part.get("text") or ""))
+            else:
+                parts.append(str(part))
+        return " ".join(parts)
+    return str(content or "")
+
+
+def _is_image_prompt_task(
+    messages: list[dict[str, Any]], request_id: str | None = None
+) -> bool:
+    rid = (request_id or "").split("?")[0]
+    if rid == "/image" or rid.startswith("/image/"):
+        return True
+    for message in messages:
+        if message.get("role") != "system":
+            continue
+        text = _content_text(message.get("content"))
+        if "Stable Diffusionのプロンプト" in text:
+            return True
+        if "recommendedStylePreset" in text and "negativePrompt" in text:
+            return True
+    return False
+
+
+def _image_prompt_extra_body() -> dict[str, Any]:
+    return {
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "sd_image_prompt",
+                "schema": IMAGE_PROMPT_JSON_SCHEMA,
+            },
+        }
+    }
+
+
 def _chat_payload(
     provider: Provider,
     model_id: str,
@@ -157,6 +227,7 @@ def _chat_payload(
     *,
     stream: bool,
     temperature: float | None = None,
+    extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """chat/completions 用ペイロード。provider.extra_body を後勝ちでマージする。"""
     payload: dict[str, Any] = {
@@ -167,6 +238,8 @@ def _chat_payload(
     if temperature is not None:
         payload["temperature"] = temperature
     payload.update(provider.extra_body)
+    if extra:
+        payload.update(extra)
     return payload
 
 
@@ -208,7 +281,13 @@ async def _complete(
         res.raise_for_status()
         data = res.json()
     choices = data.get("choices") or [{}]
-    return (choices[0].get("message") or {}).get("content", "") or ""
+    message = choices[0].get("message") or {}
+    return (
+        message.get("content")
+        or message.get("reasoning_content")
+        or message.get("reasoning")
+        or ""
+    )
 
 
 def _extract_doc_texts_full(message: dict[str, Any]) -> list[tuple[str, str]]:
@@ -283,13 +362,23 @@ def _notes_prefix(notes: list[str]) -> str:
 
 
 async def chat_once(
-    messages: list[dict[str, Any]], model: dict[str, Any] | None
+    messages: list[dict[str, Any]],
+    model: dict[str, Any] | None,
+    *,
+    request_id: str | None = None,
 ) -> str:
     """ストリームなしでチャット補完を取得する。"""
     model_id = _resolve_model(model)
     provider = _provider_for(model_id)
     openai_messages, notes = await _prepare_openai_messages(messages, model)
-    payload = _chat_payload(provider, model_id, openai_messages, stream=False)
+    extra = (
+        _image_prompt_extra_body()
+        if _is_image_prompt_task(messages, request_id)
+        else None
+    )
+    payload = _chat_payload(
+        provider, model_id, openai_messages, stream=False, extra=extra
+    )
     async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
         res = await client.post(
             f"{provider.base_url}/chat/completions",
@@ -300,12 +389,21 @@ async def chat_once(
         res.raise_for_status()
         data = res.json()
     choices = data.get("choices") or [{}]
-    answer = (choices[0].get("message") or {}).get("content", "") or ""
+    message = choices[0].get("message") or {}
+    answer = (
+        message.get("content")
+        or message.get("reasoning_content")
+        or message.get("reasoning")
+        or ""
+    )
     return _notes_prefix(notes) + answer
 
 
 async def chat_stream(
-    messages: list[dict[str, Any]], model: dict[str, Any] | None
+    messages: list[dict[str, Any]],
+    model: dict[str, Any] | None,
+    *,
+    request_id: str | None = None,
 ) -> AsyncIterator[str]:
     """源内 Web 互換の改行区切り JSON (StreamingChunk) を yield する。
 
@@ -350,7 +448,14 @@ async def chat_stream(
     prefix = _notes_prefix(notes)
     if prefix:
         yield json.dumps({"text": prefix}, ensure_ascii=False) + "\n"
-    payload = _chat_payload(provider, model_id, openai_messages, stream=True)
+    extra = (
+        _image_prompt_extra_body()
+        if _is_image_prompt_task(messages, request_id)
+        else None
+    )
+    payload = _chat_payload(
+        provider, model_id, openai_messages, stream=True, extra=extra
+    )
     try:
         async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
             async with client.stream(
@@ -382,7 +487,13 @@ async def chat_stream(
                         continue
                     choice = (chunk.get("choices") or [{}])[0]
                     delta = choice.get("delta") or {}
-                    text = delta.get("content") or ""
+                    # vLLM reasoning は content が null で reasoning / reasoning_content に載る
+                    text = (
+                        delta.get("content")
+                        or delta.get("reasoning_content")
+                        or delta.get("reasoning")
+                        or ""
+                    )
                     if text:
                         yield json.dumps({"text": text}, ensure_ascii=False) + "\n"
                     if choice.get("finish_reason"):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1457,7 +1457,9 @@ async def predict(request: Request) -> Response:
     ng = _ngword_denied(request, _last_user_text(messages))
     if ng:
         return JSONResponse(status_code=403, content={"error": ng})
-    text = await llm.chat_once(messages, body.get("model"))
+    text = await llm.chat_once(
+        messages, body.get("model"), request_id=body.get("id")
+    )
     return JSONResponse(content=text)
 
 
@@ -1600,7 +1602,7 @@ async def predict_stream(request: Request) -> StreamingResponse:
 
         return StreamingResponse(_blocked(), media_type="application/x-ndjson")
 
-    generator = llm.chat_stream(messages, model)
+    generator = llm.chat_stream(messages, model, request_id=body.get("id"))
     # 監査ログ（内容ログ）: 入力（最終ユーザー発話）と集約した出力を1件記録
     audited = audit.wrap_stream(
         generator,

--- a/chosei-app/app/assist.py
+++ b/chosei-app/app/assist.py
@@ -191,6 +191,7 @@ async def parse_dates_from_text(text: str, *, now: datetime | None = None) -> di
                 '"is_all_day":false,"label":"8/14 12:00"}],"notes":""}。'
                 "タイムゾーンは必ず +09:00。"
                 "候補は最大14件まで。平日連続などは必要な日だけ列挙し、冗長な説明は notes に書かない。"
+                "「午後」は 13:00〜18:00、「午前」は 9:00〜12:00 を目安にし、その範囲だけ出す。深夜まで伸ばさない。"
                 "終日なら is_all_day=true、start_time はその日 00:00:00+09:00、end_time は null。"
                 "必ず完全な JSON で閉じること。"
             ),
@@ -203,7 +204,46 @@ async def parse_dates_from_text(text: str, *, now: datetime | None = None) -> di
             ),
         },
     ]
-    raw = await llm.chat(messages, temperature=0.1, max_tokens=4096)
+    raw = await llm.chat(
+        messages,
+        temperature=0.1,
+        max_tokens=4096,
+        extra={
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "chosei_dates",
+                    "schema": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            "dates": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": False,
+                                    "properties": {
+                                        "start_time": {"type": "string"},
+                                        "end_time": {"type": ["string", "null"]},
+                                        "is_all_day": {"type": "boolean"},
+                                        "label": {"type": "string"},
+                                    },
+                                    "required": [
+                                        "start_time",
+                                        "end_time",
+                                        "is_all_day",
+                                        "label",
+                                    ],
+                                },
+                            },
+                            "notes": {"type": "string"},
+                        },
+                        "required": ["dates", "notes"],
+                    },
+                },
+            }
+        },
+    )
     data = llm.extract_json(raw)
     if not isinstance(data, dict):
         raise ValueError("モデル応答の形式が不正です")

--- a/chosei-app/app/llm.py
+++ b/chosei-app/app/llm.py
@@ -28,12 +28,37 @@ def _headers() -> dict[str, str]:
     }
 
 
+def _extra_body() -> dict[str, Any]:
+    """Qwen3.x は既定で思考モードになり、content が空のまま数分待たされる。"""
+    raw = (os.environ.get("CHOSEI_EXTRA_BODY") or "").strip()
+    if raw:
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            print(f"[chosei] CHOSEI_EXTRA_BODY が不正な JSON です: {raw[:80]}")
+    return {"chat_template_kwargs": {"enable_thinking": False}}
+
+
+def _message_text(message: dict[str, Any]) -> str:
+    content = message.get("content")
+    if isinstance(content, str) and content.strip():
+        return content.strip()
+    for key in ("reasoning_content", "reasoning"):
+        value = message.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return content.strip() if isinstance(content, str) else ""
+
+
 async def chat(
     messages: list[dict[str, str]],
     *,
     temperature: float = 0.2,
     model: str | None = None,
     max_tokens: int | None = None,
+    extra: dict[str, Any] | None = None,
 ) -> str:
     payload: dict[str, Any] = {
         "model": model or CHOSEI_MODEL,
@@ -42,6 +67,9 @@ async def chat(
         "temperature": temperature,
         "max_tokens": max_tokens if max_tokens is not None else DEFAULT_MAX_TOKENS,
     }
+    payload.update(_extra_body())
+    if extra:
+        payload.update(extra)
     async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
         res = await client.post(
             f"{OPENAI_BASE_URL}/chat/completions",
@@ -51,7 +79,10 @@ async def chat(
         res.raise_for_status()
         data = res.json()
     choices = data.get("choices") or [{}]
-    return ((choices[0].get("message") or {}).get("content") or "").strip()
+    text = _message_text(choices[0].get("message") or {})
+    if not text:
+        raise ValueError("モデルの本文が空です")
+    return text
 
 
 def _strip_fences(raw: str) -> str:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -262,6 +262,8 @@ services:
       - "EMBED_QUERY_PREFIX=${EMBED_QUERY_PREFIX-Represent this sentence for searching relevant passages: }"
       - "EMBED_DOC_PREFIX=${EMBED_DOC_PREFIX-}"
       - RAG_MODEL=${RAG_MODEL:-gpt-oss:20b}
+      # 通常チャットと同じ思考オフ。空なら rag-app 既定 (enable_thinking:false)
+      - RAG_EXTRA_BODY=${RAG_EXTRA_BODY:-}
       - RAG_API_KEY=${RAG_API_KEY:-local-rag-key}
       # 起動時のサンプル自動投入。false で無効（本番でサンプル不要なら false）。
       - RAG_SEED_SAMPLES=${RAG_SEED_SAMPLES:-true}
@@ -400,6 +402,8 @@ services:
       - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-ollama}
       - CHOSEI_MODEL=${CHOSEI_MODEL:-${DEFAULT_MODEL:-qwen2.5:7b}}
+      # 通常チャットと同じ思考オフ。空なら chosei-app 既定 (enable_thinking:false)
+      - CHOSEI_EXTRA_BODY=${CHOSEI_EXTRA_BODY:-}
     volumes:
       - chosei_app_data:/data
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-ollama}
       - DEFAULT_MODEL=${DEFAULT_MODEL:-qwen2.5:7b}
+      - LLM_PROVIDERS=${LLM_PROVIDERS:-}
       - DB_PATH=/data/open-genai.db
       # --- 監査ログ（8-(1)）/ チャット履歴ユーザー別分離（6-(8)）---
       - AUDIT_ENABLED=${AUDIT_ENABLED:-true}
@@ -178,8 +179,15 @@ services:
       - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-ollama}
       - QDRANT_URL=http://qdrant:6333
+      - QDRANT_COLLECTION=${QDRANT_COLLECTION:-open_genai_rag}
       - EMBED_MODEL=${EMBED_MODEL:-mxbai-embed-large}
+      - EMBED_DIM=${EMBED_DIM:-1024}
+      - EMBED_BASE_URL=${EMBED_BASE_URL:-}
+      - EMBED_API_KEY=${EMBED_API_KEY:-}
+      - "EMBED_QUERY_PREFIX=${EMBED_QUERY_PREFIX-Represent this sentence for searching relevant passages: }"
+      - "EMBED_DOC_PREFIX=${EMBED_DOC_PREFIX-}"
       - RAG_MODEL=${RAG_MODEL:-gpt-oss:20b}
+      - RAG_EXTRA_BODY=${RAG_EXTRA_BODY:-}
       - RAG_API_KEY=${RAG_API_KEY:-local-rag-key}
       # 内部サービス間署名の共有鍵（backend と同一値。x-user-*/x-scope 偽装対策）
       - INTERNAL_SIGNING_SECRET=${INTERNAL_SIGNING_SECRET:-dev-internal-secret-change-me}
@@ -408,6 +416,7 @@ services:
       - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-ollama}
       - CHOSEI_MODEL=${CHOSEI_MODEL:-${DEFAULT_MODEL:-qwen2.5:7b}}
+      - CHOSEI_EXTRA_BODY=${CHOSEI_EXTRA_BODY:-}
     volumes:
       - chosei_app_data:/data
     ports:

--- a/genai-web/packages/web/src/features/generate-image/components/GenerateImageAssistant.tsx
+++ b/genai-web/packages/web/src/features/generate-image/components/GenerateImageAssistant.tsx
@@ -5,6 +5,7 @@ import { Disclosure, DisclosureSummary } from '@/components/ui/dads/Disclosure';
 import { ProgressIndicator } from '@/components/ui/dads/ProgressIndicator';
 import { Ul } from '@/components/ui/dads/Ul';
 import { useGenerateImageStore } from '@/features/generate-image/stores/useGenerateImageStore';
+import { resolveAssistantImageContent } from '@/features/generate-image/utils/parseAssistantImageContent';
 import { useChat } from '@/hooks/useChat';
 import { useUsecasePath } from '@/hooks/useUsecasePath';
 import { useFollow } from '@/hooks/useFollow';
@@ -14,31 +15,6 @@ import { useScreen } from '@/hooks/useScreen';
 type Props = {
   isGeneratingImage: boolean;
   onGenerate: (prompt: string, negativePrompt: string, stylePreset?: string) => Promise<void>;
-};
-
-type AssistantImageContent = {
-  prompt: string | null;
-  negativePrompt: string | null;
-  comment: string;
-  recommendedStylePreset: string[];
-  error?: boolean;
-};
-
-const parseAssistantImageContent = (content: string): AssistantImageContent => {
-  const fenced = content.match(/```(?:json)?\s*([\s\S]*?)```/i);
-  const candidate = (fenced ? fenced[1] : content).trim();
-  const start = candidate.indexOf('{');
-  const end = candidate.lastIndexOf('}');
-  if (start < 0 || end <= start) {
-    throw new Error('JSON not found');
-  }
-  const parsed = JSON.parse(candidate.slice(start, end + 1)) as Partial<AssistantImageContent>;
-  return {
-    prompt: parsed.prompt ?? null,
-    negativePrompt: parsed.negativePrompt ?? null,
-    comment: parsed.comment ?? '',
-    recommendedStylePreset: parsed.recommendedStylePreset ?? [],
-  };
 };
 
 export const GenerateImageAssistant = (props: Props) => {
@@ -92,9 +68,10 @@ export const GenerateImageAssistant = (props: Props) => {
         };
       }
       try {
+        const prevUser = [...messages.slice(0, idx)].reverse().find((x) => x.role === 'user');
         return {
           role: 'assistant',
-          content: parseAssistantImageContent(m.content),
+          content: resolveAssistantImageContent(m.content, prevUser?.content ?? ''),
         };
       } catch (e) {
         console.error(e);

--- a/genai-web/packages/web/src/features/generate-image/utils/parseAssistantImageContent.ts
+++ b/genai-web/packages/web/src/features/generate-image/utils/parseAssistantImageContent.ts
@@ -1,0 +1,80 @@
+export type AssistantImageContent = {
+  prompt: string | null;
+  negativePrompt: string | null;
+  comment: string;
+  recommendedStylePreset: string[];
+  error?: boolean;
+};
+
+const DEFAULT_NEGATIVE_PROMPT =
+  'worst quality, low quality, blurry, deformed, text, watermark';
+
+const asString = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value == null) {
+    return null;
+  }
+  return String(value);
+};
+
+const asStringArray = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return [value.trim()];
+  }
+  return [];
+};
+
+export const parseAssistantImageContent = (content: string): AssistantImageContent => {
+  const fenced = content.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidate = (fenced ? fenced[1] : content).trim();
+  const start = candidate.indexOf('{');
+  const end = candidate.lastIndexOf('}');
+  if (start < 0 || end <= start) {
+    throw new Error('JSON not found');
+  }
+  const parsed = JSON.parse(candidate.slice(start, end + 1)) as Record<string, unknown>;
+  return {
+    prompt: asString(parsed.prompt),
+    negativePrompt: asString(parsed.negativePrompt),
+    comment: asString(parsed.comment) ?? '',
+    recommendedStylePreset: asStringArray(parsed.recommendedStylePreset),
+  };
+};
+
+/** LLM が会話文を返したときでも画像生成を止めない。 */
+export const fallbackAssistantImageContent = (userText: string): AssistantImageContent => {
+  const subject = userText.trim();
+  const prompt = subject
+    ? `${subject}, photorealistic, high quality, natural light`
+    : 'photorealistic, high quality, natural light';
+  return {
+    prompt,
+    negativePrompt: DEFAULT_NEGATIVE_PROMPT,
+    comment:
+      '画像を生成しました。続けて会話することで、画像を理想に近づけていくことができます。以下が改善案です。\n1. 被写体の表情や動作をより具体的に指定してみてください。\n2. 時間帯や天候を指定してみてください。\n3. 構図（寄り／引き）を指定してみてください。',
+    recommendedStylePreset: ['photographic', 'cinematic', 'analog-film'],
+  };
+};
+
+export const resolveAssistantImageContent = (
+  content: string,
+  userText: string,
+): AssistantImageContent => {
+  try {
+    const parsed = parseAssistantImageContent(content);
+    if (!parsed.prompt) {
+      return fallbackAssistantImageContent(userText);
+    }
+    return {
+      ...parsed,
+      negativePrompt: parsed.negativePrompt ?? DEFAULT_NEGATIVE_PROMPT,
+    };
+  } catch {
+    return fallbackAssistantImageContent(userText);
+  }
+};

--- a/genai-web/packages/web/tests/features/generate-image/utils/parseAssistantImageContent.test.ts
+++ b/genai-web/packages/web/tests/features/generate-image/utils/parseAssistantImageContent.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fallbackAssistantImageContent,
+  parseAssistantImageContent,
+  resolveAssistantImageContent,
+} from '../../../../src/features/generate-image/utils/parseAssistantImageContent';
+
+describe('parseAssistantImageContent', () => {
+  it('JSON をそのまま読む', () => {
+    const parsed = parseAssistantImageContent(
+      JSON.stringify({
+        prompt: 'shiba inu, grassy field',
+        negativePrompt: 'blurry',
+        comment: 'ok',
+        recommendedStylePreset: ['photographic'],
+      }),
+    );
+    expect(parsed.prompt).toBe('shiba inu, grassy field');
+    expect(parsed.recommendedStylePreset).toEqual(['photographic']);
+  });
+
+  it('会話文に埋もれた JSON と string の preset を許容する', () => {
+    const parsed = parseAssistantImageContent(
+      'はい、どうぞ\n```json\n{"prompt":"a","negativePrompt":"b","comment":"c","recommendedStylePreset":"photographic"}\n```',
+    );
+    expect(parsed.prompt).toBe('a');
+    expect(parsed.recommendedStylePreset).toEqual(['photographic']);
+  });
+
+  it('JSON が無いと例外', () => {
+    expect(() => parseAssistantImageContent('柴犬が草原で走っています')).toThrow('JSON not found');
+  });
+});
+
+describe('resolveAssistantImageContent', () => {
+  it('会話文ならユーザー入力からフォールバックする', () => {
+    const resolved = resolveAssistantImageContent(
+      '柴犬が広々とした草原で元気よく走り回っている様子は、とても癒やされますね！',
+      '柴犬が草原で楽しそうに走り回っている',
+    );
+    expect(resolved.prompt).toContain('柴犬が草原で楽しそうに走り回っている');
+    expect(resolved.negativePrompt).toContain('blurry');
+    expect(resolved.recommendedStylePreset).toContain('photographic');
+  });
+
+  it('空プロンプトもフォールバックする', () => {
+    const resolved = resolveAssistantImageContent(
+      '{"prompt":"","negativePrompt":"x","comment":"","recommendedStylePreset":[]}',
+      '猫',
+    );
+    expect(resolved.prompt).toContain('猫');
+  });
+});
+
+describe('fallbackAssistantImageContent', () => {
+  it('ユーザー文が空でも品質語だけ返す', () => {
+    const fallback = fallbackAssistantImageContent('   ');
+    expect(fallback.prompt).toBe('photorealistic, high quality, natural light');
+  });
+});

--- a/rag-app/app/embeddings.py
+++ b/rag-app/app/embeddings.py
@@ -23,6 +23,39 @@ EMBED_BASE_URL = (os.environ.get("EMBED_BASE_URL") or OPENAI_BASE_URL).rstrip("/
 EMBED_API_KEY = os.environ.get("EMBED_API_KEY") or OPENAI_API_KEY
 EMBED_MODEL = os.environ.get("EMBED_MODEL", "mxbai-embed-large")
 RAG_MODEL = os.environ.get("RAG_MODEL", "gpt-oss:20b")
+# Qwen3.x は既定で思考モードになり、content が空のまま数分待たされる。
+# 通常チャット (LLM_PROVIDERS.extra_body) と同じく、既定は思考オフ。
+# 上書き例: RAG_EXTRA_BODY={"chat_template_kwargs":{"enable_thinking":true}}
+def _rag_extra_body() -> dict[str, Any]:
+    raw = (os.environ.get("RAG_EXTRA_BODY") or "").strip()
+    if raw:
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            print(f"[rag-app] RAG_EXTRA_BODY が不正な JSON です: {raw[:80]}")
+    return {"chat_template_kwargs": {"enable_thinking": False}}
+
+
+def _message_text(message: dict[str, Any]) -> str:
+    content = message.get("content")
+    if isinstance(content, str) and content.strip():
+        return content
+    reasoning = message.get("reasoning_content")
+    if isinstance(reasoning, str):
+        return reasoning
+    return content if isinstance(content, str) else ""
+
+
+def _chat_payload(messages: list[dict[str, Any]], *, stream: bool) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "model": RAG_MODEL,
+        "messages": messages,
+        "stream": stream,
+    }
+    payload.update(_rag_extra_body())
+    return payload
 
 # 検索クエリ / 文書に付ける prefix はモデル依存（本プロジェクトは任意の埋め込みモデルを
 # 差し替え可能）。既定は現行 mxbai-embed-large 互換（クエリのみ英語 prefix・文書は無し）で、
@@ -66,13 +99,13 @@ async def generate(messages: list[dict[str, Any]]) -> str:
     async with httpx.AsyncClient(timeout=600) as client:
         res = await client.post(
             f"{OPENAI_BASE_URL}/chat/completions",
-            json={"model": RAG_MODEL, "messages": messages, "stream": False},
+            json=_chat_payload(messages, stream=False),
             headers=_headers(),
         )
         res.raise_for_status()
         data = res.json()
     choices = data.get("choices") or [{}]
-    return (choices[0].get("message") or {}).get("content", "") or ""
+    return _message_text((choices[0].get("message") or {}))
 
 
 async def generate_stream(messages: list[dict[str, Any]]) -> AsyncIterator[str]:
@@ -80,7 +113,7 @@ async def generate_stream(messages: list[dict[str, Any]]) -> AsyncIterator[str]:
         async with client.stream(
             "POST",
             f"{OPENAI_BASE_URL}/chat/completions",
-            json={"model": RAG_MODEL, "messages": messages, "stream": True},
+            json=_chat_payload(messages, stream=True),
             headers=_headers(),
         ) as res:
             res.raise_for_status()

--- a/scripts/run-regression-tests.sh
+++ b/scripts/run-regression-tests.sh
@@ -31,6 +31,7 @@ WEB_TEST_TARGETS=(
   tests/utils/copyToClipboard.test.ts
   tests/utils/toAbsoluteUrl.test.ts
   tests/features/chat/ChatPage.test.tsx
+  tests/features/generate-image/utils/parseAssistantImageContent.test.ts
 )
 
 while [ $# -gt 0 ]; do

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import importlib.util
+import itertools
 import sys
+import types
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -16,19 +18,37 @@ for path in (ROOT, SHARED, BACKEND):
     if text not in sys.path:
         sys.path.insert(0, text)
 
+_LOAD_SEQ = itertools.count()
+
 
 def load_service_module(relative_path: str):
-    """サービス配下の app/*.py を import パス衝突なく読み込む。"""
+    """サービス配下の app/*.py を import パス衝突なく読み込む。
+
+    `from .sibling import ...` のような相対 import も、一時パッケージとして
+    解決する。呼び出しごとに一意なパッケージ名を使うため、環境変数を
+    差し替えて再読込するテストも干渉しない。
+    """
     path = ROOT / relative_path
     # 同一ディレクトリの兄弟モジュール（例: rag-app/app/textnorm.py）を
     # パッケージなしのフォールバック import で解決できるようにする。
     parent = str(path.parent)
     if parent not in sys.path:
         sys.path.insert(0, parent)
-    module_name = f"testmod_{path.parent.parent.name.replace('-', '_')}_{path.stem}"
+
+    seq = next(_LOAD_SEQ)
+    pkg_name = f"testmod_{path.parent.parent.name.replace('-', '_')}_{seq}"
+    module_name = f"{pkg_name}.{path.stem}"
+
+    pkg = types.ModuleType(pkg_name)
+    pkg.__path__ = [parent]
+    pkg.__package__ = pkg_name
+    sys.modules[pkg_name] = pkg
+
     spec = importlib.util.spec_from_file_location(module_name, path)
     if spec is None or spec.loader is None:
         raise ImportError(f"cannot load module from {path}")
     module = importlib.util.module_from_spec(spec)
+    module.__package__ = pkg_name
+    sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module

--- a/tests/test_chosei_llm.py
+++ b/tests/test_chosei_llm.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+
+from conftest import load_service_module
+
+
+def test_chosei_extra_body_defaults_to_thinking_off(monkeypatch) -> None:
+    monkeypatch.delenv("CHOSEI_EXTRA_BODY", raising=False)
+    llm = load_service_module("chosei-app/app/llm.py")
+    assert llm._extra_body() == {"chat_template_kwargs": {"enable_thinking": False}}
+
+
+def test_chosei_extra_body_from_env(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "CHOSEI_EXTRA_BODY",
+        json.dumps({"chat_template_kwargs": {"enable_thinking": True}}),
+    )
+    llm = load_service_module("chosei-app/app/llm.py")
+    assert llm._extra_body()["chat_template_kwargs"]["enable_thinking"] is True
+
+
+def test_chosei_message_text_prefers_content() -> None:
+    llm = load_service_module("chosei-app/app/llm.py")
+    assert llm._message_text({"content": "ok", "reasoning_content": "think"}) == "ok"
+    assert llm._message_text({"content": "", "reasoning_content": "think"}) == "think"

--- a/tests/test_llm_image_prompt.py
+++ b/tests/test_llm_image_prompt.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from conftest import load_service_module
+
+
+def test_is_image_prompt_task_by_request_id() -> None:
+    llm = load_service_module("backend/app/llm.py")
+    assert llm._is_image_prompt_task([], "/image") is True
+    assert llm._is_image_prompt_task([], "/image/abc") is True
+    assert llm._is_image_prompt_task([], "/chat") is False
+
+
+def test_is_image_prompt_task_by_system_prompt() -> None:
+    llm = load_service_module("backend/app/llm.py")
+    messages = [
+        {
+            "role": "system",
+            "content": "あなたはStable Diffusionのプロンプトを生成するAIアシスタントです。",
+        }
+    ]
+    assert llm._is_image_prompt_task(messages) is True
+    assert llm._is_image_prompt_task([{"role": "user", "content": "柴犬"}]) is False
+
+
+def test_image_prompt_extra_body_uses_json_schema() -> None:
+    llm = load_service_module("backend/app/llm.py")
+    extra = llm._image_prompt_extra_body()
+    assert extra["response_format"]["type"] == "json_schema"
+    schema = extra["response_format"]["json_schema"]["schema"]
+    assert "prompt" in schema["properties"]
+    assert "negativePrompt" in schema["required"]
+
+
+def test_chat_payload_merges_image_extra_after_provider() -> None:
+    llm = load_service_module("backend/app/llm.py")
+    provider = llm.Provider(
+        name="t",
+        base_url="http://example",
+        extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+    )
+    payload = llm._chat_payload(
+        provider,
+        "qwen3.6-35b-a3b",
+        [{"role": "user", "content": "hi"}],
+        stream=True,
+        extra=llm._image_prompt_extra_body(),
+    )
+    assert payload["chat_template_kwargs"] == {"enable_thinking": False}
+    assert payload["response_format"]["type"] == "json_schema"


### PR DESCRIPTION
## Summary
PR #45 分割の 2本目。LLM プロバイダ非依存の思考オフ・reasoning フォールバック・JSON Schema 構造化出力を汎用化する。

- RAG（`rag-app`）・日程調整（`chosei-app`）の生成で Qwen 思考モードをオフ（`RAG_EXTRA_BODY` / `CHOSEI_EXTRA_BODY`、空なら `enable_thinking: false`）
- `content` が空のとき `reasoning` / `reasoning_content` を本文として読む
- 画像プロンプト・日程候補を JSON Schema で固定。画像応答は JSON 以外（会話文）でもユーザー入力から復元
- 未登録 `modelId` は既定モデルへフォールバック（backend `_resolve_model`）
- `request_id` を `chat_once` / `chat_stream` に配線し、`/image` 系リクエストのみ画像 Schema を発火
- `tests/conftest.py` を相対 import 対応にし、追加テストを CI 実行対象へ

## 注意
- `json_schema` 非対応の LLM バックエンドでは日程/画像で 400 の可能性。Qwen/vLLM 系での利用を想定。ステージング確認推奨。

## Test plan
- [x] `pytest`（全 pass）
- [x] `npm run web:test -- tests/features/generate-image/utils/parseAssistantImageContent.test.ts`（6 pass）
- [x] `npm run web:build`
- [x] `docker compose -f docker-compose.yml config` / prod（構造 OK）
- [ ] Qwen3+vLLM で RAG/日程/画像が思考待ちで止まらないこと

## Breaking changes
なし（新 env はすべて既定付き）

Made with [Cursor](https://cursor.com)