### PR TITLE
feat(infra): Whisper GPU 接続口とサイト overlay 契約・公開ドキュメント

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,7 +129,9 @@ AUDIT_APP_URL=http://audit-app:8005/invoke
 
 # --- 文字起こし(Whisper) AI アプリ ---
 WHISPER_MODEL=medium        # small / medium / large-v3
-WHISPER_COMPUTE=int8
+WHISPER_DEVICE=cpu          # cpu / cuda（NVIDIA GPU + Container Toolkit）
+WHISPER_COMPUTE=int8        # GPU なら float16 推奨
+# 別エンジンにする場合は WHISPER_APP_URL を差し替える（/invoke と /health があれば可）。
 
 # --- 画像生成(Stable Diffusion) AI アプリ ---
 # 画像生成バックエンド: a1111（既定・GPU 自前運用）| fastsd（CPU-only, FastSD CPU/LCM）

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -176,6 +176,7 @@ AUDIT_RETENTION_DAYS=1825
 
 # --- 文字起こし / 画像生成 ---
 WHISPER_MODEL=medium
+WHISPER_DEVICE=cpu
 WHISPER_COMPUTE=int8
 # 画像生成バックエンド: a1111（既定・GPU 自前運用）| fastsd（CPU-only, FastSD CPU/LCM）
 SD_BACKEND=a1111

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,15 @@ genai-web/packages/web/dist/
 # --- デジタル庁オリジナルの 源内 AI アプリ（未改変・別途 clone のため除外） ---
 /genai-ai-api/
 
+# --- 学習済み画像モデル（巨大。リポジトリに含めない） ---
+/sd-models/
+
+# --- サイト固有の画像生成・文字起こし実装（本家は URL 差し替え） ---
+/docker-compose.spark.yml
+/whisper-app/Dockerfile.spark
+/sd-server/
+/scripts/open-genai-ts-forward.sh
+
 # --- サイト固有の Keycloak 管理コンソール許可 ---
 /proxy/kc-admin-allow.d/10-local.conf
 
@@ -52,3 +61,4 @@ deletion-report-*.txt
 !/docs/chosei.md
 !/docs/doccheck.md
 !/docs/patchform.md
+!/docs/spark.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - 固定チーム（共通アプリ / 管理者ツール）の名称変更・削除を禁止し、システム管理者は共通アプリに AI アプリを登録可能に
 - AI アプリ実行履歴のシード再投入で、管理者が編集した名称・紹介・使い方を保持
 - Keycloak 静的リソース `/kc/resources/` をログイン用 rate limit から除外。管理コンソール許可は `proxy/kc-admin-allow.d/`（サイト固有 CIDR は gitignore）
+- Whisper に `WHISPER_DEVICE` を追加（既定は CPU）。画像生成・文字起こしの本体は環境側で差し替え（`SD_API_URL` / `WHISPER_APP_URL`）。サイト overlay（`docker-compose.spark.yml`）は `-f` マージで opt-in（`include` は非対応ファイルや同名サービス上書きで失敗するため不使用）。構築メモは `docs/spark.md`
 
 ## [0.8.0] - 2026-08-30
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Linux + NVIDIA GPU 機（例: **NVIDIA DGX Spark**）でも動作します。
 | `procedure-mcp/` | 手続きマスタ MCP（`profiles: ["patchform"]`。公開済みのみ。詳細は [`docs/procedure-mcp.md`](docs/procedure-mcp.md)） |
 | `seaweedfs/` | 成果物配信用 S3 互換ストレージ設定 |
 | `scripts/` | 運用スクリプト（契約終了時の完全削除・報告書生成 等） |
-| `docs/` | Open GENAI レイヤのガイド（[ナレッジ API](docs/knowledge-api.md) / [MCP](docs/knowledge-mcp.md) / [Dify 事例](docs/dify-knowledge.md)） |
+| `docs/` | Open GENAI レイヤのガイド（[ナレッジ API](docs/knowledge-api.md) / [MCP](docs/knowledge-mcp.md) / [Dify 事例](docs/dify-knowledge.md) / [DGX Spark](docs/spark.md)） |
 | `docker-compose.yml` | **開発用**。proxy + web(Vite dev server) / backend / … をまとめて起動（HTTP :80 のみ公開、コード変更は無ビルドで即時反映） |
 | `docker-compose.prod.yml` | **本番 TLS 構成**（proxy :80/:443 のみ公開。web は静的ビルド `genai-web/Dockerfile.prod` を nginx で配信） |
 | `docker-compose.verify.yml` | 本番スタックを HTTP で検証／閉域運用するオーバーライド（自己署名不要。web は本番同様の静的ビルド） |
@@ -661,7 +661,7 @@ Open GENAI では **機能ごとに入口を分けています**（どちらも�
 
 `backend` の `/image/generate` が画像生成サーバへプロキシします。バックエンドは `.env` の
 **`SD_BACKEND`** で切り替えます（既定 `a1111`）。画像生成サーバ本体はいずれも**アプリ外で運用**します
-（RAG 埋め込みと同様、環境に応じて差し替える方針）。
+（RAG 埋め込みと同様、環境に応じて差し替える方針）。DGX Spark での一例は [docs/spark.md](docs/spark.md)。
 
 | `SD_BACKEND` | 用途 | サーバ | 既定接続先 | 初期 step/cfg 目安 |
 | --- | --- | --- | --- | --- |

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,14 @@
 #   Docker 内部ネットワークでのみ到達（proxy がパスで振り分ける）。
 # - フロントの API 参照は相対パス /api（genai-web 無改修・.env 設定のみ）。
 
+# サイト用 overlay（DGX Spark 等）はこの本番 compose には include しない。
+# overlay を使うホストは `-f docker-compose.spark.yml` を後ろに足す（既存サービスの
+# 上書きも可能。verify 構成と同じ流儀）。`.env` に COMPOSE_FILE を書けば -f を省略できる。
+# 例: docker compose -f docker-compose.prod.yml -f docker-compose.spark.yml up -d
+# ※ Compose の `include` には required フィールドが無く、実在しないファイルを指すと
+#   compose 全体が失敗する。また include は同名サービスを上書きできない（衝突エラー）
+#   ため、overlay の汎用機構としては -f マージを採用する。
+
 services:
   # 唯一の公開点: TLS を終端し /、/api/、/kc/ を内部サービスへ振り分ける
   proxy:
@@ -84,7 +92,7 @@ services:
       - PROMPT_APP_URL=${PROMPT_APP_URL:-http://prompt-app:8009/invoke}
       # 日程調整（profiles: ["chosei"] で起動。未起動時は専用ページが案内を表示）
       - CHOSEI_APP_URL=${CHOSEI_APP_URL:-http://chosei-app:8010/invoke}
-      - CHOSEI_PUBLIC_ENDPOINT=${CHOSEI_PUBLIC_ENDPOINT:-}
+      - CHOSEI_PUBLIC_ENDPOINT=${CHOSEI_PUBLIC_ENDPOINT:-${PUBLIC_URL:-}}
       # 書類領域分割チェック（profiles: ["doccheck"]）
       - DOCCHECK_APP_URL=${DOCCHECK_APP_URL:-http://doccheck-app:8011/invoke}
       - DOCCHECK_PUBLIC_ENDPOINT=${DOCCHECK_PUBLIC_ENDPOINT:-}
@@ -312,6 +320,7 @@ services:
     environment:
       - RAG_API_KEY=${RAG_API_KEY:-local-rag-key}
       - WHISPER_MODEL=${WHISPER_MODEL:-medium}
+      - WHISPER_DEVICE=${WHISPER_DEVICE:-cpu}
       - WHISPER_COMPUTE=${WHISPER_COMPUTE:-int8}
     volumes:
       - whisper_cache:/cache
@@ -399,7 +408,7 @@ services:
       - INTERNAL_SIGNING_SECRET=${INTERNAL_SIGNING_SECRET:?INTERNAL_SIGNING_SECRET を設定してください}
       - CHOSEI_DB_PATH=/data/chosei.db
       # profile 有効時は外部公開 URL を必ず設定すること（例: https://chosei.example.lg.jp）
-      - CHOSEI_PUBLIC_ENDPOINT=${CHOSEI_PUBLIC_ENDPOINT:-}
+      - CHOSEI_PUBLIC_ENDPOINT=${CHOSEI_PUBLIC_ENDPOINT:-${PUBLIC_URL:-}}
       - CHOSEI_RETENTION_DAYS=${CHOSEI_RETENTION_DAYS:-90}
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
       - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -242,13 +242,14 @@ services:
       - qdrant_data:/qdrant/storage
     restart: unless-stopped
 
-  # 文字起こしを「AI アプリ」として提供（faster-whisper / CPU）
+  # 文字起こしを「AI アプリ」として提供（faster-whisper / CPU）。GPU 実装は環境側で差し替え。
   whisper-app:
     build: ./whisper-app
     container_name: open-genai-whisper-app
     environment:
       - RAG_API_KEY=${RAG_API_KEY:-local-rag-key}
       - WHISPER_MODEL=${WHISPER_MODEL:-medium}
+      - WHISPER_DEVICE=${WHISPER_DEVICE:-cpu}
       - WHISPER_COMPUTE=${WHISPER_COMPUTE:-int8}
     volumes:
       - whisper_cache:/cache

--- a/docs/spark.md
+++ b/docs/spark.md
@@ -1,0 +1,160 @@
+# DGX Spark での構築メモ
+
+NVIDIA DGX Spark（aarch64 / GB10 / CUDA 13）向けの現場メモです。
+**画像生成と文字起こしの実装は環境ごとに異なる**ため、本家の既定 compose には載せません。
+本家が持つのは接続口だけです。
+
+| 機能 | 本家の接続口 | Spark 側の実装（このメモ） |
+| --- | --- | --- |
+| 文字起こし | `whisper-app` の `/invoke` `/health`。差替は `WHISPER_APP_URL` | CUDA 付き faster-whisper（CTranslate2 aarch64） |
+| 画像生成 | `SD_BACKEND=a1111` + `SD_API_URL` | A1111 互換の最小 SD サーバ（SD-Turbo） |
+
+サイト名称・公開 URL・管理コンソール許可 CIDR も `.env` と gitignore した overlay に置きます。コードへ自治体名やホスト IP を直書きしないこと。
+
+## 起動
+
+`docker-compose.prod.yml` は overlay を include しません。overlay を使うホストは
+`-f docker-compose.spark.yml` を後ろに足して起動します（Whisper GPU と `sd-server` が載る）。
+本家の既定 clone（overlay 無し）は `docker-compose.prod.yml` だけで CPU Whisper が動きます。
+
+> Compose の `include` には `required` フィールドが無く、実在しないファイルを指すと
+> compose 全体が失敗します。また `include` は同名サービス（`whisper-app` 等）を上書き
+> できず衝突エラーになります。overlay で既存サービスを GPU 版に差し替えられるよう、
+> include ではなく `-f` マージ（複数 compose ファイル）を使います。
+
+```bash
+# このホスト（閉域 HTTP 検証 + Spark overlay）
+docker compose \
+  -f docker-compose.prod.yml \
+  -f docker-compose.verify.yml \
+  -f docker-compose.spark.yml \
+  --env-file .env up -d
+```
+
+`docker-compose.spark.yml` は **gitignore**（`/docker-compose.spark.yml`）。
+サイトの `.env` に `COMPOSE_FILE=docker-compose.prod.yml:docker-compose.verify.yml:docker-compose.spark.yml`
+を書いておくと、`-f` を省略しても同じファイル順になります。
+
+TLS 本番にするときは `verify` を外し、`proxy/certs/` を置いて `docker-compose.prod.yml` と
+`docker-compose.spark.yml` の 2 つにします。
+
+## `.env` で足す値
+
+本家の `.env.example` をコピーしたうえで、Spark では少なくとも次を上書きします。
+値の例は構築時のものです。モデル名や公開 URL はサイトに合わせて変えてください。
+
+```bash
+# 画面名称（静的ビルドの web に埋め込まれる。変更後は web 再ビルド）
+VITE_APP_TITLE=Open GENAI
+# ゲスト HTML（日程調整・書類チェック・フォーム）は未設定なら VITE_APP_TITLE
+# APP_TITLE=Open GENAI
+
+# 文字起こし（GPU）
+WHISPER_MODEL=large-v3
+WHISPER_DEVICE=cuda
+WHISPER_COMPUTE=float16
+
+# 画像生成。サーバは overlay の sd-server（コンテナ名）
+SD_BACKEND=a1111
+SD_API_URL=http://sd-server:7860
+SD_MODEL_ID=/models/sd-turbo
+```
+
+Qwen3.x / vLLM を使う場合、思考モードで `content` が空のまま待たされることがあります。
+チャットは `LLM_PROVIDERS[].extra_body`、RAG / 日程調整は `RAG_EXTRA_BODY` / `CHOSEI_EXTRA_BODY`
+（未設定時は本家側で `enable_thinking: false`）。
+
+```json
+{"chat_template_kwargs":{"enable_thinking":false}}
+```
+
+## 文字起こし（GPU Whisper）
+
+本家の `whisper-app/Dockerfile` は `python:3.12-slim`（CPU）です。Spark では次が必要です。
+
+- ベース: `nvidia/cuda:12.8.0-cudnn-runtime-ubuntu24.04`
+- PyPI の aarch64 `ctranslate2` は CPU 専用。CUDA 本体は別バイナリを入れ、Python バインディングだけソースから入れる
+- 構築時に使ったバイナリ:
+  `https://github.com/assix/ctranslate2-aarch64-cuda13-binaries/releases/download/v4.6.0-cuda13-aarch64/ctranslate2-dgxspark-aarch64-cuda13.tar.gz`
+  （CTranslate2 v4.6.0）
+- ホストの cuBLAS 13 を実行時マウントする（コンテナイメージに CUDA 13 を全部入れない）
+  - ホストパス: `/usr/local/cuda/targets/sbsa-linux/lib`
+  - コンテナ: `/opt/cuda13/lib`
+- `gpus: all` と NVIDIA Container Toolkit
+- サイト用 Dockerfile は gitignore（`/whisper-app/Dockerfile.spark`）
+
+overlay の要点:
+
+```yaml
+services:
+  whisper-app:
+    build:
+      context: ./whisper-app
+      dockerfile: Dockerfile.spark
+    gpus: all
+    environment:
+      - WHISPER_DEVICE=${WHISPER_DEVICE:-cuda}
+      - WHISPER_COMPUTE=${WHISPER_COMPUTE:-float16}
+      - LD_LIBRARY_PATH=/opt/ctranslate2/lib:/opt/cuda13/lib:/usr/local/cuda/lib64
+    volumes:
+      - whisper_cache:/cache
+      - /usr/local/cuda/targets/sbsa-linux/lib:/opt/cuda13/lib:ro
+```
+
+`WHISPER_APP_URL` は未設定なら `http://whisper-app:8002/invoke` のまま使えます。
+別エンジンにするときだけ差し替え（`/invoke` と `/health` があれば可）。
+
+## 画像生成（A1111 互換サーバ）
+
+本家 backend は AUTOMATIC1111 互換 API（`/sdapi/v1/txt2img`）へプロキシします。
+Spark では GB10 向け PyTorch イメージを流用した最小サーバを立てました。
+
+- ベースイメージ例: 手元の `storage-manager/llm-router:2.0.1`（torch 2.12 + cu130）。
+  公開レジストリの汎用イメージではない。**その環境で動く torch を流用する**
+- 追加 pip: `diffusers` / `accelerate` / `pillow`（torch は再取得しない）
+- 既定モデル: **SD-Turbo**（数ステップ、guidance 0）。UI 既定の 50/7 はサーバ側で丸める
+- 重みはホストの `./sd-models/sd-turbo` を読み取り専用マウント（gitignore。約数 GB）
+- サイト用コードは gitignore（`/sd-server/`）
+- backend からの接続: `SD_API_URL=http://sd-server:7860`
+
+overlay の要点:
+
+```yaml
+services:
+  sd-server:
+    build: ./sd-server
+    container_name: open-genai-sd-server
+    gpus: all
+    environment:
+      - HF_HOME=/models
+      - SD_MODEL_ID=${SD_MODEL_ID:-/models/sd-turbo}
+    volumes:
+      - sd_models:/models
+      - ./sd-models/sd-turbo:/models/sd-turbo:ro
+```
+
+AUTOMATIC1111 本体や FastSD に差し替える場合は、`SD_API_URL`（と必要なら `SD_BACKEND`）だけ変え、
+この `sd-server` は起動しなくてよい。
+
+## リポジトリに載せないもの
+
+| 対象 | 置き場 |
+| --- | --- |
+| `.env` / 証明書 / DB | 既存の gitignore |
+| `docker-compose.spark.yml` | サイト overlay |
+| `whisper-app/Dockerfile.spark` | サイト用イメージ |
+| `sd-server/` | サイト用 SD 実装 |
+| `sd-models/` | 学習済み重み |
+| `proxy/kc-admin-allow.d/10-local.conf` | 管理コンソール許可 CIDR |
+| Tailscale 等の作業スクリプト | サイト用 |
+
+Keycloak 管理コンソール（`/kc/admin`）は本家既定で deny-all です。
+庁内網からだけ通すときは `10-local.conf` に `allow 10.0.0.0/8;` 等を書き、proxy を reload します。
+`/kc/resources/` はログイン用 rate limit の対象外（管理画面の JS が 503 になるため）。
+
+## 確認の目安
+
+- `whisper-app` の `/health` が `"device":"cuda"`
+- `/image` から生成でき、`sd-server` のログに txt2img が残る
+- overlay 無しの `docker compose -f docker-compose.prod.yml config` に `sd-server` が出ない
+- 画面タイトルは `.env` の `VITE_APP_TITLE` だけで変わる（コードにサイト名が無い）

--- a/whisper-app/app/main.py
+++ b/whisper-app/app/main.py
@@ -1,4 +1,4 @@
-"""文字起こし「AI アプリ」マイクロサービス（faster-whisper / CPU）。
+"""文字起こし「AI アプリ」マイクロサービス（faster-whisper / CUDA or CPU）。
 
 源内の AI アプリ同期プロトコルに準拠:
 - リクエスト: { "inputs": { "audio": ..., "language": "auto|ja|en", "files": [...] } }
@@ -35,7 +35,14 @@ def _get_model():
     if _model is not None:
         return _model
     try:
+        import ctranslate2
         from faster_whisper import WhisperModel
+
+        if WHISPER_DEVICE == "cuda" and ctranslate2.get_cuda_device_count() < 1:
+            raise RuntimeError(
+                "WHISPER_DEVICE=cuda ですが CUDA デバイスが見つかりません。"
+                "コンテナに GPU が渡されているか確認してください。"
+            )
 
         _model = WhisperModel(
             WHISPER_MODEL, device=WHISPER_DEVICE, compute_type=WHISPER_COMPUTE
@@ -55,7 +62,13 @@ def _check_key(x_api_key: str | None) -> JSONResponse | None:
 
 @app.get("/health")
 async def health() -> dict[str, Any]:
-    return {"status": "ok", "model": WHISPER_MODEL, "loaded": _model is not None}
+    return {
+        "status": "ok",
+        "model": WHISPER_MODEL,
+        "device": WHISPER_DEVICE,
+        "compute": WHISPER_COMPUTE,
+        "loaded": _model is not None,
+    }
 
 
 def _extract_audio(inputs: dict[str, Any]) -> tuple[str, bytes] | None:


### PR DESCRIPTION
## Summary
PR #45 分割の 7本目（最後）。Whisper の GPU 接続口、サイト overlay の契約、公開ドキュメントをまとめる。現場固有物（`docker-compose.spark.yml` / `sd-server/` / モデル / スクリプト）は Git 外のまま。

- `whisper-app` に `WHISPER_DEVICE`（`cpu` / `cuda`）を追加。`cuda` 指定時に CUDA デバイス有無を検証し、`/health` に `device` / `compute` を出す
- `docker-compose*.yml` / `.env(.prod).example` に `WHISPER_DEVICE`（既定 `cpu`）を追加
- `CHOSEI_PUBLIC_ENDPOINT` の既定を `PUBLIC_URL` にフォールバック
- `.gitignore` に `sd-models/` / `docker-compose.spark.yml` / `sd-server/` / 現場スクリプトを追加
- `README` と `docs/spark.md`（DGX Spark 構築メモ）を追加・更新

## PR #45 からの重要な修正（overlay 契約）
上流 PR #45 は本番 compose に以下を入れていたが、現行 Docker Compose（v2.40.3 で確認）では機能せず、**overlay 無しの本家利用者で `docker compose -f docker-compose.prod.yml up` が失敗**する：

```yaml
include:
  - path: docker-compose.spark.yml
    required: false   # ← include に required フィールドは存在しない（Compose 仕様）
```

- `include` に `required` は無く（`env_file` 専用）、実在しないファイルを指すと compose 全体が exit 1
- さらに `include` は同名サービス（`whisper-app`）を**上書きできず衝突**するため、GPU 版へ差し替える overlay 用途に使えない

本 PR では include を外し、overlay は **`-f docker-compose.spark.yml`（または `COMPOSE_FILE`）で opt-in** する方式に統一（`docker-compose.verify.yml` と同じ流儀。既存サービスの上書きも可能）。

## Test plan（`docker compose config` で検証済み）
- [x] overlay 無し `docker compose -f docker-compose.prod.yml config` → exit 0、`WHISPER_DEVICE: cpu`、`sd-server` 無し
- [x] overlay 有り `-f docker-compose.prod.yml -f docker-compose.spark.yml config` → exit 0、`WHISPER_DEVICE: cuda`、`sd-server` 追加
- [x] `docker compose -f docker-compose.yml config`（dev）
- [x] `python -m py_compile whisper-app/app/main.py`
- [ ] 実機 GPU で `WHISPER_DEVICE=cuda` の文字起こし、overlay の sd-server 連携

## 動作要件
- Docker Compose v2.20 以降を推奨（`-f` マージ・`depends_on` の `required` 等）。

## Breaking changes
- overlay を使うサイトは `docker-compose.spark.yml` を **自動 include から `-f` 追加（または `COMPOSE_FILE`）へ**変更が必要（`docs/spark.md` に記載）。本家の既定 clone は影響なし。

Made with [Cursor](https://cursor.com)