### PR TITLE
v0.9.0 リリース（提案実装 第3弾：Markdown エディタ＋各種文書作成）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 | [v0.6.0](https://github.com/hirokawaguchi/open-genai/releases/tag/v0.6.0) | `340e88e` | 添付・ナレッジの個人情報検知、ナレッジ専用ページ、チャット大容量添付、Dify エラー分類、OSS ガバナンス整備 |
 | [v0.7.0](https://github.com/hirokawaguchi/open-genai/releases/tag/v0.7.0) | `d7ae61e` | 提案実装：書類読取とチェック・日程調整（chosei）・様式 Excel 文書生成（自治体の「あったらいいな」を AI で実現） |
 | [v0.8.0](https://github.com/hirokawaguchi/open-genai/releases/tag/v0.8.0) | `b1943d1` 以降 | 提案実装（第2弾）：オンラインフォーム（patchform）／手続き（申請束）・申請受付／マイ手続き（docmaker）／手続き MCP |
+| [v0.9.0](https://github.com/hirokawaguchi/open-genai/releases/tag/v0.9.0) | `d48cb96` 以降 | 提案実装（第3弾）：Markdown エディタ＋オプションの各種文書作成（調達仕様書・セキュリティポリシー/実施手順・業務マニュアル・アクションプラン等を AI 対話で作成。生成 API はプラガブル＝契約は OSS 公開・生成ロジックは非公開アプリに閉じ込め可能） |
 
 ## 設計思想の転換（0.1 → 0.2）
 
@@ -31,6 +32,32 @@
 ---
 
 ## [Unreleased]
+
+## [0.9.0] - 2026-09-04
+
+このリリースのテーマは前回・前々回に続く **「提案実装」**（第3弾）。今回の主役は、
+ブラウザ完結の **Markdown エディタ** と、その上に載る **オプションの各種文書作成** です。
+「AI と対話しながら実務文書を仕上げ、最後は Word（一部 Excel）へ書き出す」までを
+1 つの流れとして通しました。**調達仕様書**のほか、**セキュリティポリシー及び実施手順**・
+**業務マニュアル**・**計画のアクションプラン**……といった文書を、テーマを選んで
+ヒアリングシートから章別ドラフトを生成し、編集・AI 加筆／要約／整形し、図（Mermaid）や
+画像を差し込み、出力ファイルへ章を並べて合成できます。
+
+要点は **「文書の種類（テーマ）ごとに専用の生成アプリを差し替えられる」構造** です。
+生成ロジック（テンプレート＋LLM/Dify プロンプト）そのものは業務ノウハウを含むため
+**非公開の専用アプリに閉じ込められます**（OSS として公開しない運用が可能）。一方で、
+それらを **追加するためのインターフェース（テーマ↔ヒアリングシート↔生成/合成 API の契約）は
+OSS として公開** しているため、利用者は同じ契約を満たす **自前の文書作成アプリ** を足すだけで、
+エディタから使えるようになります。公開リポジトリには契約を満たす **汎用リファレンス実装
+`procuretech-generate-app`**（LLM/Dify なしで生成〜Word 合成〜様式配布まで一通り動く）と、
+**調達仕様書の参考実装 `procuretech-spec-app`** を同梱しています。
+
+いずれも既定では無効（opt-in の Compose `profiles`）で、既存環境への影響はありません。
+併せて、本人によるアカウント設定（表示名・パスワード変更）やアプリ名・説明の一元化などの
+改善も取り込んでいます。仕様の詳細は [`docs/procuretech-editor.md`](docs/procuretech-editor.md) /
+[`docs/procuretech-generate-contract.md`](docs/procuretech-generate-contract.md) を参照してください。
+
+---
 
 - 情報化企画書エディタ（procuretech-editor）を追加。案件フォルダ（プロジェクト）内の生成文書（Markdown）をブラウザで編集・保存し、出力ファイルごとに章を並べて Word 文書へ合成できる専用ページ（`/procuretech-editor`）。ファイル本体は SeaweedFS（S3 互換）に保存、メタデータは SQLite で管理。ファイル管理（新規/アップロード/リネーム/複製/削除）、分割プレビュー、スクロール連動に対応。Compose profile `procuretech-editor` でオプション起動（詳細は `docs/procuretech-editor.md`）
   - 画像の埋め込みに対応。ツールバーの画像ボタンからローカル画像を案件フォルダ（`images/`）へアップロードし、相対パスで本文へ埋め込む。保存内容は相対パスのまま保持し、プレビュー時のみ presigned URL に差し替えて表示（書き出し zip にも画像が含まれるため Word 変換側でも解決可能）
@@ -516,7 +543,9 @@ Dify エラー分類の改善に加え、公式リポジトリとしてのガバ
 
 ---
 
-[Unreleased]: https://github.com/hirokawaguchi/open-genai/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/hirokawaguchi/open-genai/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/hirokawaguchi/open-genai/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/hirokawaguchi/open-genai/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/hirokawaguchi/open-genai/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/hirokawaguchi/open-genai/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/hirokawaguchi/open-genai/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open GENAI
 
-![Version](https://img.shields.io/badge/version-0.8.0-blue)
+![Version](https://img.shields.io/badge/version-0.9.0-blue)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 ![LLM](https://img.shields.io/badge/LLM-Ollama%20%2F%20OpenAI--compatible-0a7)
 ![Stack](https://img.shields.io/badge/stack-FastAPI%20%7C%20React%20%7C%20Qdrant%20%7C%20Keycloak-success)
@@ -10,7 +10,7 @@
 デジタル庁がオープンソースで公開したガバメント AI「源内（GENAI）」を、
 **完全ローカル環境 × ローカル LLM（OpenAI 互換 API）** で動かすためのプロジェクトです。
 
-> **バージョン:** 現在 **v0.8.0**（提案実装 第2弾：オンラインフォーム（patchform）／手続き（申請束）・申請受付／マイ手続き（docmaker）／手続き MCP。いずれもオプション profile）。v0.7.0 = 提案実装（書類読取とチェック・日程調整・様式 Excel 文書生成）、v0.6.0 = 添付・ナレッジの個人情報検知／ナレッジ専用ページ／チャット大容量添付の mapreduce／Dify エラー分類、v0.5.0 = 本番静的ビルド/デプロイ整備・複数LLM/埋め込み/画像モデルの差し替え・SAML/認証堅牢化、v0.4.0 = 構造化 RAG・ナレッジ MCP・Dify 連携事例・マイナンバー検査、v0.3.x = 出典表示・画像生成一本化等、v0.2.x = 自治体・閉域向け拡張、v0.1.0 = ローカル源内化の第一段階。
+> **バージョン:** 現在 **v0.9.0**（提案実装 第3弾：Markdown エディタ＋オプションの各種文書作成。調達仕様書・セキュリティポリシー/実施手順・業務マニュアル・アクションプラン等を AI 対話で作成でき、生成 API はプラガブル＝契約は OSS 公開・生成ロジックは非公開アプリに閉じ込め可能。いずれもオプション profile）。v0.8.0 = 提案実装 第2弾：オンラインフォーム（patchform）／手続き（申請束）・申請受付／マイ手続き（docmaker）／手続き MCP、v0.7.0 = 提案実装（書類読取とチェック・日程調整・様式 Excel 文書生成）、v0.6.0 = 添付・ナレッジの個人情報検知／ナレッジ専用ページ／チャット大容量添付の mapreduce／Dify エラー分類、v0.5.0 = 本番静的ビルド/デプロイ整備・複数LLM/埋め込み/画像モデルの差し替え・SAML/認証堅牢化、v0.4.0 = 構造化 RAG・ナレッジ MCP・Dify 連携事例・マイナンバー検査、v0.3.x = 出典表示・画像生成一本化等、v0.2.x = 自治体・閉域向け拡張、v0.1.0 = ローカル源内化の第一段階。
 > 変更履歴は [CHANGELOG.md](CHANGELOG.md) を参照。
 
 > **免責 / Disclaimer**: 本リポジトリは有志による**非公式フォーク**です。デジタル庁とは一切関係がなく、
@@ -40,7 +40,7 @@ Linux + NVIDIA GPU 機（例: **NVIDIA DGX Spark**）でも動作します。
 
 本番は `docker-compose.prod.yml` で TLS(443) 終端。閉域検証は HTTP(80) のみ（`docker-compose.verify.yml`）。SeaweedFS（8333）は本番 compose ではホスト非公開で、成果物のダウンロードは `S3_PUBLIC_ENDPOINT` 経由のリバースプロキシを別途用意します（詳細は「成果物ファイル」節）。
 
-> **変更履歴:** [CHANGELOG.md](CHANGELOG.md)（**v0.8.0** = 提案実装 第2弾：オンラインフォーム（patchform）・手続き（申請束）・申請受付・マイ手続き（docmaker）・手続き MCP、**v0.7.0** = 提案実装：書類読取とチェック・日程調整・様式 Excel 文書生成、**v0.6.0** = PII 検知・ナレッジ専用ページ・大容量添付 mapreduce 等、**v0.5.0** = 本番静的ビルド/デプロイ整備・複数LLM/埋め込み/画像モデル差し替え・SAML/認証堅牢化、**v0.4.0** = 構造化 RAG・ナレッジ MCP・Dify 連携事例・マイナンバー検査、それ以前は CHANGELOG 参照）
+> **変更履歴:** [CHANGELOG.md](CHANGELOG.md)（**v0.9.0** = 提案実装 第3弾：Markdown エディタ＋オプションの各種文書作成（生成 API はプラガブル・契約は OSS 公開）、**v0.8.0** = 提案実装 第2弾：オンラインフォーム（patchform）・手続き（申請束）・申請受付・マイ手続き（docmaker）・手続き MCP、**v0.7.0** = 提案実装：書類読取とチェック・日程調整・様式 Excel 文書生成、**v0.6.0** = PII 検知・ナレッジ専用ページ・大容量添付 mapreduce 等、**v0.5.0** = 本番静的ビルド/デプロイ整備・複数LLM/埋め込み/画像モデル差し替え・SAML/認証堅牢化、**v0.4.0** = 構造化 RAG・ナレッジ MCP・Dify 連携事例・マイナンバー検査、それ以前は CHANGELOG 参照）
 
 ## 設計思想：自治体・閉域運用への拡張
 
@@ -61,7 +61,7 @@ Linux + NVIDIA GPU 機（例: **NVIDIA DGX Spark**）でも動作します。
 
 ### 4 つの柱
 
-1. **自治体実務を想定した機能** — 監査ログ（3 年以上保持）、利用者 CSV 一括管理、モデル利用制御、禁止語／個人情報検知（添付警告・ナレッジラベル、任意の GiNZA NER）、プロンプトテンプレート、日程調整（オプション profile）、書類領域分割チェック（オプション profile）、オンライン申請フォーム・手続き（申請束）・マイ手続き（オプション profile）、契約終了時の完全削除と報告書生成
+1. **自治体実務を想定した機能** — 監査ログ（3 年以上保持）、利用者 CSV 一括管理、モデル利用制御、禁止語／個人情報検知（添付警告・ナレッジラベル、任意の GiNZA NER）、プロンプトテンプレート、日程調整（オプション profile）、書類領域分割チェック（オプション profile）、オンライン申請フォーム・手続き（申請束）・マイ手続き（オプション profile）、Markdown エディタ＋各種文書作成（調達仕様書・セキュリティポリシー/実施手順・業務マニュアル・アクションプラン等を AI 対話で。生成 API はプラガブル、オプション profile）、契約終了時の完全削除と報告書生成
 2. **チーム主体・複数所属** — 親子階層のないフラットなチーム。利用者は複数チームに所属可能。AI アプリ・RAG ナレッジ・保存プロンプトの共有は **所属チーム** を軸に制御
 3. **源内 UI 制約の opt-in 拡張** — Form Spec v1（条件表示・リアクティブフォーム・プレビュー）、`dynamic_schema` による動的フォーム、各画面の折りたたみヘルプ。既存 exApp は無改修で従来どおり動作
 4. **成果物のオブジェクトストレージ** — AI アプリ（Dify 等）が生成したファイルを SeaweedFS に保存し、backend 経由で署名付き URL を提示
@@ -86,6 +86,10 @@ Linux + NVIDIA GPU 機（例: **NVIDIA DGX Spark**）でも動作します。
 | `doccheck-app/` | 書類領域分割チェック（オプション・`profiles: ["doccheck"]`。詳細は [`docs/doccheck.md`](docs/doccheck.md)） |
 | `patchform-app/` | フォーム（オプション・`profiles: ["patchform"]`。詳細は [`docs/patchform.md`](docs/patchform.md)） |
 | `procedure-mcp/` | 手続きマスタ MCP（`profiles: ["patchform"]`。公開済みのみ。詳細は [`docs/procedure-mcp.md`](docs/procedure-mcp.md)） |
+| `procuretech-navigator-app/` | 情報化企画書ナビ（オプション・`profiles: ["procuretech"]`。詳細は [`docs/procuretech.md`](docs/procuretech.md)） |
+| `procuretech-editor-app/` | Markdown エディタ＋各種文書作成（オプション・`profiles: ["procuretech-editor"]`。詳細は [`docs/procuretech-editor.md`](docs/procuretech-editor.md)） |
+| `procuretech-generate-app/` | 文書生成/合成の公開・汎用リファレンス実装（`procuretech-editor` プロファイルで同時起動・既定の合成バックエンド。契約は [`docs/procuretech-generate-contract.md`](docs/procuretech-generate-contract.md)） |
+| `procuretech-spec-app/` | 調達仕様書の生成/合成（オプション・`profiles: ["procuretech-spec"]`） |
 | `seaweedfs/` | 成果物配信用 S3 互換ストレージ設定 |
 | `scripts/` | 運用スクリプト（契約終了時の完全削除・報告書生成 等） |
 | `docs/` | Open GENAI レイヤのガイド（[ナレッジ API](docs/knowledge-api.md) / [MCP](docs/knowledge-mcp.md) / [Dify 事例](docs/dify-knowledge.md) / [DGX Spark](docs/spark.md)） |


### PR DESCRIPTION
## 概要
**v0.9.0** リリース準備（ドキュメント更新）。テーマは前回・前々回に続く **「提案実装」**（第3弾）。主役は **Markdown エディタ** と、その上に載る **オプションの各種文書作成**（調達仕様書・セキュリティポリシー/実施手順・業務マニュアル・アクションプラン等を AI 対話で作成）。生成 API は **プラガブル**（契約は OSS 公開・生成ロジックは非公開アプリに閉じ込め可能）。

## 変更
- `CHANGELOG.md`
  - トップ表に **v0.9.0** 行を追加
  - `## [Unreleased]` の内容を `## [0.9.0] - 2026-09-04` へ確定（テーマ物語文を追加、空の `[Unreleased]` を新設）
  - 末尾リンクを整備（`Unreleased` を `v0.9.0...HEAD` に、`[0.9.0]` / 欠落していた `[0.8.0]` を追加）
- `README.md`
  - バージョンバッジ `0.9.0`
  - 版・変更履歴の記述を更新
  - 機能一覧に「Markdown エディタ＋各種文書作成」を追記
  - ディレクトリ表に `procuretech-navigator-app` / `procuretech-editor-app` / `procuretech-generate-app` / `procuretech-spec-app` を追記

## リリース手順（マージ後）
1. main を最新化
2. `v0.9.0` タグ付与・push
3. GitHub Release 作成（CHANGELOG の 0.9.0 セクションを本文に）

ドキュメントのみの変更です。

Made with [Cursor](https://cursor.com)