### PR TITLE
fix(deps): pypdf を 6.16.2 に更新し既知脆弱性を横断解消

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,7 +4,7 @@ httpx==0.28.1
 python3-saml==1.16.0
 PyJWT==2.13.0
 python-multipart==0.0.31
-pypdf==6.15.0
+pypdf==6.16.2
 python-docx==1.1.2
 openpyxl==3.1.5
 python-pptx==1.0.2

--- a/doccheck-app/requirements.txt
+++ b/doccheck-app/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.139.0
 uvicorn[standard]==0.34.0
 httpx==0.28.1
 Pillow==12.3.0
-pypdf==6.15.0
+pypdf==6.16.2
 python-multipart==0.0.31
 numpy==2.2.3
 rapidocr-onnxruntime==1.4.4

--- a/patchform-app/requirements.txt
+++ b/patchform-app/requirements.txt
@@ -3,7 +3,7 @@ uvicorn[standard]==0.34.0
 bcrypt==4.2.1
 httpx==0.28.1
 cryptography==50.0.1
-pypdf==6.15.0
+pypdf==6.16.2
 python-docx==1.1.2
 openpyxl==3.1.5
 python-pptx==1.0.2

--- a/rag-app/requirements.txt
+++ b/rag-app/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.139.0
 uvicorn[standard]==0.34.0
 httpx==0.28.1
-pypdf==6.15.0
+pypdf==6.16.2
 python-docx==1.1.2
 openpyxl==3.1.5
 python-pptx==1.0.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest==9.0.3
 httpx==0.28.1
-pypdf==6.15.0
+pypdf==6.16.2


### PR DESCRIPTION
## 概要
pip-audit で検出された `pypdf==6.15.0` の既知脆弱性を横断的に解消します。

## 詳細
- 脆弱性: CVE-2026-84309 / 84310 / 84311（修正版 6.16.0 / 6.16.1）
- 対応: 対象の全 `requirements.txt` を **6.16.2**（最新安定・全CVE対応）へ更新
- 対象ファイル: `backend` / `rag-app` / `doccheck-app` / `patchform-app` / `tests`

## 影響・検証
- コードは `PdfReader` / `PdfWriter` の基本APIのみ使用。6.15→6.16 に破壊的変更なし。
- ローカルで pypdf 6.16.2 のラウンドトリップ（write→read→extract_text）を確認済み。
- CI（python-regression / web-regression / pip-audit）で確認。

Made with [Cursor](https://cursor.com)