### PR TITLE
本人によるアカウント設定（表示名・パスワード変更）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -260,6 +260,9 @@ KEYCLOAK_ADMIN_PASSWORD=admin
 # usermgmt-app から見た Keycloak の内部URL（proxy 経由 /kc）
 # KEYCLOAK_INTERNAL_URL=http://keycloak:8080/kc
 KEYCLOAK_REALM=open-genai
+# 本人パスワード変更（アカウント設定）で現行パスワードを検証する realm 内 OIDC クライアント。
+# Keycloak 既定の admin-cli は各 realm に存在し direct access grants が有効なため既定値に採用。
+# KEYCLOAK_PASSWORD_VERIFY_CLIENT=admin-cli
 
 # --- 監査ログ（利用状況/内容ログ・8-(1) 対応）---
 # 監査ログ機能の有効化

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
   - テーマ無し（ヒアリングシート未生成）の素のプロジェクトは、合成タブでテーマの章立てを並べず**空の Word 出力を 1 つだけ**表示する。素の文書の Word 化はテーマ固有の生成 API（例: 調達仕様書=spec-app）に依存させず、汎用サービス `procuretech-generate-app`（`EDITOR_COMPOSE_URL`、`procuretech-editor` プロファイルで同時起動）へ振り分ける
   - 公開の汎用リファレンス実装を `procuretech-generate-sample` → **`procuretech-generate-app`** に改称（既定の合成バックエンドを兼ねるため）。合成サービスの env を `GENERATE_SAMPLE_*` → `GENERATE_*` に統一（旧名も後方互換で参照）
   - 「調達仕様書」生成・合成サービス `procuretech-spec-app` を追加（非公開参考実装のドメインを移植し、Nextcloud→zip 返却・Dify キー外出し・`/generate`・`/status`・`/result`・`/compose` を実装。Compose profile `procuretech-spec`）
+- アカウント設定（本人）を追加。ヘッダー右上メニューの「アカウント設定」から、自分の表示名（姓名）とパスワードを変更できる専用ページ（`/settings`）。ヘッダー等のユーザー表示をログイン名ではなく**表示名（姓名）**に変更（Keycloak の firstName/lastName から組み立て、未取得時はログイン名にフォールバック）。パスワード変更は現行パスワードを realm 内 OIDC クライアント（既定 `admin-cli`、`KEYCLOAK_PASSWORD_VERIFY_CLIENT` で変更可）で検証してから更新する。処理は既存の利用者一括管理サービス（`usermgmt-app`）の Keycloak Admin API に**本人スコープ**の新エンドポイント（`GET/PUT /me/profile`・`POST /me/password`）を追加し、backend が非管理者プロキシ（`/my/profile`・`/my/password`）として仲介する（対象ユーザーは署名付き `x-user-id`（メール）から厳密解決し、本文指定は信用しない）
 - 情報化企画書ナビ（procuretech）を追加。情報化企画書（Excel）を読み込み、4分野（背景・業務・現行システム・目標）を AI 対話で整理し、各欄（`B10/B14/B19/B23`）へ書き戻して更新版をダウンロードできる専用ページ（`/procuretech`）。Compose profile `procuretech` でオプション起動（詳細は `docs/procuretech.md`）
 - プロンプトテンプレートの「チャットで開く」で入力欄が空になる不具合を修正
 - HTTP/LAN 環境（非セキュアオリジン）向けに UUID 生成とクリップボードコピーのフォールバックを共通化

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5535,6 +5535,32 @@ def _usermgmt_headers(request: Request) -> tuple[JSONResponse | None, dict[str, 
     return None, headers
 
 
+def _usermgmt_self_headers(request: Request) -> tuple[JSONResponse | None, dict[str, str]]:
+    """本人向け（自己プロフィール/パスワード）用の署名ヘッダ。管理者権限は不要。
+
+    対象ユーザーは JWT の sub（正規化メール）を x-user-id として署名付与し、
+    usermgmt-app 側でこのメールから Keycloak ユーザーを厳密解決する。
+    """
+    claims = _claims_from_request(request)
+    user_id = _user_id(claims)
+    if not user_id:
+        return JSONResponse(status_code=401, content={"error": "Unauthorized"}), {}
+    groups_str = ",".join(claims.get("groups") or [])
+    team_ids = _user_team_ids_str(user_id)
+    teams_hdr = _user_teams_header(user_id)
+    headers = {
+        "x-api-key": RAG_API_KEY,
+        "x-user-id": user_id,
+        "x-user-groups": groups_str,
+        "x-user-tags": team_ids,
+        "x-user-teams": teams_hdr,
+        "x-scope": COMMON_TEAM_ID,
+        **intauth.signed_headers(user_id, groups_str, COMMON_TEAM_ID, team_ids),
+        "Content-Type": "application/json",
+    }
+    return None, headers
+
+
 async def _proxy_usermgmt(
     method: str,
     url: str,
@@ -5558,6 +5584,35 @@ async def _proxy_usermgmt(
     except ValueError:
         payload = {"error": "利用者管理サービスから不正な応答を受け取りました"}
     return JSONResponse(status_code=res.status_code, content=payload)
+
+
+@app.get("/my/profile")
+async def get_my_profile(request: Request) -> JSONResponse:
+    """本人のプロフィール（姓名・表示名）を取得する。"""
+    err, headers = _usermgmt_self_headers(request)
+    if err:
+        return err
+    return await _proxy_usermgmt("GET", _usermgmt_app_url("/me/profile"), headers)
+
+
+@app.put("/my/profile")
+async def update_my_profile(request: Request) -> JSONResponse:
+    """本人のプロフィール（姓・名）を更新する。"""
+    err, headers = _usermgmt_self_headers(request)
+    if err:
+        return err
+    body = await request.json()
+    return await _proxy_usermgmt("PUT", _usermgmt_app_url("/me/profile"), headers, body)
+
+
+@app.post("/my/password")
+async def change_my_password(request: Request) -> JSONResponse:
+    """本人のパスワードを変更する（現行パスワード検証あり）。"""
+    err, headers = _usermgmt_self_headers(request)
+    if err:
+        return err
+    body = await request.json()
+    return await _proxy_usermgmt("POST", _usermgmt_app_url("/me/password"), headers, body)
 
 
 @app.get("/admin/users")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -301,6 +301,8 @@ services:
       - KEYCLOAK_REALM=${KEYCLOAK_REALM:-open-genai}
       - KEYCLOAK_ADMIN=${KEYCLOAK_ADMIN:-admin}
       - KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD:-admin}
+      # 本人パスワード変更時の現行パスワード検証に使う realm 内クライアント（既定 admin-cli）。
+      - KEYCLOAK_PASSWORD_VERIFY_CLIENT=${KEYCLOAK_PASSWORD_VERIFY_CLIENT:-admin-cli}
       - INTERNAL_SIGNING_SECRET=${INTERNAL_SIGNING_SECRET:-dev-internal-secret-change-me}
     depends_on:
       - keycloak

--- a/genai-web/packages/web/src/components/ui/AccountMenu.tsx
+++ b/genai-web/packages/web/src/components/ui/AccountMenu.tsx
@@ -60,6 +60,16 @@ export const AccountMenu = (props: Props) => {
           <MenuItem>
             {({ focus }) => (
               <Link
+                to='/settings'
+                className={`relative flex w-full items-center gap-x-2 bg-white py-3 pr-6 pl-4 text-oln-16N-100 text-nowrap text-solid-gray-800 hover:bg-solid-gray-50 hover:underline hover:underline-offset-[calc(3/16*1rem)] ${focus ? '[:root[data-headlessui-focus-visible]_&]:bg-yellow-300 [:root[data-headlessui-focus-visible]_&]:ring-[calc(6/16*1rem)] [:root[data-headlessui-focus-visible]_&]:ring-yellow-300 [:root[data-headlessui-focus-visible]_&]:outline-4 [:root[data-headlessui-focus-visible]_&]:-outline-offset-4 [:root[data-headlessui-focus-visible]_&]:outline-black [:root[data-headlessui-focus-visible]_&]:outline-solid [:root[data-headlessui-focus-visible]_&]:ring-inset' : ''}`}
+              >
+                アカウント設定
+              </Link>
+            )}
+          </MenuItem>
+          <MenuItem>
+            {({ focus }) => (
+              <Link
                 to='/history'
                 className={`relative flex w-full items-center gap-x-2 bg-white py-3 pr-6 pl-4 text-oln-16N-100 text-nowrap text-solid-gray-800 hover:bg-solid-gray-50 hover:underline hover:underline-offset-[calc(3/16*1rem)] ${focus ? '[:root[data-headlessui-focus-visible]_&]:bg-yellow-300 [:root[data-headlessui-focus-visible]_&]:ring-[calc(6/16*1rem)] [:root[data-headlessui-focus-visible]_&]:ring-yellow-300 [:root[data-headlessui-focus-visible]_&]:outline-4 [:root[data-headlessui-focus-visible]_&]:-outline-offset-4 [:root[data-headlessui-focus-visible]_&]:outline-black [:root[data-headlessui-focus-visible]_&]:outline-solid [:root[data-headlessui-focus-visible]_&]:ring-inset' : ''}`}
               >

--- a/genai-web/packages/web/src/components/ui/Header.tsx
+++ b/genai-web/packages/web/src/components/ui/Header.tsx
@@ -8,6 +8,7 @@ import { isSidebarNavLayout } from '@/constants/navLayout';
 import { useAuth } from '@/hooks/useAuth';
 import { useMobileMenuHandler } from '@/layout/hooks/useMobileMenuHandler';
 import { signOut as localSignOut } from '@/local/localAuth';
+import { useMyProfile } from '@/open-genai/settings/useMyProfile';
 
 type Props = {
   className?: string;
@@ -22,11 +23,14 @@ export const Header = (props: Props) => {
   const { data } = useAuth();
   const groups =
     (data?.tokens?.accessToken.payload['cognito:groups'] as unknown as string[] | undefined) ?? [];
-  const userDisplayName =
+  const loginName =
     (data?.tokens?.accessToken.payload['username'] as string | undefined) ||
     (data?.tokens?.idToken.payload['cognito:username'] as string | undefined) ||
     (data?.tokens?.idToken.payload['email'] as string | undefined) ||
     '';
+  // 表示名（姓名）は Keycloak のプロフィールから取得する。未取得時はログイン名に退避。
+  const { profile } = useMyProfile(Boolean(loginName));
+  const userDisplayName = profile?.displayName?.trim() || loginName;
 
   const { cache } = useSWRConfig();
 

--- a/genai-web/packages/web/src/components/ui/mobile-menu/MobileMenu.tsx
+++ b/genai-web/packages/web/src/components/ui/mobile-menu/MobileMenu.tsx
@@ -5,11 +5,7 @@ import { AccountIcon } from '@/components/ui/icons/AccountIcon';
 import { isSidebarNavLayout } from '@/constants/navLayout';
 import { useExApps } from '@/features/exapps/hooks/useExApps';
 import { useFilteredTeams } from '@/features/exapps/hooks/useFilteredTeams';
-import {
-  ALL_APPS_NAV_ITEM,
-  pinnedAppHref,
-  useRecommendedNavItems,
-} from '@/layout/navItems';
+import { ALL_APPS_NAV_ITEM, pinnedAppHref, useRecommendedNavItems } from '@/layout/navItems';
 import { partitionPinnedApps } from '@/open-genai/app-pins/partitionPinnedApps';
 import { useFetchAppPins } from '@/open-genai/app-pins/useFetchAppPins';
 import { MobileMenuItemButton, MobileMenuItemLink } from './MobileMenuItem';
@@ -119,7 +115,8 @@ export const MobileMenu = forwardRef<HTMLDialogElement, Props>((props, ref) => {
                 <ul>
                   {userDisplayName?.trim() && (
                     <li className='px-4 py-2 text-dns-14N-130 text-solid-gray-600'>
-                      ログイン中: <span className='font-bold text-solid-gray-800'>{userDisplayName}</span>
+                      ログイン中:{' '}
+                      <span className='font-bold text-solid-gray-800'>{userDisplayName}</span>
                     </li>
                   )}
                   {isShowTeamManagementMenu && (
@@ -127,6 +124,9 @@ export const MobileMenu = forwardRef<HTMLDialogElement, Props>((props, ref) => {
                       <MobileMenuItemLink label='チーム管理' to='/teams' />
                     </li>
                   )}
+                  <li>
+                    <MobileMenuItemLink label='アカウント設定' to='/settings' />
+                  </li>
                   <li>
                     <MobileMenuItemLink label='利用履歴' to='/history' />
                   </li>

--- a/genai-web/packages/web/src/open-genai/settings/SettingsPage.tsx
+++ b/genai-web/packages/web/src/open-genai/settings/SettingsPage.tsx
@@ -1,0 +1,66 @@
+import { PageTitle } from '@/components/PageTitle';
+import { ProgressIndicator } from '@/components/ui/dads/ProgressIndicator';
+import { LayoutBody } from '@/layout/LayoutBody';
+import { PasswordForm } from './components/PasswordForm';
+import { ProfileForm } from './components/ProfileForm';
+import { useMyProfile } from './useMyProfile';
+
+export const SettingsPage = () => {
+  const { profile, error, isLoading, mutate } = useMyProfile();
+
+  return (
+    <LayoutBody>
+      <PageTitle title='アカウント設定' />
+      <div className='mx-auto flex w-full max-w-3xl flex-col gap-6 p-4 lg:p-6'>
+        <div className='flex flex-col gap-1'>
+          <h1 className='text-std-22B-150 text-solid-gray-900'>アカウント設定</h1>
+          <p className='text-dns-16N-170 text-solid-gray-700'>
+            表示名（姓名）とパスワードを変更できます。
+          </p>
+        </div>
+
+        {isLoading && (
+          <div className='py-6'>
+            <ProgressIndicator label='設定を読み込み中...' />
+          </div>
+        )}
+
+        {!isLoading && error && (
+          <div className='rounded-8 border border-amber-300 bg-amber-50 px-4 py-3 text-dns-14N-130 text-solid-gray-800'>
+            設定情報を取得できませんでした。時間をおいて再度お試しください。
+          </div>
+        )}
+
+        {!isLoading && profile && (
+          <>
+            <section className='flex flex-col gap-4 rounded-8 border border-solid-gray-300 bg-white p-5'>
+              <div className='flex flex-col gap-1'>
+                <h2 className='text-std-18B-160 text-solid-gray-900'>プロフィール</h2>
+                <p className='text-dns-14N-130 text-solid-gray-600'>
+                  ログインID: <span className='font-bold'>{profile.username}</span>
+                  {profile.email ? `（${profile.email}）` : ''}
+                </p>
+              </div>
+              <ProfileForm
+                profile={profile}
+                onUpdated={(next) => {
+                  void mutate(next, { revalidate: false });
+                }}
+              />
+            </section>
+
+            <section className='flex flex-col gap-4 rounded-8 border border-solid-gray-300 bg-white p-5'>
+              <div className='flex flex-col gap-1'>
+                <h2 className='text-std-18B-160 text-solid-gray-900'>パスワード変更</h2>
+                <p className='text-dns-14N-130 text-solid-gray-600'>
+                  現在のパスワードを確認のうえ、新しいパスワードに変更します。
+                </p>
+              </div>
+              <PasswordForm />
+            </section>
+          </>
+        )}
+      </div>
+    </LayoutBody>
+  );
+};

--- a/genai-web/packages/web/src/open-genai/settings/components/PasswordForm.tsx
+++ b/genai-web/packages/web/src/open-genai/settings/components/PasswordForm.tsx
@@ -1,0 +1,135 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { ErrorText } from '@/components/ui/dads/ErrorText';
+import { Input } from '@/components/ui/dads/Input';
+import { Label } from '@/components/ui/dads/Label';
+import { RequirementBadge } from '@/components/ui/dads/RequirementBadge';
+import { LoadingButton } from '@/components/ui/LoadingButton';
+import { isApiError, teamApi } from '@/lib/fetcher';
+import { type PasswordSchema, passwordSchema } from '../schema';
+
+export const PasswordForm = () => {
+  const [error, setError] = useState('');
+  const [done, setDone] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<PasswordSchema>({
+    mode: 'onSubmit',
+    resolver: zodResolver(passwordSchema),
+    defaultValues: {
+      currentPassword: '',
+      newPassword: '',
+      confirmPassword: '',
+    },
+  });
+
+  const onSubmit = handleSubmit(async (data) => {
+    try {
+      setError('');
+      setDone(false);
+      setIsLoading(true);
+      await teamApi.post('my/password', {
+        currentPassword: data.currentPassword,
+        newPassword: data.newPassword,
+      });
+      setDone(true);
+      reset();
+    } catch (e) {
+      if (isApiError(e)) {
+        setError((e.data as { error?: string })?.error ?? 'パスワードの変更に失敗しました。');
+      } else {
+        setError('システムエラーが発生しました。ページをリロードして再度お試しください。');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  });
+
+  return (
+    <form onSubmit={onSubmit} className='flex flex-col gap-4'>
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='settings-current-password' size='lg'>
+          現在のパスワード<RequirementBadge>※必須</RequirementBadge>
+        </Label>
+        <Input
+          id='settings-current-password'
+          type='password'
+          className='w-full max-w-md'
+          autoComplete='current-password'
+          aria-describedby={errors.currentPassword ? 'settings-current-password-error' : undefined}
+          {...register('currentPassword')}
+        />
+        {errors.currentPassword && (
+          <ErrorText id='settings-current-password-error'>
+            ＊{errors.currentPassword.message}
+          </ErrorText>
+        )}
+      </div>
+
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='settings-new-password' size='lg'>
+          新しいパスワード<RequirementBadge>※必須</RequirementBadge>
+        </Label>
+        <Input
+          id='settings-new-password'
+          type='password'
+          className='w-full max-w-md'
+          autoComplete='new-password'
+          aria-describedby={errors.newPassword ? 'settings-new-password-error' : undefined}
+          {...register('newPassword')}
+        />
+        {errors.newPassword ? (
+          <ErrorText id='settings-new-password-error'>＊{errors.newPassword.message}</ErrorText>
+        ) : (
+          <p className='text-dns-14N-130 text-solid-gray-600'>8文字以上で入力してください。</p>
+        )}
+      </div>
+
+      <div className='flex flex-col gap-1.5'>
+        <Label htmlFor='settings-confirm-password' size='lg'>
+          新しいパスワード（確認）<RequirementBadge>※必須</RequirementBadge>
+        </Label>
+        <Input
+          id='settings-confirm-password'
+          type='password'
+          className='w-full max-w-md'
+          autoComplete='new-password'
+          aria-describedby={errors.confirmPassword ? 'settings-confirm-password-error' : undefined}
+          {...register('confirmPassword')}
+        />
+        {errors.confirmPassword && (
+          <ErrorText id='settings-confirm-password-error'>
+            ＊{errors.confirmPassword.message}
+          </ErrorText>
+        )}
+      </div>
+
+      {error && (
+        <div className='rounded-6 bg-red-50 p-3 text-dns-14N-130 text-error-1'>{error}</div>
+      )}
+      {done && (
+        <div className='rounded-6 bg-green-50 p-3 text-dns-14N-130 text-green-900'>
+          パスワードを変更しました。
+        </div>
+      )}
+
+      <div className='flex justify-start'>
+        <LoadingButton
+          type='submit'
+          variant='solid-fill'
+          size='md'
+          className='w-48'
+          loading={isLoading}
+        >
+          {isLoading ? '変更中' : 'パスワードを変更'}
+        </LoadingButton>
+      </div>
+    </form>
+  );
+};

--- a/genai-web/packages/web/src/open-genai/settings/components/ProfileForm.tsx
+++ b/genai-web/packages/web/src/open-genai/settings/components/ProfileForm.tsx
@@ -1,0 +1,116 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { ErrorText } from '@/components/ui/dads/ErrorText';
+import { Input } from '@/components/ui/dads/Input';
+import { Label } from '@/components/ui/dads/Label';
+import { LoadingButton } from '@/components/ui/LoadingButton';
+import { isApiError, teamApi } from '@/lib/fetcher';
+import { type ProfileSchema, profileSchema } from '../schema';
+import type { MyProfile } from '../types';
+
+type Props = {
+  profile: MyProfile;
+  onUpdated: (profile: MyProfile) => void;
+};
+
+export const ProfileForm = ({ profile, onUpdated }: Props) => {
+  const [error, setError] = useState('');
+  const [done, setDone] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ProfileSchema>({
+    mode: 'onSubmit',
+    resolver: zodResolver(profileSchema),
+    values: {
+      lastName: profile.lastName,
+      firstName: profile.firstName,
+    },
+  });
+
+  const onSubmit = handleSubmit(async (data) => {
+    try {
+      setError('');
+      setDone(false);
+      setIsLoading(true);
+      const res = await teamApi.put<MyProfile>('my/profile', {
+        lastName: data.lastName,
+        firstName: data.firstName,
+      });
+      onUpdated(res.data);
+      setDone(true);
+    } catch (e) {
+      if (isApiError(e)) {
+        setError((e.data as { error?: string })?.error ?? '更新に失敗しました。');
+      } else {
+        setError('システムエラーが発生しました。ページをリロードして再度お試しください。');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  });
+
+  return (
+    <form onSubmit={onSubmit} className='flex flex-col gap-4'>
+      <div className='grid grid-cols-1 gap-4 sm:grid-cols-2'>
+        <div className='flex flex-col gap-1.5'>
+          <Label htmlFor='settings-lastname' size='lg'>
+            姓
+          </Label>
+          <Input
+            id='settings-lastname'
+            type='text'
+            className='w-full'
+            autoComplete='family-name'
+            aria-describedby={errors.lastName ? 'settings-lastname-error' : undefined}
+            {...register('lastName')}
+          />
+          {errors.lastName && (
+            <ErrorText id='settings-lastname-error'>＊{errors.lastName.message}</ErrorText>
+          )}
+        </div>
+        <div className='flex flex-col gap-1.5'>
+          <Label htmlFor='settings-firstname' size='lg'>
+            名
+          </Label>
+          <Input
+            id='settings-firstname'
+            type='text'
+            className='w-full'
+            autoComplete='given-name'
+            aria-describedby={errors.firstName ? 'settings-firstname-error' : undefined}
+            {...register('firstName')}
+          />
+          {errors.firstName && (
+            <ErrorText id='settings-firstname-error'>＊{errors.firstName.message}</ErrorText>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className='rounded-6 bg-red-50 p-3 text-dns-14N-130 text-error-1'>{error}</div>
+      )}
+      {done && (
+        <div className='rounded-6 bg-green-50 p-3 text-dns-14N-130 text-green-900'>
+          プロフィールを更新しました。
+        </div>
+      )}
+
+      <div className='flex justify-start'>
+        <LoadingButton
+          type='submit'
+          variant='solid-fill'
+          size='md'
+          className='w-48'
+          loading={isLoading}
+        >
+          {isLoading ? '保存中' : '保存'}
+        </LoadingButton>
+      </div>
+    </form>
+  );
+};

--- a/genai-web/packages/web/src/open-genai/settings/schema.ts
+++ b/genai-web/packages/web/src/open-genai/settings/schema.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+export const profileSchema = z.object({
+  lastName: z.string().trim().max(100, '姓は100文字以内で入力してください'),
+  firstName: z.string().trim().max(100, '名は100文字以内で入力してください'),
+});
+
+export type ProfileSchema = z.infer<typeof profileSchema>;
+
+export const passwordSchema = z
+  .object({
+    currentPassword: z.string().min(1, '現在のパスワードを入力してください'),
+    newPassword: z.string().min(8, '新しいパスワードは8文字以上で入力してください'),
+    confirmPassword: z.string().min(1, '確認用のパスワードを入力してください'),
+  })
+  .refine((v) => v.newPassword === v.confirmPassword, {
+    path: ['confirmPassword'],
+    message: '新しいパスワードが一致しません',
+  });
+
+export type PasswordSchema = z.infer<typeof passwordSchema>;

--- a/genai-web/packages/web/src/open-genai/settings/types.ts
+++ b/genai-web/packages/web/src/open-genai/settings/types.ts
@@ -1,0 +1,7 @@
+export type MyProfile = {
+  username: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  displayName: string;
+};

--- a/genai-web/packages/web/src/open-genai/settings/useMyProfile.ts
+++ b/genai-web/packages/web/src/open-genai/settings/useMyProfile.ts
@@ -1,0 +1,21 @@
+import useSWR from 'swr';
+import { teamApiFetcher } from '@/lib/fetcher';
+import type { MyProfile } from './types';
+
+/**
+ * ログイン中ユーザー自身のプロフィール（姓名・表示名）を取得する。
+ *
+ * ヘッダー等で表示名を出すために使うため、未認証時やサービス未起動時は
+ * 例外で画面を壊さないよう `enabled` で抑止し、リトライも行わない。
+ */
+export const useMyProfile = (enabled = true) => {
+  const { data, error, isLoading, mutate } = useSWR<MyProfile>(
+    enabled ? 'my/profile' : null,
+    teamApiFetcher,
+    {
+      revalidateOnFocus: false,
+      shouldRetryOnError: false,
+    },
+  );
+  return { profile: data, error, isLoading, mutate };
+};

--- a/genai-web/packages/web/src/routes.tsx
+++ b/genai-web/packages/web/src/routes.tsx
@@ -8,7 +8,6 @@ import { GenerateDiagramPage } from '@/features/generate-diagram/GenerateDiagram
 import { GenerateImagePage } from '@/features/generate-image/GenerateImagePage';
 import { GenerateTextPage } from '@/features/generate-text/GenerateTextPage';
 import { LandingPage } from '@/features/landing/LandingPage';
-import { KnowledgePage } from '@/open-genai/knowledge/KnowledgePage';
 import { TeamAppCopyPage } from '@/features/team-apps/copy/TeamAppCopyPage';
 import { TeamAppCreatePage } from '@/features/team-apps/create/TeamAppCreatePage';
 import { TeamAppEditPage } from '@/features/team-apps/edit/TeamAppEditPage';
@@ -21,6 +20,7 @@ import { TeamEditPage } from '@/features/teams/edit/TeamEditPage';
 import { TeamsPage } from '@/features/teams/TeamsPage';
 import { TranslatePage } from '@/features/translate/TranslatePage';
 import { WHISPER_EXAPP_PATH } from '@/layout/navItems';
+import { NotFound } from '@/NotFound';
 import { AuditLogsPage } from '@/open-genai/admin-audit/AuditLogsPage';
 import { ModelPolicyPage } from '@/open-genai/admin-modelpolicy/ModelPolicyPage';
 import { NgWordPage } from '@/open-genai/admin-ngword/NgWordPage';
@@ -30,6 +30,7 @@ import { ChoseiEventPage } from '@/open-genai/chosei/ChoseiEventPage';
 import { ChoseiPage } from '@/open-genai/chosei/ChoseiPage';
 import { DoccheckPage } from '@/open-genai/doccheck/DoccheckPage';
 import { DocmakerPage } from '@/open-genai/docmaker/DocmakerPage';
+import { KnowledgePage } from '@/open-genai/knowledge/KnowledgePage';
 import { PatchformApplicationPage } from '@/open-genai/patchform/PatchformApplicationPage';
 import { PatchformApplyPage } from '@/open-genai/patchform/PatchformApplyPage';
 import { PatchformDetailPage } from '@/open-genai/patchform/PatchformDetailPage';
@@ -42,7 +43,7 @@ import { PatchformWizardPage } from '@/open-genai/patchform/PatchformWizardPage'
 import { ProcuretechPage } from '@/open-genai/procuretech/ProcuretechPage';
 import { ProcuretechEditorPage } from '@/open-genai/procuretech-editor/ProcuretechEditorPage';
 import { PromptTemplatesPage } from '@/open-genai/prompt-templates/PromptTemplatesPage';
-import { NotFound } from '@/NotFound';
+import { SettingsPage } from '@/open-genai/settings/SettingsPage';
 import { ApiRequestDataFormatPage } from '@/pages/ApiRequestDataFormat';
 import { isUseCaseEnabled } from '@/utils/isUseCaseEnabled';
 import { Layout } from './layout/Layout';
@@ -141,6 +142,8 @@ export const createRoutes = (): RouteObject[] => {
     { path: 'chat', element: <ChatPage /> },
     { path: 'chat/:chatId', element: <ChatPage /> },
     { path: 'history', element: <ChatHistoryPage /> },
+    // 本人のアカウント設定（表示名・パスワード変更）。
+    { path: 'settings', element: <SettingsPage /> },
     ...optionalUseCaseRoutes.flatMap((routes) => routes ?? []),
     // 源内 /transcribe は Amazon Transcribe 前提。Open GENAI は Whisper exApp へ誘導する。
     { path: 'transcribe', element: <Navigate to={WHISPER_EXAPP_PATH} replace /> },

--- a/usermgmt-app/app/main.py
+++ b/usermgmt-app/app/main.py
@@ -38,6 +38,10 @@ KEYCLOAK_REALM = os.environ.get("KEYCLOAK_REALM", "open-genai")
 KC_ADMIN = os.environ.get("KEYCLOAK_ADMIN", "admin")
 KC_ADMIN_PASSWORD = os.environ.get("KEYCLOAK_ADMIN_PASSWORD", "admin")
 KC_ADMIN_CLIENT = os.environ.get("KEYCLOAK_ADMIN_CLIENT", "admin-cli")
+# 本人パスワード変更時、現行パスワードを検証するための realm 内 OIDC クライアント。
+# Keycloak 既定の admin-cli は各 realm に存在し direct access grants(パスワード付与)が
+# 有効なため、これを使って「現行パスワードが正しいか」を realm に対して確認する。
+KC_PASSWORD_CLIENT = os.environ.get("KEYCLOAK_PASSWORD_VERIFY_CLIENT", "admin-cli")
 
 app = FastAPI(title="Open GENAI User Management App", version="0.1.0")
 
@@ -106,6 +110,24 @@ async def _find_user(client: httpx.AsyncClient, token: str, username: str) -> di
     users = res.json()
     for u in users:
         if u.get("username") == username:
+            return u
+    return users[0] if users else None
+
+
+async def _find_user_by_email(
+    client: httpx.AsyncClient, token: str, email: str
+) -> dict[str, Any] | None:
+    """メール（backend が署名付与する信頼済み x-user-id）で厳密検索する。"""
+    res = await client.get(
+        f"{KEYCLOAK_URL}/admin/realms/{KEYCLOAK_REALM}/users",
+        params={"email": email, "exact": "true"},
+        headers=_auth_headers(token),
+    )
+    res.raise_for_status()
+    users = res.json()
+    target = (email or "").strip().lower()
+    for u in users:
+        if (u.get("email") or "").strip().lower() == target:
             return u
     return users[0] if users else None
 
@@ -509,6 +531,164 @@ async def apply_users_api(request: Request) -> Any:
             status_code=502, content={"error": f"Keycloak への接続/認証に失敗しました: {e}"}
         )
     return {"results": results, "count": len(results)}
+
+
+# ---------------------------------------------------------------------------
+# 本人向け（自己サービス）エンドポイント
+#
+# 一般利用者が自分自身のプロフィール（姓名）とパスワードを変更できるようにする。
+# 管理者権限は不要だが、対象ユーザーは backend が署名付与する x-user-id（メール）
+# から厳密に解決し、リクエスト本文の指定は信用しない（他人のなりすまし防止）。
+# ---------------------------------------------------------------------------
+def _verify_self(request: Request) -> tuple[JSONResponse | None, str]:
+    """内部署名を検証し、対象ユーザーのメール（x-user-id）を返す。管理者権限は不要。"""
+    h = request.headers
+    err = _check_key(h.get("x-api-key"))
+    if err:
+        return err, ""
+    if not intauth.verify(
+        h.get("x-user-id"),
+        h.get("x-user-groups"),
+        h.get("x-scope"),
+        h.get("x-user-ts"),
+        h.get("x-user-sig"),
+        h.get("x-user-tags"),
+    ):
+        return JSONResponse(status_code=401, content={"error": "invalid internal signature"}), ""
+    uid = (h.get("x-user-id") or "").strip()
+    if not uid:
+        return JSONResponse(status_code=401, content={"error": "unauthorized"}), ""
+    return None, uid
+
+
+def _display_name(user: dict[str, Any]) -> str:
+    """姓 名（firstName/lastName）から表示名を組み立てる。未設定なら username に退避。"""
+    first = (user.get("firstName") or "").strip()
+    last = (user.get("lastName") or "").strip()
+    joined = " ".join(x for x in [last, first] if x)
+    return joined or (user.get("username") or "").strip() or (user.get("email") or "").strip()
+
+
+def _profile_payload(user: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "username": user.get("username") or "",
+        "email": user.get("email") or "",
+        "firstName": (user.get("firstName") or "").strip(),
+        "lastName": (user.get("lastName") or "").strip(),
+        "displayName": _display_name(user),
+    }
+
+
+@app.get("/me/profile")
+async def get_me_profile(request: Request) -> Any:
+    err, email = _verify_self(request)
+    if err:
+        return err
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            token = await _admin_token(client)
+            user = await _find_user_by_email(client, token, email)
+    except Exception as e:  # noqa: BLE001
+        return JSONResponse(
+            status_code=502, content={"error": f"Keycloak への接続/認証に失敗しました: {e}"}
+        )
+    if not user:
+        return JSONResponse(status_code=404, content={"error": "ユーザーが見つかりません"})
+    return _profile_payload(user)
+
+
+@app.put("/me/profile")
+async def update_me_profile(request: Request) -> Any:
+    err, email = _verify_self(request)
+    if err:
+        return err
+    body = await request.json()
+    first = (body.get("firstName") or "").strip()
+    last = (body.get("lastName") or "").strip()
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            token = await _admin_token(client)
+            user = await _find_user_by_email(client, token, email)
+            if not user:
+                return JSONResponse(status_code=404, content={"error": "ユーザーが見つかりません"})
+            rep = {"firstName": first, "lastName": last}
+            r = await client.put(
+                f"{KEYCLOAK_URL}/admin/realms/{KEYCLOAK_REALM}/users/{user['id']}",
+                json=rep,
+                headers=_auth_headers(token),
+            )
+            if r.status_code not in (200, 204):
+                return JSONResponse(
+                    status_code=502, content={"error": f"プロフィール更新に失敗しました HTTP {r.status_code}"}
+                )
+            user = {**user, "firstName": first, "lastName": last}
+    except Exception as e:  # noqa: BLE001
+        return JSONResponse(
+            status_code=502, content={"error": f"Keycloak への接続/認証に失敗しました: {e}"}
+        )
+    return {"ok": True, **_profile_payload(user)}
+
+
+async def _verify_current_password(
+    client: httpx.AsyncClient, username: str, password: str
+) -> bool:
+    """realm 内クライアント(既定 admin-cli)へのパスワード付与で現行パスワードを検証する。"""
+    try:
+        res = await client.post(
+            f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/token",
+            data={
+                "grant_type": "password",
+                "client_id": KC_PASSWORD_CLIENT,
+                "username": username,
+                "password": password,
+            },
+        )
+    except httpx.HTTPError:
+        return False
+    return res.status_code == 200
+
+
+@app.post("/me/password")
+async def change_me_password(request: Request) -> Any:
+    err, email = _verify_self(request)
+    if err:
+        return err
+    body = await request.json()
+    current = body.get("currentPassword") or ""
+    new_password = body.get("newPassword") or ""
+    if len(new_password) < 8:
+        return JSONResponse(
+            status_code=400, content={"error": "新しいパスワードは8文字以上にしてください"}
+        )
+    if not current:
+        return JSONResponse(
+            status_code=400, content={"error": "現在のパスワードを入力してください"}
+        )
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            token = await _admin_token(client)
+            user = await _find_user_by_email(client, token, email)
+            if not user:
+                return JSONResponse(status_code=404, content={"error": "ユーザーが見つかりません"})
+            username = user.get("username") or ""
+            if not await _verify_current_password(client, username, current):
+                return JSONResponse(
+                    status_code=400, content={"error": "現在のパスワードが正しくありません"}
+                )
+            r = await client.put(
+                f"{KEYCLOAK_URL}/admin/realms/{KEYCLOAK_REALM}/users/{user['id']}/reset-password",
+                json={"type": "password", "value": new_password, "temporary": False},
+                headers=_auth_headers(token),
+            )
+            if r.status_code not in (200, 204):
+                return JSONResponse(
+                    status_code=502, content={"error": f"パスワード更新に失敗しました HTTP {r.status_code}"}
+                )
+    except Exception as e:  # noqa: BLE001
+        return JSONResponse(
+            status_code=502, content={"error": f"Keycloak への接続/認証に失敗しました: {e}"}
+        )
+    return {"ok": True}
 
 
 @app.post("/invoke")


### PR DESCRIPTION
## 概要
ログインユーザー自身が **表示名（姓名）** と **パスワード** を変更できる自己サービス機能を追加します。併せて、ヘッダー等のユーザー表示を **ログイン名 → 表示名（姓名）** に変更します。

## 変更点
### フロントエンド
- 右上メニュー・モバイルメニューに **「アカウント設定」** 導線を追加
- 専用ページ `/settings`（`open-genai/settings/`）を新設
  - プロフィール: 姓・名の編集（ログインID/メールは参照表示）
  - パスワード変更: 現在のパスワード検証＋確認欄＋8文字以上バリデーション
- ヘッダー/モバイルのユーザー表示名を Keycloak の姓名（`firstName`/`lastName`）に変更。取得失敗時はログイン名にフォールバック

### バックエンド（Keycloak 連携は usermgmt-app に集約）
- `usermgmt-app`: 本人スコープの `GET/PUT /me/profile`・`POST /me/password` を追加
  - 対象ユーザーは backend が署名付与する `x-user-id`（メール）から厳密解決し、本文指定は信用しない
  - 現行パスワードは realm 内 OIDC クライアント（既定 `admin-cli`）へのパスワード付与で検証
- `backend`: 非管理者プロキシ `/my/profile`・`/my/password` と自己用署名ヘッダを追加

### 設定・ドキュメント
- `docker-compose.yml` / `.env.example`: `KEYCLOAK_PASSWORD_VERIFY_CLIENT`（既定 `admin-cli`）を追加
- `CHANGELOG.md`: 追記

## 検証
- `tsc --noEmit` / `biome check` / `py_compile` OK
- 再ビルド後、usermgmt-app `/health` OK、backend `/api/my/profile`（未認証）→ 401 を確認
- フロントの既存失敗テスト（`useLocalStorage` 等）は本変更前から失敗しており本 PR とは無関係

## 注意点
- 開発用 Keycloak は `--import-realm ... OVERWRITE_EXISTING` のため、Keycloak 再起動時に実行時のパスワード変更がリセットされます（本番＝再インポートなしでは永続）
- 現行パスワード検証は Keycloak 既定の `admin-cli`（direct access grants 有効）を利用。専用クライアントを使う場合は `KEYCLOAK_PASSWORD_VERIFY_CLIENT` で差し替え可能

Made with [Cursor](https://cursor.com)