### PR TITLE
feat(procuretech-editor): 書き出し形式を html / pptx / txt / md に広げる

### DIFF
--- a/docs/procuretech-generate-contract.md
+++ b/docs/procuretech-generate-contract.md
@@ -24,7 +24,7 @@
 | `GET  {base_url}/waiting/{request_id}` | 生成ジョブの待ち画像（任意。`image/png`） |
 | `POST {base_url}/waiting-picture` | 書き出し待ち用の画像（任意。`image/png`） |
 | `GET  {base_url}/result/{request_id}` | 生成結果 zip の取得 |
-| `POST {base_url}/compose` | 順序付き Markdown を Word(`.docx`) に合成し zip で返す |
+| `POST {base_url}/compose` | 順序付き Markdown を指定形式（既定 `.docx`）に合成し zip で返す |
 | `POST {base_url}/excel` | 書き出し時に、その時点の章 Markdown＋保存パラメータから Excel を生成（任意実装） |
 | `GET  {base_url}/template/{input_key}` | 入力（ヒアリングシート）の様式ファイルを配信（任意実装） |
 
@@ -81,6 +81,7 @@
   "outputs": [
     {
       "name": "調達仕様書",
+      "format": "docx",
       "sections": [
         { "filename": "section1.md", "content": "# 背景\n...\n![図](images/zu1.png)" },
         { "filename": "section2.md", "content": "# 目的\n..." }
@@ -95,16 +96,20 @@
 ```
 
 - `outputs[].sections` は**呼び出し元で解決済みの本文を順序どおり**に並べたもの。
-  生成側はこれを連結して `.docx` に変換します（本番は pandoc、実装サンプルは python-docx を使用）。
-- `reference` は任意（Word のスタイル参照ドキュメントの種別など）。
-- `assets` は任意。本文が参照する**画像を `{相対パス: base64}`** で渡す。生成側は本文と
-  同じ相対パスに画像を配置してから変換することで、Word へ画像を埋め込む
-  （pandoc は入力 Markdown と同じディレクトリを `--resource-path` に含めて解決する）。
+- `outputs[].format` は任意。`docx`（既定）/ `html` / `pptx` / `txt` / `md`。
+  省略時は従来どおり `.docx`。未対応の形式は `422` `{"error": "…"}`（その出力は呼び出し元がスキップする）。
+- 生成側は連結した Markdown を指定形式へ変換する。
+  - **docx**: テーマ固有サービス（例: spec-app / pandoc）またはリファレンス実装（python-docx）。
+  - **html / pptx / txt / md**: 公開リファレンス実装 `procuretech-generate-app` が担う。
+    エディタは docx をテーマの `/compose` へ、それ以外を `EDITOR_COMPOSE_URL` へ振り分ける。
+- `reference` は任意（Word のスタイル参照ドキュメントの種別など）。docx 以外では無視してよい。
+- `assets` は任意。本文が参照する**画像を `{相対パス: base64}`** で渡す。視覚形式（docx / html / pptx）では
+  画像を埋め込む。html は data URI で単一ファイルにする。md / txt は画像を埋め込まない。
   相対パスは Markdown の画像記法 `![alt](相対パス)` と一致させること。
   **Mermaid 図はコードのままでは画像化されない**ため、呼び出し元（エディタ）が
-  合成前に PNG 画像へ変換して `assets` に載せ、本文の ```` ```mermaid ```` ブロックを
-  画像参照へ差し替えてから送る。
-- 応答: `application/zip`。出力ファイルごとに `<name>.docx` を格納。
+  視覚形式の合成前に PNG 画像へ変換して `assets` に載せ、本文の ```` ```mermaid ```` ブロックを
+  画像参照へ差し替えてから送る。md / txt では Mermaid をコードのまま残す。
+- 応答: `application/zip`。出力ファイルごとに `<name>.<format>` を格納。
 
 ### POST /excel
 

--- a/genai-web/packages/web/src/open-genai/procuretech-editor/ProcuretechEditorPage.tsx
+++ b/genai-web/packages/web/src/open-genai/procuretech-editor/ProcuretechEditorPage.tsx
@@ -48,13 +48,17 @@ import { findModelByModelId, resolveSelectedModelId } from '@/models';
 import { getPrompter } from '@/prompts';
 import {
   baseName,
+  composeFormatOf,
+  EDITOR_COMPOSE_FORMATS,
   extractImageSources,
   fileToBase64,
   formatBytes,
+  isVisualComposeFormat,
   rewriteImageSources,
   triggerDownload,
 } from './format';
 import type {
+  EditorComposeFormat,
   EditorComposeResult,
   EditorComposition,
   EditorCompositionItem,
@@ -440,6 +444,7 @@ const CompositionEditor = ({ projectId }: { projectId: string }) => {
   const [outputs, setOutputs] = useState<EditorCompositionOutput[]>([]);
   const [dirty, setDirty] = useState(false);
   const [newOutputName, setNewOutputName] = useState('');
+  const [newOutputFormat, setNewOutputFormat] = useState<EditorComposeFormat>('docx');
   const [savedNotice, setSavedNotice] = useState(false);
   const [carrierLoading, setCarrierLoading] = useState(false);
   const [compose, setCompose] = useState<ComposeUiState>({ phase: 'idle' });
@@ -594,9 +599,12 @@ const CompositionEditor = ({ projectId }: { projectId: string }) => {
   const addOutput = useCallback(() => {
     const name = newOutputName.trim();
     if (!name) return;
-    update([...outputs, { id: `output-${Date.now()}`, name, enabled: true, items: [] }]);
+    update([
+      ...outputs,
+      { id: `output-${Date.now()}`, name, format: newOutputFormat, enabled: true, items: [] },
+    ]);
     setNewOutputName('');
-  }, [newOutputName, outputs, update]);
+  }, [newOutputFormat, newOutputName, outputs, update]);
 
   const removeOutput = useCallback(
     (oi: number) => update(outputs.filter((_, i) => i !== oi)),
@@ -627,6 +635,7 @@ const CompositionEditor = ({ projectId }: { projectId: string }) => {
     const targets = new Map<string, string>(); // file id -> rel_path
     for (const o of outputs) {
       if (o.enabled === false || o.kind === 'excel') continue;
+      if (!isVisualComposeFormat(composeFormatOf(o))) continue;
       for (const it of o.items) {
         const f = it.section_key
           ? fileByKey[it.section_key]
@@ -723,12 +732,12 @@ const CompositionEditor = ({ projectId }: { projectId: string }) => {
       <div className='rounded-8 border border-solid-gray-300 p-4'>
         <h2 className='text-std-18B-160 text-solid-gray-900'>文書の書き出し・合成</h2>
         <p className='mt-1 text-dns-14N-130 text-solid-gray-600'>
-          出力ファイル（Word形式）に含めたいMarkdownファイルを順番に追加します。
+          出力ファイルに含めたい Markdown ファイルを順番に追加し、形式を選びます。
           {theme?.label ? `（テーマ: ${theme.label}）` : ''}
         </p>
         {!composeConfigured && (
           <p className='mt-2 rounded-8 border border-amber-300 bg-amber-50 px-3 py-2 text-dns-14N-130 text-solid-gray-800'>
-            このテーマの Word 合成 API が未設定です。管理者に設定を依頼してください。
+            このテーマの合成 API が未設定です。管理者に設定を依頼してください。
           </p>
         )}
 
@@ -799,7 +808,20 @@ const CompositionEditor = ({ projectId }: { projectId: string }) => {
                     className='min-w-0 flex-1 rounded-6 border border-solid-gray-300 px-2 py-1 text-std-16N-170'
                     placeholder='出力ファイル名'
                   />
-                  <span className='shrink-0 text-dns-14N-130 text-solid-gray-500'>.docx</span>
+                  <select
+                    value={composeFormatOf(out)}
+                    onChange={(e) =>
+                      patchOutput(oi, { format: e.target.value as EditorComposeFormat })
+                    }
+                    className='shrink-0 rounded-6 border border-solid-gray-300 bg-white px-2 py-1 text-dns-14N-130 text-solid-gray-800'
+                    title='出力形式'
+                  >
+                    {EDITOR_COMPOSE_FORMATS.map((fmt) => (
+                      <option key={fmt} value={fmt}>
+                        .{fmt}
+                      </option>
+                    ))}
+                  </select>
                   <button
                     type='button'
                     onClick={() => removeOutput(oi)}
@@ -915,6 +937,18 @@ const CompositionEditor = ({ projectId }: { projectId: string }) => {
             className='w-64 rounded-6 border border-solid-gray-300 px-2 py-1 text-std-16N-170'
             placeholder='出力ファイルを追加（名称）'
           />
+          <select
+            value={newOutputFormat}
+            onChange={(e) => setNewOutputFormat(e.target.value as EditorComposeFormat)}
+            className='shrink-0 rounded-6 border border-solid-gray-300 bg-white px-2 py-1 text-dns-14N-130 text-solid-gray-800'
+            title='出力形式'
+          >
+            {EDITOR_COMPOSE_FORMATS.map((fmt) => (
+              <option key={fmt} value={fmt}>
+                .{fmt}
+              </option>
+            ))}
+          </select>
           <Button type='button' variant='outline' size='sm' onClick={addOutput}>
             <span className='inline-flex items-center gap-1'>
               <PiFilePlus className='size-4' />
@@ -1033,7 +1067,7 @@ export const ProcuretechEditorPage = () => {
   const appTitle = (registryApp?.exAppName || '').trim() || 'Markdown エディタ';
   const appDescription =
     (registryApp?.description || '').trim() ||
-    'プロジェクト内の文書（Markdown）を編集・校正し、Word 文書へ統合する準備を行います。';
+    'プロジェクト内の文書（Markdown）を編集・校正し、Word / HTML などへ書き出します。';
   const { projects, loadError: projectsError, mutate: mutateProjects } = useEditorProjects();
   const [projectId, setProjectId] = useState<string | null>(null);
   const {

--- a/genai-web/packages/web/src/open-genai/procuretech-editor/format.test.ts
+++ b/genai-web/packages/web/src/open-genai/procuretech-editor/format.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { baseName, dirOf, extractImageSources, formatBytes, rewriteImageSources } from './format';
+import {
+  baseName,
+  composeFormatOf,
+  dirOf,
+  extractImageSources,
+  formatBytes,
+  isVisualComposeFormat,
+  rewriteImageSources,
+} from './format';
 
 describe('procuretech-editor/format', () => {
   describe('formatBytes', () => {
@@ -62,6 +70,24 @@ describe('procuretech-editor/format', () => {
     it('外部 URL は書き換えない', () => {
       const md = '![h](https://x/y.png)';
       expect(rewriteImageSources(md, { 'https://x/y.png': 'nope' })).toBe(md);
+    });
+  });
+
+  describe('composeFormatOf', () => {
+    it('未指定は docx', () => {
+      expect(composeFormatOf({})).toBe('docx');
+    });
+    it('指定があればそれを返す', () => {
+      expect(composeFormatOf({ format: 'html' })).toBe('html');
+    });
+  });
+
+  describe('isVisualComposeFormat', () => {
+    it('docx / html / pptx は視覚形式', () => {
+      expect(isVisualComposeFormat('docx')).toBe(true);
+      expect(isVisualComposeFormat('html')).toBe(true);
+      expect(isVisualComposeFormat('md')).toBe(false);
+      expect(isVisualComposeFormat('txt')).toBe(false);
     });
   });
 });

--- a/genai-web/packages/web/src/open-genai/procuretech-editor/format.ts
+++ b/genai-web/packages/web/src/open-genai/procuretech-editor/format.ts
@@ -1,5 +1,27 @@
 // 情報化企画書エディタ用の小さな整形ユーティリティ（テスト対象）。
 
+import type { EditorComposeFormat, EditorCompositionOutput } from './types';
+
+export const EDITOR_COMPOSE_FORMATS: readonly EditorComposeFormat[] = [
+  'docx',
+  'html',
+  'pptx',
+  'txt',
+  'md',
+];
+
+export const EDITOR_VISUAL_FORMATS: readonly EditorComposeFormat[] = ['docx', 'html', 'pptx'];
+
+export const composeFormatOf = (
+  out: Pick<EditorCompositionOutput, 'format'>,
+): EditorComposeFormat =>
+  out.format && (EDITOR_COMPOSE_FORMATS as readonly string[]).includes(out.format)
+    ? out.format
+    : 'docx';
+
+export const isVisualComposeFormat = (fmt: EditorComposeFormat): boolean =>
+  (EDITOR_VISUAL_FORMATS as readonly string[]).includes(fmt);
+
 /** バイト数を人間可読な文字列に整形する（例: 1536 → "1.5 KB"）。 */
 export const formatBytes = (bytes: number): string => {
   if (!Number.isFinite(bytes) || bytes <= 0) {

--- a/genai-web/packages/web/src/open-genai/procuretech-editor/types.ts
+++ b/genai-web/packages/web/src/open-genai/procuretech-editor/types.ts
@@ -73,12 +73,17 @@ export type EditorThemeSection = {
   label: string;
 };
 
+/** Markdown 合成の出力形式（kind=excel は対象外）。省略時は docx。 */
+export type EditorComposeFormat = 'docx' | 'html' | 'pptx' | 'txt' | 'md';
+
 /** テーマ既定の合成定義（出力ファイル毎の順序付き section key リスト）。 */
 export type EditorThemeOutput = {
   id: string;
   name: string;
-  /** markdown: 章を並べて Word 合成 / excel: 書き出し時に章＋パラメータから Excel を生成 */
+  /** markdown: 章を並べて文書合成 / excel: 書き出し時に章＋パラメータから Excel を生成 */
   kind?: 'markdown' | 'excel';
+  /** markdown 出力の形式（docx / html / pptx / txt / md） */
+  format?: EditorComposeFormat;
   /** excel の生成方法（例: quotation=見積総括表 / primaryexam=一次審査表） */
   builder?: string;
   sections: string[];
@@ -109,8 +114,10 @@ export type EditorCompositionItem = {
 export type EditorCompositionOutput = {
   id: string;
   name: string;
-  /** markdown: 章を並べて Word 合成 / excel: 書き出し時に章＋パラメータから Excel を生成 */
+  /** markdown: 章を並べて文書合成 / excel: 書き出し時に章＋パラメータから Excel を生成 */
   kind?: 'markdown' | 'excel';
+  /** markdown 出力の形式（docx / html / pptx / txt / md） */
+  format?: EditorComposeFormat;
   /** excel の生成方法（例: quotation / primaryexam） */
   builder?: string;
   enabled: boolean;

--- a/procuretech-editor-app/app/generate.py
+++ b/procuretech-editor-app/app/generate.py
@@ -53,10 +53,23 @@ TIMEOUT = float(os.environ.get("EDITOR_GENERATE_TIMEOUT", "180"))
 EXCEL_TIMEOUT = float(os.environ.get("EDITOR_EXCEL_TIMEOUT", "900"))
 DEFAULT_DOC_TYPE = os.environ.get("EDITOR_GENERATE_DOC_TYPE", "specification")
 
-# 素の文書（テーマ無し）の Word 合成先。テーマ固有の生成 API（例: 調達仕様書＝spec-app）に
-# 依存させないため、汎用の合成サービス（既定: procuretech-generate-app）へ振り分ける。
+# 素の文書（テーマ無し）および html / pptx / txt / md の合成先。テーマ固有の生成 API
+# （例: 調達仕様書＝spec-app）に依存させないため、汎用の合成サービス
+# （既定: procuretech-generate-app）へ振り分ける。
 EDITOR_COMPOSE_URL = os.environ.get("EDITOR_COMPOSE_URL", "").rstrip("/")
 EDITOR_COMPOSE_API_KEY = os.environ.get("EDITOR_COMPOSE_API_KEY", EDITOR_GENERATE_API_KEY)
+
+# Markdown 合成の出力形式（kind=excel は対象外）。省略時は docx。
+COMPOSE_FORMATS = ("docx", "html", "pptx", "txt", "md")
+VISUAL_COMPOSE_FORMATS = frozenset({"docx", "html", "pptx"})
+GENERIC_COMPOSE_FORMATS = frozenset({"html", "pptx", "txt", "md"})
+
+
+def normalize_compose_format(raw: Any) -> str:
+    """未知・空の形式は docx に落とす。"""
+    fmt = str(raw or "docx").strip().lower().lstrip(".")
+    return fmt if fmt in COMPOSE_FORMATS else "docx"
+
 
 XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
@@ -107,8 +120,8 @@ def _default_theme() -> dict[str, Any]:
             {"key": "other", "label": "その他"},
             {"key": "rfi", "label": "情報提供依頼（RFI）"},
         ],
-        # 合成（Word/Excel 出力）の既定定義。
-        # - kind=markdown: section key を順序付きで並べ、Word(.docx) に合成する。
+        # 合成（文書/Excel 出力）の既定定義。
+        # - kind=markdown: section key を順序付きで並べ、format（既定 docx）に合成する。
         # - kind=excel: 書き出し時に、その時点の Markdown＋保存パラメータから Excel を生成する
         #   （builder が生成方法を示す。quotation=見積総括表、primaryexam=一次審査表）。
         #   ソース章は生成サービス側が決定するため items（section key）は持たない。
@@ -170,8 +183,8 @@ def plain_theme() -> dict[str, Any]:
     """テーマ無し（ヒアリングシート未生成）のプロジェクト向けの素のテーマ。
 
     調達仕様書などテーマ固有の生成 API には送らず、汎用の合成サービス
-    （`EDITOR_COMPOSE_URL`、既定は procuretech-generate-app）で Word 化する。既定の出力は
-    空の Word 1 つのみで、章は利用者が手動の Markdown を追加して構成する。
+    （`EDITOR_COMPOSE_URL`、既定は procuretech-generate-app）で合成する。既定の出力は
+    空の文書 1 つ（format=docx）のみで、章は利用者が手動の Markdown を追加して構成する。
     """
     return {
         "id": PLAIN_THEME_ID,
@@ -222,12 +235,15 @@ def theme_outputs(theme: dict[str, Any]) -> list[dict[str, Any]]:
     for o in theme.get("outputs", []) or []:
         if not isinstance(o, dict) or not o.get("id"):
             continue
+        kind = o.get("kind", "markdown")
         entry: dict[str, Any] = {
             "id": o.get("id"),
             "name": o.get("name", o.get("id")),
-            "kind": o.get("kind", "markdown"),
+            "kind": kind,
             "sections": [str(k) for k in (o.get("sections") or [])],
         }
+        if kind != "excel":
+            entry["format"] = normalize_compose_format(o.get("format"))
         if o.get("builder"):
             entry["builder"] = str(o.get("builder"))
         out.append(entry)
@@ -395,11 +411,10 @@ async def compose(
     reference: str | None = None,
     assets: dict[str, bytes] | None = None,
 ) -> bytes:
-    """順序付き Markdown（出力ファイル毎）を生成サービスへ送り Word(.docx) zip を得る。
+    """順序付き Markdown（出力ファイル毎）を生成サービスへ送り合成 zip を得る。
 
-    outputs = [{"name": str, "sections": [{"filename": str, "content": str}, ...]}, ...]
-    assets  = {相対パス: バイト列}（本文が参照する画像。生成サービス側で同じ相対パスに
-              配置してから pandoc に渡すことで Word へ埋め込まれる）。
+    outputs = [{"name": str, "format"?: str, "sections": [{"filename": str, "content": str}, ...]}, ...]
+    assets  = {相対パス: バイト列}（本文が参照する画像。視覚形式では同じ相対パスで埋め込む）。
     """
     if not base_url:
         raise GenerateError("文書生成 API が未設定です（このテーマの合成先が未設定）。")
@@ -421,9 +436,9 @@ async def compose(
             raise GenerateError(f"外部サービスとの通信に失敗しました: {_httpx_message(e)}") from e
     if res.status_code != 200:
         try:
-            msg = res.json().get("error") or "Word 合成に失敗しました。"
+            msg = res.json().get("error") or "文書の合成に失敗しました。"
         except Exception:  # noqa: BLE001
-            msg = "Word 合成に失敗しました。"
+            msg = "文書の合成に失敗しました。"
         raise GenerateError(msg)
     return res.content
 

--- a/procuretech-editor-app/app/main.py
+++ b/procuretech-editor-app/app/main.py
@@ -1020,7 +1020,7 @@ async def theme_waiting_picture(
     return Response(content=png, media_type="image/png")
 
 
-# --- composition（出力ファイルの合成定義 + Word 合成実行） --------------------
+# --- composition（出力ファイルの合成定義 + 文書合成実行） --------------------
 
 
 def _resolve_theme_for_project(
@@ -1030,7 +1030,7 @@ def _resolve_theme_for_project(
 
     優先順: 明示指定(hint) → 保存済み定義のテーマ → 直近生成ジョブのテーマ。
     いずれも無い（ヒアリングシート未生成の素の）プロジェクトは、テーマ固有の生成 API に
-    依存しない「素のテーマ」を返す（汎用の合成サービスで Word 化する）。
+    依存しない「素のテーマ」を返す（汎用の合成サービスで合成する）。
     """
     theme_id = (
         (hint or "").strip()
@@ -1046,13 +1046,16 @@ def _default_composition(theme: dict[str, Any]) -> dict[str, Any]:
     """テーマ既定から合成定義（出力ファイル毎の順序付き section）を作る。"""
     outputs = []
     for o in generate.theme_outputs(theme):
+        kind = o.get("kind", "markdown")
         entry: dict[str, Any] = {
             "id": o["id"],
             "name": o["name"],
-            "kind": o.get("kind", "markdown"),
+            "kind": kind,
             "enabled": True,
             "items": [{"section_key": k} for k in o.get("sections", [])],
         }
+        if kind != "excel":
+            entry["format"] = generate.normalize_compose_format(o.get("format"))
         if o.get("builder"):
             entry["builder"] = o["builder"]
         outputs.append(entry)
@@ -1084,13 +1087,16 @@ def _normalize_composition(data: Any, theme: dict[str, Any]) -> dict[str, Any]:
             if fid:
                 entry["file_id"] = fid
             items.append(entry)
+        kind = "excel" if str(o.get("kind") or "") == "excel" else "markdown"
         entry = {
             "id": str(o.get("id") or f"output{i}"),
             "name": str(o.get("name") or f"output{i}"),
-            "kind": "excel" if str(o.get("kind") or "") == "excel" else "markdown",
+            "kind": kind,
             "enabled": o.get("enabled", True) is not False,
             "items": items,
         }
+        if kind != "excel":
+            entry["format"] = generate.normalize_compose_format(o.get("format"))
         if o.get("builder"):
             entry["builder"] = str(o.get("builder"))
         outputs.append(entry)
@@ -1323,7 +1329,8 @@ async def _run_compose_job(
             if o.get("builder")
         }
 
-        md_outputs: list[dict[str, Any]] = []
+        theme_md: list[dict[str, Any]] = []
+        generic_md: list[dict[str, Any]] = []
         excel_outputs: list[tuple[str, str]] = []
         excel_files: list[tuple[str, bytes]] = []
         included_names: list[str] = []
@@ -1356,14 +1363,22 @@ async def _run_compose_job(
                     continue
                 excel_outputs.append((name, builder))
             else:
-                sections = _collect_output_sections(o, files_by_key, files_by_id, overrides)
+                fmt = generate.normalize_compose_format(o.get("format"))
+                use_overrides = overrides if fmt in generate.VISUAL_COMPOSE_FORMATS else None
+                sections = _collect_output_sections(o, files_by_key, files_by_id, use_overrides)
                 if not sections:
                     continue
-                md_outputs.append({"name": name, "sections": sections})
+                payload = {"name": name, "format": fmt, "sections": sections}
+                if fmt in generate.GENERIC_COMPOSE_FORMATS:
+                    generic_md.append(payload)
+                else:
+                    theme_md.append(payload)
                 included_names.append(name)
 
         assets: dict[str, bytes] = {}
-        for o in md_outputs:
+        for o in theme_md + generic_md:
+            if o.get("format") not in generate.VISUAL_COMPOSE_FORMATS:
+                continue
             for sec in o["sections"]:
                 for rel in _extract_image_refs(sec.get("content", "")):
                     if rel in assets:
@@ -1375,7 +1390,7 @@ async def _run_compose_job(
                     if data is not None:
                         assets[rel] = data
 
-        if not md_outputs and not excel_outputs:
+        if not theme_md and not generic_md and not excel_outputs:
             store.update_compose_job(
                 request_id,
                 uid,
@@ -1384,7 +1399,34 @@ async def _run_compose_job(
                 current_step="エラー",
             )
             return
-        if (md_outputs or excel_outputs) and not base_url:
+        if generate.EDITOR_COMPOSE_URL:
+            generic_url = generate.EDITOR_COMPOSE_URL
+            generic_key = generate.EDITOR_COMPOSE_API_KEY
+        elif theme_def.get("id") == generate.PLAIN_THEME_ID:
+            generic_url = base_url
+            generic_key = generate.theme_api_key(theme_def)
+        else:
+            generic_url = ""
+            generic_key = ""
+        if theme_md and not base_url:
+            store.update_compose_job(
+                request_id,
+                uid,
+                status="error",
+                error="このテーマの生成 API が未設定です（管理者に確認してください）。",
+                current_step="エラー",
+            )
+            return
+        if generic_md and not generic_url:
+            store.update_compose_job(
+                request_id,
+                uid,
+                status="error",
+                error="汎用の合成サービスが未設定です（管理者に確認してください）。",
+                current_step="エラー",
+            )
+            return
+        if excel_outputs and not base_url:
             store.update_compose_job(
                 request_id,
                 uid,
@@ -1395,28 +1437,40 @@ async def _run_compose_job(
             return
         api_key = generate.theme_api_key(theme_def)
 
-        work_n = (1 if md_outputs else 0) + len(excel_outputs) + 1
+        work_n = (1 if theme_md else 0) + (1 if generic_md else 0) + len(excel_outputs) + 1
         done = 0
 
         def work_progress() -> int:
             return 10 + int(80 * done / max(1, work_n))
 
-        docx_zip: bytes | None = None
-        if md_outputs:
-            names = " / ".join(o["name"] for o in md_outputs)
-            step(work_progress(), f"Word を合成しています（{names}）")
+        compose_zips: list[bytes] = []
+
+        async def _run_compose(batch: list[dict[str, Any]], *, url: str, key: str) -> bool:
+            names = " / ".join(o["name"] for o in batch)
+            step(work_progress(), f"文書を合成しています（{names}）")
             try:
-                docx_zip = await generate.compose(
-                    md_outputs,
-                    base_url=base_url,
-                    api_key=api_key,
-                    reference=str(theme_def.get("doc_type") or ""),
-                    assets=assets or None,
+                compose_zips.append(
+                    await generate.compose(
+                        batch,
+                        base_url=url,
+                        api_key=key,
+                        reference=str(theme_def.get("doc_type") or ""),
+                        assets=assets or None,
+                    )
                 )
             except generate.GenerateError as e:
                 store.update_compose_job(
                     request_id, uid, status="error", error=str(e), current_step="エラー",
                 )
+                return False
+            return True
+
+        if theme_md:
+            if not await _run_compose(theme_md, url=base_url, key=api_key):
+                return
+            done += 1
+        if generic_md:
+            if not await _run_compose(generic_md, url=generic_url, key=generic_key):
                 return
             done += 1
 
@@ -1452,7 +1506,7 @@ async def _run_compose_job(
                     done += 1
                     continue
                 except generate.GenerateError as e:
-                    # Word など他成果物は残し、この Excel だけ外す（Dify 504 等）。
+                    # 他成果物は残し、この Excel だけ外す（Dify 504 等）。
                     skipped.append({"name": name, "reason": str(e)})
                     done += 1
                     continue
@@ -1460,7 +1514,7 @@ async def _run_compose_job(
                 included_names.append(name)
                 done += 1
 
-        if not md_outputs and not excel_files:
+        if not compose_zips and not excel_files:
             detail = (
                 "; ".join(f"{s['name']}: {s['reason']}" for s in skipped) or "対象がありません。"
             )
@@ -1476,9 +1530,9 @@ async def _run_compose_job(
         step(work_progress(), "書き出しファイルを保存しています")
         buf = io.BytesIO()
         with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-            if docx_zip:
+            for composed in compose_zips:
                 try:
-                    with zipfile.ZipFile(io.BytesIO(docx_zip)) as dz:
+                    with zipfile.ZipFile(io.BytesIO(composed)) as dz:
                         for n in dz.namelist():
                             if n.endswith("/"):
                                 continue
@@ -1492,7 +1546,7 @@ async def _run_compose_job(
                         request_id,
                         uid,
                         status="error",
-                        error="Word 合成結果の展開に失敗しました。",
+                        error="合成結果の展開に失敗しました。",
                         current_step="エラー",
                     )
                     return

--- a/procuretech-editor-app/tests/test_api.py
+++ b/procuretech-editor-app/tests/test_api.py
@@ -550,6 +550,7 @@ def test_composition_plain_default_for_empty_project(client):
     outputs = body["composition"]["outputs"]
     assert len(outputs) == 1
     assert outputs[0]["kind"] == "markdown"
+    assert outputs[0]["format"] == "docx"
     assert outputs[0]["items"] == []
     # 調達仕様書テーマの章立て（背景〜その他）が並んでいないこと
     assert outputs[0]["id"] != "specification"
@@ -580,6 +581,7 @@ def test_composition_save_and_get(client, monkeypatch):
     assert got["composition"]["outputs"][0]["name"] == "まとめ"
     keys = [it["section_key"] for it in got["composition"]["outputs"][0]["items"]]
     assert keys == ["businessPurpose", "background"]
+    assert got["composition"]["outputs"][0]["format"] == "docx"
 
 
 def test_compose_assembles_and_returns_url(client, monkeypatch):
@@ -909,3 +911,142 @@ def test_compose_skips_excel_when_generate_fails(client, monkeypatch, _mem_objst
     assert body["status"] == "success"
     assert "調達仕様書" in (body.get("outputs") or [])
     assert any(s["name"] == "一次審査表" for s in body.get("skipped", []))
+
+
+def test_composition_saves_format(client, monkeypatch):
+    p = _create_project(client)
+    _run_generation_with_sections(client, monkeypatch, p["id"])
+    composition = {
+        "theme": "procurement_spec",
+        "outputs": [
+            {
+                "id": "web",
+                "name": "閲覧用",
+                "format": "html",
+                "enabled": True,
+                "items": [{"section_key": "background"}],
+            }
+        ],
+    }
+    put = client.put(
+        f"/projects/{p['id']}/composition",
+        json={"composition": composition},
+        headers=USER_A,
+    )
+    assert put.status_code == 200, put.text
+    got = client.get(f"/projects/{p['id']}/composition", headers=USER_A).json()
+    assert got["composition"]["outputs"][0]["format"] == "html"
+
+
+def test_compose_routes_html_to_generic_url(client, monkeypatch, _mem_objstore):
+    """docx はテーマの /compose、html は EDITOR_COMPOSE_URL へ分ける。"""
+    from app import generate
+
+    p = _create_project(client)
+    _run_generation_with_sections(client, monkeypatch, p["id"])
+    monkeypatch.setattr(generate, "EDITOR_COMPOSE_URL", "http://generic.test")
+    monkeypatch.setattr(generate, "EDITOR_COMPOSE_API_KEY", "generic-key")
+
+    captured: list[dict] = []
+
+    async def fake_compose(outputs, *, base_url, api_key="", reference=None, assets=None):
+        captured.append({"base_url": base_url, "outputs": outputs})
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            for o in outputs:
+                fmt = o.get("format") or "docx"
+                zf.writestr(f"{o['name']}.{fmt}", b"DATA")
+        return buf.getvalue()
+
+    monkeypatch.setattr(generate, "compose", fake_compose)
+
+    async def fake_build_excel(
+        builder, *, base_url, api_key="", params=None, sections=None, on_progress=None
+    ):
+        raise generate.ExcelSkip("テスト: スキップ")
+
+    monkeypatch.setattr(generate, "build_excel", fake_build_excel)
+
+    composition = {
+        "theme": "procurement_spec",
+        "outputs": [
+            {
+                "id": "specification",
+                "name": "調達仕様書",
+                "kind": "markdown",
+                "format": "docx",
+                "enabled": True,
+                "items": [{"section_key": "background"}],
+            },
+            {
+                "id": "web",
+                "name": "閲覧用",
+                "kind": "markdown",
+                "format": "html",
+                "enabled": True,
+                "items": [{"section_key": "background"}],
+            },
+        ],
+    }
+    body = _compose_until_done(client, p["id"], {"composition": composition})
+    assert body["status"] == "success"
+    assert len(captured) == 2
+    by_url = {c["base_url"]: c for c in captured}
+    assert "http://generic.test" in by_url
+    assert generate.EDITOR_GENERATE_URL in by_url or any(
+        c["base_url"] != "http://generic.test" for c in captured
+    )
+    html_batch = next(c for c in captured if c["base_url"] == "http://generic.test")
+    assert html_batch["outputs"][0]["format"] == "html"
+    docx_batch = next(c for c in captured if c["base_url"] != "http://generic.test")
+    assert docx_batch["outputs"][0]["format"] == "docx"
+    key = body["object_key"]
+    with zipfile.ZipFile(io.BytesIO(_mem_objstore[key])) as zf:
+        names = set(zf.namelist())
+        assert "調達仕様書.docx" in names
+        assert "閲覧用.html" in names
+
+
+def test_compose_md_skips_mermaid_overrides(client, monkeypatch):
+    """md 出力には Mermaid 用 overrides を適用しない。"""
+    from app import generate
+
+    p = _create_project(client)
+    _run_generation_with_sections(client, monkeypatch, p["id"])
+    monkeypatch.setattr(generate, "EDITOR_COMPOSE_URL", "http://generic.test")
+
+    files = client.get(f"/projects/{p['id']}/files", headers=USER_A).json()["files"]
+    bg_id = next(f["id"] for f in files if f["rel_path"] == "section1.md")
+
+    captured = {}
+
+    async def fake_compose(outputs, *, base_url, api_key="", reference=None, assets=None):
+        captured["outputs"] = outputs
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            for o in outputs:
+                zf.writestr(f"{o['name']}.md", b"MD")
+        return buf.getvalue()
+
+    monkeypatch.setattr(generate, "compose", fake_compose)
+
+    override = "# 背景\n\n![diagram](images/pic.png)\n"
+    composition = {
+        "theme": "procurement_spec",
+        "outputs": [
+            {
+                "id": "src",
+                "name": "ソース",
+                "kind": "markdown",
+                "format": "md",
+                "enabled": True,
+                "items": [{"section_key": "background"}],
+            }
+        ],
+    }
+    body = _compose_until_done(
+        client, p["id"], {"composition": composition, "overrides": {bg_id: override}}
+    )
+    assert body["status"] == "success"
+    assert captured["outputs"][0]["sections"][0]["content"].startswith("# 背景")
+    assert "![diagram]" not in captured["outputs"][0]["sections"][0]["content"]

--- a/procuretech-editor-app/tests/test_generate.py
+++ b/procuretech-editor-app/tests/test_generate.py
@@ -10,6 +10,13 @@ from app import generate
 BASE = "http://generate.test"
 
 
+def test_normalize_compose_format():
+    assert generate.normalize_compose_format(None) == "docx"
+    assert generate.normalize_compose_format("HTML") == "html"
+    assert generate.normalize_compose_format(".pptx") == "pptx"
+    assert generate.normalize_compose_format("pdf") == "docx"
+
+
 def test_default_theme_present():
     ids = [t["id"] for t in generate.THEMES]
     assert "procurement_spec" in ids

--- a/procuretech-generate-app/app/compose_formats.py
+++ b/procuretech-generate-app/app/compose_formats.py
@@ -1,0 +1,549 @@
+"""Markdown 章を html / pptx / txt / md へ変換する（/compose の新形式）。"""
+
+from __future__ import annotations
+
+import base64
+import html
+import io
+import re
+from typing import Any
+
+from app.dads import (
+    ACCENT,
+    BODY,
+    FONT,
+    FONT_MONO,
+    INK,
+    MUTED,
+    ON_ACCENT,
+    PAPER,
+    RULE,
+    SURFACE,
+    hex_of,
+)
+
+# 画像のみの行（ブロック画像）。
+_IMAGE_LINE_RE = re.compile(r"^!\[[^\]]*\]\(\s*<?([^)>\s]+)>?(?:\s+\"[^\"]*\")?\s*\)$")
+_INLINE_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(\s*<?([^)>\s]+)>?(?:\s+\"[^\"]*\")?\s*\)")
+_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+_BOLD_RE = re.compile(r"(\*\*|__)(.+?)\1")
+_ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)")
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+_BULLET_RE = re.compile(r"^(\s*)[-*]\s+(.*)$")
+
+SUPPORTED_FORMATS = ("docx", "html", "pptx", "txt", "md")
+
+def _css_hex(rgb: tuple[int, int, int]) -> str:
+    return f"#{hex_of(rgb)}"
+
+
+# デジタル庁デザインシステム（DADS）。docx / pptx と同じトークン。
+_HTML_CSS = f"""
+:root {{
+  --ink: {_css_hex(INK)};
+  --body: {_css_hex(BODY)};
+  --muted: {_css_hex(MUTED)};
+  --rule: {_css_hex(RULE)};
+  --paper: {_css_hex(PAPER)};
+  --surface: {_css_hex(SURFACE)};
+  --accent: {_css_hex(ACCENT)};
+}}
+@page {{ margin: 20mm 18mm; }}
+html {{ background: {_css_hex(SURFACE)}; }}
+body {{
+  box-sizing: border-box;
+  max-width: 46rem;
+  margin: 2rem auto 3rem;
+  padding: 2.2rem 2.4rem 2.8rem;
+  background: var(--paper);
+  color: var(--body);
+  font-family: "{FONT}", "Hiragino Sans", "Yu Gothic Medium", "Yu Gothic", sans-serif;
+  font-size: 16px;
+  line-height: 1.7;
+  letter-spacing: 0.02em;
+}}
+h1, h2, h3, h4 {{
+  font-family: "{FONT}", "Hiragino Sans", "Yu Gothic", sans-serif;
+  font-weight: 700;
+  line-height: 1.5;
+  color: var(--ink);
+  letter-spacing: 0.01em;
+}}
+h1 {{
+  font-size: 1.5rem;
+  margin: 0 0 1.25rem;
+  padding-bottom: 0.55rem;
+  border-bottom: 2px solid var(--accent);
+}}
+h2 {{
+  font-size: 1.25rem;
+  margin: 1.75rem 0 0.6rem;
+  padding-bottom: 0.35rem;
+  border-bottom: 1px solid var(--rule);
+}}
+h3 {{ font-size: 1.1rem; margin: 1.4rem 0 0.45rem; }}
+p {{ margin: 0 0 0.9rem; }}
+ul {{ margin: 0 0 1rem 1.2rem; padding: 0; }}
+li {{ margin: 0.2rem 0; }}
+img {{ max-width: 100%; height: auto; display: block; margin: 1rem 0; }}
+code, pre {{
+  font-family: "{FONT_MONO}", ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: 0.88em;
+}}
+code {{ background: var(--surface); padding: 0.1em 0.35em; }}
+pre {{
+  background: var(--surface);
+  padding: 0.85rem 1rem;
+  overflow: auto;
+  line-height: 1.55;
+  border: 1px solid var(--rule);
+}}
+pre code {{ background: none; padding: 0; }}
+blockquote {{
+  margin: 0 0 1rem;
+  padding: 0.15rem 0 0.15rem 1rem;
+  border-left: 3px solid var(--accent);
+  color: var(--muted);
+}}
+table {{ border-collapse: collapse; width: 100%; margin: 1rem 0 1.2rem; font-size: 0.95em; }}
+th, td {{ border: 1px solid var(--rule); padding: 0.4rem 0.65rem; text-align: left; }}
+th {{ background: var(--surface); font-weight: 700; }}
+.figure-missing {{ color: var(--muted); font-style: italic; }}
+footer.meta {{ margin-top: 2.5rem; color: var(--muted); font-size: 0.8rem; }}
+@media print {{
+  html {{ background: #fff; }}
+  body {{ margin: 0; max-width: none; }}
+}}
+""".strip()
+
+
+def normalize_format(raw: Any) -> str:
+    fmt = str(raw or "docx").strip().lower().lstrip(".")
+    return fmt if fmt in SUPPORTED_FORMATS else "docx"
+
+
+def _rel_of(path: str) -> str:
+    return path.replace("\\", "/").lstrip("/")
+
+
+def _join_sections(sections: list[dict[str, Any]]) -> str:
+    parts: list[str] = []
+    for sec in sections:
+        content = str(sec.get("content") or "").strip()
+        if content:
+            parts.append(content)
+    return "\n\n".join(parts)
+
+
+def _data_uri(rel: str, data: bytes) -> str:
+    ext = rel.rsplit(".", 1)[-1].lower() if "." in rel else ""
+    mime = {
+        "png": "image/png",
+        "jpg": "image/jpeg",
+        "jpeg": "image/jpeg",
+        "gif": "image/gif",
+        "webp": "image/webp",
+        "svg": "image/svg+xml",
+    }.get(ext, "application/octet-stream")
+    return f"data:{mime};base64,{base64.b64encode(data).decode('ascii')}"
+
+
+def markdown_to_md(sections: list[dict[str, Any]]) -> bytes:
+    """章本文を空行区切りで連結する（ソースそのもの）。"""
+    body = _join_sections(sections)
+    if body and not body.endswith("\n"):
+        body += "\n"
+    return body.encode("utf-8")
+
+
+def markdown_to_txt(sections: list[dict[str, Any]]) -> bytes:
+    """Markdown 記法を除いたプレーンテキスト。画像・Mermaid はプレースホルダ。"""
+    lines_out: list[str] = []
+    in_code = False
+    code_lang = ""
+    for raw in _join_sections(sections).splitlines():
+        stripped = raw.strip()
+        if stripped.startswith("```"):
+            if in_code:
+                if code_lang == "mermaid":
+                    lines_out.append("[図]")
+                in_code = False
+                code_lang = ""
+            else:
+                in_code = True
+                code_lang = stripped[3:].strip().lower()
+            continue
+        if in_code:
+            if code_lang != "mermaid":
+                lines_out.append(raw)
+            continue
+        m = _IMAGE_LINE_RE.match(stripped)
+        if m:
+            lines_out.append(f"[画像: {_rel_of(m.group(1))}]")
+            continue
+        line = _INLINE_IMAGE_RE.sub(lambda mm: f"[画像: {_rel_of(mm.group(2))}]", raw)
+        line = _LINK_RE.sub(r"\1", line)
+        line = _BOLD_RE.sub(r"\2", line)
+        line = _ITALIC_RE.sub(r"\1", line)
+        hm = _HEADING_RE.match(line)
+        if hm:
+            line = hm.group(2).strip()
+        bm = _BULLET_RE.match(line)
+        if bm:
+            line = f"{bm.group(1)}・ {bm.group(2)}"
+        lines_out.append(line.rstrip())
+    text = "\n".join(lines_out).strip() + "\n"
+    return text.encode("utf-8")
+
+
+def _inline_html(text: str, assets: dict[str, bytes]) -> str:
+    def img(m: re.Match[str]) -> str:
+        rel = _rel_of(m.group(2))
+        data = assets.get(rel)
+        alt = html.escape(m.group(1) or "")
+        if data:
+            return f'<img src="{_data_uri(rel, data)}" alt="{alt}">'
+        return f'<span class="figure-missing">[画像: {html.escape(rel)}]</span>'
+
+    escaped = html.escape(text)
+    # エスケープ後に画像記法を戻すため、元テキストで置換してから残りを escape する。
+    parts: list[str] = []
+    last = 0
+    for m in _INLINE_IMAGE_RE.finditer(text):
+        parts.append(html.escape(text[last : m.start()]))
+        parts.append(img(m))
+        last = m.end()
+    parts.append(html.escape(text[last:]))
+    s = "".join(parts)
+    s = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", s)
+    s = re.sub(r"`([^`]+)`", r"<code>\1</code>", s)
+    return s
+
+
+def markdown_to_html(
+    name: str, sections: list[dict[str, Any]], assets: dict[str, bytes] | None = None
+) -> bytes:
+    """タイポグラフィ用 CSS を埋め込んだ単一 HTML。画像は data URI。"""
+    assets = assets or {}
+    chunks: list[str] = [f"<h1>{html.escape(name)}</h1>"]
+    in_code = False
+    code_lang = ""
+    code_lines: list[str] = []
+    in_list = False
+
+    def close_list() -> None:
+        nonlocal in_list
+        if in_list:
+            chunks.append("</ul>")
+            in_list = False
+
+    def flush_code() -> None:
+        nonlocal in_code, code_lang, code_lines
+        body = html.escape("\n".join(code_lines))
+        chunks.append(f"<pre><code>{body}</code></pre>")
+        in_code, code_lang, code_lines = False, "", []
+
+    for raw_line in _join_sections(sections).splitlines():
+        stripped = raw_line.strip()
+        if stripped.startswith("```"):
+            if in_code:
+                flush_code()
+            else:
+                close_list()
+                in_code, code_lang, code_lines = True, stripped[3:].strip().lower(), []
+            continue
+        if in_code:
+            code_lines.append(raw_line)
+            continue
+        if not stripped:
+            close_list()
+            continue
+        hm = _HEADING_RE.match(stripped)
+        if hm:
+            close_list()
+            level = min(len(hm.group(1)) + 1, 4)
+            chunks.append(f"<h{level}>{html.escape(hm.group(2).strip())}</h{level}>")
+            continue
+        m = _IMAGE_LINE_RE.match(stripped)
+        if m:
+            close_list()
+            rel = _rel_of(m.group(1))
+            data = assets.get(rel)
+            if data:
+                chunks.append(f'<p><img src="{_data_uri(rel, data)}" alt=""></p>')
+            else:
+                chunks.append(f'<p class="figure-missing">[画像: {html.escape(rel)}]</p>')
+            continue
+        bm = _BULLET_RE.match(raw_line)
+        if bm:
+            if not in_list:
+                chunks.append("<ul>")
+                in_list = True
+            chunks.append(f"<li>{_inline_html(bm.group(2), assets)}</li>")
+            continue
+        close_list()
+        if stripped.startswith("> "):
+            chunks.append(f"<blockquote><p>{_inline_html(stripped[2:], assets)}</p></blockquote>")
+            continue
+        chunks.append(f"<p>{_inline_html(stripped, assets)}</p>")
+    if in_code:
+        flush_code()
+    close_list()
+
+    doc = (
+        "<!DOCTYPE html>\n"
+        '<html lang="ja">\n<head>\n<meta charset="utf-8">\n'
+        f"<title>{html.escape(name)}</title>\n"
+        f"<style>\n{_HTML_CSS}\n</style>\n</head>\n<body>\n"
+        + "\n".join(chunks)
+        + "\n</body>\n</html>\n"
+    )
+    return doc.encode("utf-8")
+
+
+# PPTX は dads のトークンをそのまま使う（docx / html と揃える）。
+_PPTX_INK = INK
+_PPTX_BODY = BODY
+_PPTX_MUTED = MUTED
+_PPTX_RULE = RULE
+_PPTX_PAPER = PAPER
+_PPTX_SURFACE = SURFACE
+_PPTX_ACCENT = ACCENT
+_PPTX_ON_ACCENT = ON_ACCENT
+_PPTX_FONT = FONT
+
+
+def _rgb(rgb: tuple[int, int, int]) -> Any:
+    from pptx.dml.color import RGBColor
+
+    return RGBColor(*rgb)
+
+
+def _no_line(shape: Any) -> None:
+    shape.line.fill.background()
+
+
+def _solid(shape: Any, rgb: tuple[int, int, int]) -> None:
+    shape.fill.solid()
+    shape.fill.fore_color.rgb = _rgb(rgb)
+    _no_line(shape)
+
+
+def _set_run_font(
+    run: Any,
+    *,
+    size: Any,
+    color: tuple[int, int, int],
+    bold: bool = False,
+    name: str = _PPTX_FONT,
+) -> None:
+    from lxml import etree
+    from pptx.oxml.ns import qn
+
+    run.font.size = size
+    run.font.bold = bold
+    run.font.color.rgb = _rgb(color)
+    run.font.name = name
+    r_pr = run._r.get_or_add_rPr()
+    for tag in ("a:latin", "a:ea", "a:cs"):
+        el = r_pr.find(qn(tag))
+        if el is None:
+            el = etree.SubElement(r_pr, qn(tag))
+        el.set("typeface", name)
+
+
+def _fill_slide(slide: Any, rgb: tuple[int, int, int]) -> None:
+    fill = slide.background.fill
+    fill.solid()
+    fill.fore_color.rgb = _rgb(rgb)
+
+
+def _add_rect(slide: Any, left: Any, top: Any, width: Any, height: Any, rgb: tuple[int, int, int]) -> Any:
+    from pptx.enum.shapes import MSO_SHAPE
+
+    shape = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, left, top, width, height)
+    _solid(shape, rgb)
+    return shape
+
+
+def _style_paragraph(
+    paragraph: Any,
+    text: str,
+    *,
+    size: Any,
+    color: tuple[int, int, int],
+    bold: bool = False,
+    space_after: Any | None = None,
+    space_before: Any | None = None,
+) -> None:
+    from pptx.enum.text import PP_ALIGN
+
+    paragraph.text = text
+    paragraph.alignment = PP_ALIGN.LEFT
+    if space_after is not None:
+        paragraph.space_after = space_after
+    if space_before is not None:
+        paragraph.space_before = space_before
+    for run in paragraph.runs:
+        _set_run_font(run, size=size, color=color, bold=bold)
+
+
+def _add_title_slide(prs: Any, title: str) -> None:
+    """表紙。DADS の Blue 900 ヘッダー＋白地。装飾色は使わない。"""
+    from pptx.util import Emu, Inches, Pt
+
+    blank = prs.slide_layouts[6]
+    slide = prs.slides.add_slide(blank)
+    _fill_slide(slide, _PPTX_PAPER)
+    _add_rect(slide, Inches(0), Inches(0), prs.slide_width, Inches(1.05), _PPTX_ACCENT)
+    label = slide.shapes.add_textbox(Inches(0.7), Inches(0.32), Inches(12.0), Inches(0.45))
+    _style_paragraph(label.text_frame.paragraphs[0], "資料", size=Pt(14), color=_PPTX_ON_ACCENT, bold=True)
+
+    box = slide.shapes.add_textbox(Inches(0.7), Inches(2.35), Inches(12.0), Inches(2.4))
+    box.text_frame.word_wrap = True
+    _style_paragraph(box.text_frame.paragraphs[0], title, size=Pt(36), color=_PPTX_INK, bold=True)
+    _add_rect(slide, Inches(0.7), Inches(5.0), Inches(3.2), Inches(0.04), _PPTX_ACCENT)
+    _add_rect(
+        slide, Inches(0), Emu(prs.slide_height - Inches(0.28)), prs.slide_width, Inches(0.28), _PPTX_SURFACE
+    )
+
+
+def _add_content_chrome(slide: Any, prs: Any, title: str) -> None:
+    from pptx.util import Inches, Pt
+
+    _fill_slide(slide, _PPTX_PAPER)
+    _add_rect(slide, Inches(0), Inches(0), prs.slide_width, Inches(0.08), _PPTX_ACCENT)
+    box = slide.shapes.add_textbox(Inches(0.7), Inches(0.28), Inches(12.0), Inches(0.85))
+    box.text_frame.word_wrap = True
+    _style_paragraph(box.text_frame.paragraphs[0], title, size=Pt(24), color=_PPTX_INK, bold=True)
+    _add_rect(slide, Inches(0.7), Inches(1.16), Inches(11.9), Inches(0.012), _PPTX_RULE)
+
+
+def _add_slide_footers(prs: Any) -> None:
+    from pptx.enum.text import PP_ALIGN
+    from pptx.util import Emu, Inches, Pt
+
+    total = len(prs.slides)
+    for i, slide in enumerate(prs.slides, start=1):
+        if i == 1:
+            continue
+        _add_rect(
+            slide,
+            Inches(0.7),
+            Emu(prs.slide_height - Inches(0.42)),
+            Inches(11.9),
+            Inches(0.01),
+            _PPTX_RULE,
+        )
+        box = slide.shapes.add_textbox(
+            Inches(11.4), Emu(prs.slide_height - Inches(0.38)), Inches(1.3), Inches(0.3)
+        )
+        p = box.text_frame.paragraphs[0]
+        p.alignment = PP_ALIGN.RIGHT
+        run = p.add_run()
+        run.text = f"{i} / {total}"
+        _set_run_font(run, size=Pt(10), color=_PPTX_MUTED)
+
+
+def markdown_to_pptx(
+    name: str, sections: list[dict[str, Any]], assets: dict[str, bytes] | None = None
+) -> bytes:
+    """`#` / `##` 見出しでスライドを分け、本文と画像を配置する。"""
+    from pptx import Presentation
+    from pptx.util import Inches, Pt
+
+    assets = assets or {}
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    blank = prs.slide_layouts[6]
+    _add_title_slide(prs, name)
+
+    slide = None
+    body_lines: list[tuple[str, bool]] = []
+    in_code = False
+    code_lang = ""
+
+    def flush_text(*, narrow: bool = False) -> None:
+        nonlocal body_lines
+        if slide is None or not body_lines:
+            body_lines = []
+            return
+        width = Inches(6.6) if narrow else Inches(11.9)
+        box = slide.shapes.add_textbox(Inches(0.7), Inches(1.4), width, Inches(5.3))
+        tf = box.text_frame
+        tf.word_wrap = True
+        for i, (line, is_bullet) in enumerate(body_lines):
+            p = tf.paragraphs[0] if i == 0 else tf.add_paragraph()
+            text = f"•   {line}" if is_bullet else line
+            _style_paragraph(p, text, size=Pt(18), color=_PPTX_BODY, space_after=Pt(12), space_before=Pt(2))
+        body_lines = []
+
+    def new_slide(title: str) -> None:
+        nonlocal slide
+        flush_text()
+        slide = prs.slides.add_slide(blank)
+        _add_content_chrome(slide, prs, title)
+
+    def add_image(rel: str) -> None:
+        data = assets.get(rel)
+        if slide is None:
+            new_slide(name)
+        if not data:
+            body_lines.append((f"[画像: {rel}]", False))
+            return
+        narrow = bool(body_lines)
+        flush_text(narrow=narrow)
+        stream = io.BytesIO(data)
+        try:
+            if narrow:
+                slide.shapes.add_picture(stream, Inches(7.6), Inches(1.45), width=Inches(5.0))
+            else:
+                slide.shapes.add_picture(stream, Inches(1.8), Inches(1.5), width=Inches(9.6))
+        except Exception:  # noqa: BLE001
+            body_lines.append((f"[画像: {rel}]", False))
+
+    for raw_line in _join_sections(sections).splitlines():
+        stripped = raw_line.strip()
+        if stripped.startswith("```"):
+            if in_code:
+                in_code = False
+                code_lang = ""
+            else:
+                in_code = True
+                code_lang = stripped[3:].strip().lower()
+            continue
+        if in_code:
+            if code_lang != "mermaid":
+                body_lines.append((raw_line, False))
+            continue
+        if not stripped:
+            continue
+        hm = _HEADING_RE.match(stripped)
+        if hm and len(hm.group(1)) <= 2:
+            new_slide(hm.group(2).strip())
+            continue
+        if hm:
+            if slide is None:
+                new_slide(name)
+            body_lines.append((hm.group(2).strip(), False))
+            continue
+        m = _IMAGE_LINE_RE.match(stripped)
+        if m:
+            add_image(_rel_of(m.group(1)))
+            continue
+        if slide is None:
+            new_slide(name)
+        bm = _BULLET_RE.match(raw_line)
+        text = bm.group(2) if bm else stripped
+        text = _INLINE_IMAGE_RE.sub("", text).strip()
+        text = _BOLD_RE.sub(r"\2", text)
+        if text:
+            body_lines.append((text, bool(bm)))
+    flush_text()
+    _add_slide_footers(prs)
+
+    out = io.BytesIO()
+    prs.save(out)
+    return out.getvalue()
+

--- a/procuretech-generate-app/app/dads.py
+++ b/procuretech-generate-app/app/dads.py
@@ -1,0 +1,192 @@
+"""デジタル庁デザインシステム（DADS）の共通トークンと Word 向け適用。
+
+https://design.digital.go.jp/dads/foundations/color/color-palette/
+https://design.digital.go.jp/dads/foundations/typography/
+https://www.digital.go.jp/resources/dashboard-guidebook/color-palette/color-code
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Solid Gray / Blue（ダッシュボード資料のカラーコードに合わせる）
+INK = (0x1A, 0x1A, 0x1A)  # Solid Gray 900
+BODY = (0x33, 0x33, 0x33)  # Solid Gray 800
+MUTED = (0x76, 0x76, 0x76)  # Solid Gray 536（白地で本文 4.5:1）
+RULE = (0xCC, 0xCC, 0xCC)  # Solid Gray 200
+PAPER = (0xFF, 0xFF, 0xFF)  # White
+SURFACE = (0xF2, 0xF2, 0xF2)  # Solid Gray 50
+ACCENT = (0x00, 0x17, 0xC1)  # Blue 900
+ON_ACCENT = (0xFF, 0xFF, 0xFF)
+FONT = "Noto Sans JP"
+FONT_MONO = "Noto Sans Mono"
+
+
+def hex_of(rgb: tuple[int, int, int]) -> str:
+    return f"{rgb[0]:02X}{rgb[1]:02X}{rgb[2]:02X}"
+
+
+def style_run(
+    run: Any,
+    *,
+    name: str = FONT,
+    size: Any = None,
+    color: tuple[int, int, int] | None = None,
+    bold: bool | None = None,
+    italic: bool | None = None,
+) -> None:
+    """python-docx の Run に和欧とも同じ書体を付ける。"""
+    from docx.oxml.ns import qn
+    from docx.shared import RGBColor
+
+    run.font.name = name
+    if size is not None:
+        run.font.size = size
+    if color is not None:
+        run.font.color.rgb = RGBColor(*color)
+    if bold is not None:
+        run.font.bold = bold
+    if italic is not None:
+        run.font.italic = italic
+    r_pr = run._element.get_or_add_rPr()
+    r_fonts = r_pr.rFonts
+    if r_fonts is None:
+        from docx.oxml import OxmlElement
+
+        r_fonts = OxmlElement("w:rFonts")
+        r_pr.insert(0, r_fonts)
+    r_fonts.set(qn("w:ascii"), name)
+    r_fonts.set(qn("w:hAnsi"), name)
+    r_fonts.set(qn("w:eastAsia"), name)
+    r_fonts.set(qn("w:cs"), name)
+
+
+def _set_style_font(
+    style: Any,
+    *,
+    name: str,
+    size: Any,
+    color: tuple[int, int, int],
+    bold: bool | None = None,
+) -> None:
+    from docx.oxml import OxmlElement
+    from docx.oxml.ns import qn
+    from docx.shared import RGBColor
+
+    style.font.name = name
+    style.font.size = size
+    style.font.color.rgb = RGBColor(*color)
+    if bold is not None:
+        style.font.bold = bold
+    r_pr = style.element.get_or_add_rPr()
+    r_fonts = r_pr.find(qn("w:rFonts"))
+    if r_fonts is None:
+        r_fonts = OxmlElement("w:rFonts")
+        r_pr.insert(0, r_fonts)
+    r_fonts.set(qn("w:ascii"), name)
+    r_fonts.set(qn("w:hAnsi"), name)
+    r_fonts.set(qn("w:eastAsia"), name)
+    r_fonts.set(qn("w:cs"), name)
+
+
+def _bottom_border(p_pr: Any, color: tuple[int, int, int], *, sz: str = "12", space: str = "4") -> None:
+    from docx.oxml import OxmlElement
+    from docx.oxml.ns import qn
+
+    old = p_pr.find(qn("w:pBdr"))
+    if old is not None:
+        p_pr.remove(old)
+    border = OxmlElement("w:pBdr")
+    bottom = OxmlElement("w:bottom")
+    bottom.set(qn("w:val"), "single")
+    bottom.set(qn("w:sz"), sz)
+    bottom.set(qn("w:space"), space)
+    bottom.set(qn("w:color"), hex_of(color))
+    border.append(bottom)
+    p_pr.append(border)
+
+
+def _add_page_field(paragraph: Any) -> None:
+    from docx.oxml import OxmlElement
+    from docx.oxml.ns import qn
+    from docx.shared import Pt
+
+    run = paragraph.add_run()
+    style_run(run, name=FONT, size=Pt(9), color=MUTED)
+    begin = OxmlElement("w:fldChar")
+    begin.set(qn("w:fldCharType"), "begin")
+    instr = OxmlElement("w:instrText")
+    instr.set(qn("xml:space"), "preserve")
+    instr.text = " PAGE "
+    end = OxmlElement("w:fldChar")
+    end.set(qn("w:fldCharType"), "end")
+    run._r.append(begin)
+    run._r.append(instr)
+    run._r.append(end)
+
+
+def apply_docx_theme(doc: Any) -> None:
+    """A4・余白・見出し／本文スタイルを DADS に合わせる。"""
+    from docx.enum.text import WD_ALIGN_PARAGRAPH
+    from docx.shared import Cm, Pt
+
+    section = doc.sections[0]
+    section.page_width = Cm(21.0)
+    section.page_height = Cm(29.7)
+    section.left_margin = Cm(2.5)
+    section.right_margin = Cm(2.5)
+    section.top_margin = Cm(2.2)
+    section.bottom_margin = Cm(2.2)
+
+    header = section.header.paragraphs[0]
+    header.text = ""
+    _bottom_border(header._p.get_or_add_pPr(), ACCENT, sz="18", space="1")
+
+    footer = section.footer.paragraphs[0]
+    footer.alignment = WD_ALIGN_PARAGRAPH.RIGHT
+    footer.text = ""
+    _add_page_field(footer)
+
+    normal = doc.styles["Normal"]
+    _set_style_font(normal, name=FONT, size=Pt(11), color=BODY)
+    normal.paragraph_format.line_spacing = 1.7
+    normal.paragraph_format.space_after = Pt(10)
+    normal.paragraph_format.space_before = Pt(0)
+
+    title = doc.styles["Title"]
+    _set_style_font(title, name=FONT, size=Pt(22), color=INK, bold=True)
+    title.paragraph_format.space_after = Pt(18)
+    title.paragraph_format.space_before = Pt(0)
+    title.paragraph_format.line_spacing = 1.5
+    _bottom_border(title.element.get_or_add_pPr(), ACCENT, sz="12", space="6")
+
+    for style_name, size, before in (("Heading 1", 16, 20), ("Heading 2", 14, 16), ("Heading 3", 12, 14)):
+        st = doc.styles[style_name]
+        _set_style_font(st, name=FONT, size=Pt(size), color=INK, bold=True)
+        st.paragraph_format.space_before = Pt(before)
+        st.paragraph_format.space_after = Pt(8)
+        st.paragraph_format.line_spacing = 1.5
+    _bottom_border(doc.styles["Heading 1"].element.get_or_add_pPr(), RULE, sz="6", space="4")
+
+    try:
+        bullet = doc.styles["List Bullet"]
+        _set_style_font(bullet, name=FONT, size=Pt(11), color=BODY)
+        bullet.paragraph_format.line_spacing = 1.7
+        bullet.paragraph_format.space_after = Pt(4)
+    except KeyError:
+        pass
+
+
+def shade_paragraph(paragraph: Any, fill: tuple[int, int, int] = SURFACE) -> None:
+    from docx.oxml import OxmlElement
+    from docx.oxml.ns import qn
+
+    p_pr = paragraph._p.get_or_add_pPr()
+    old = p_pr.find(qn("w:shd"))
+    if old is not None:
+        p_pr.remove(old)
+    shd = OxmlElement("w:shd")
+    shd.set(qn("w:val"), "clear")
+    shd.set(qn("w:color"), "auto")
+    shd.set(qn("w:fill"), hex_of(fill))
+    p_pr.append(shd)

--- a/procuretech-generate-app/app/main.py
+++ b/procuretech-generate-app/app/main.py
@@ -13,10 +13,11 @@ Word(.docx) 合成まで一通り行える。テーマ固有の非公開サー�
 - GET  /waiting/{id}        -> image/png（ジョブの待ち画像）
 - POST /waiting-picture     -> image/png（書き出し待ち用。フォールバック落書き）
 - GET  /result/{id}         -> application/zip（section*.md, README.md, sections.json）
-- POST /compose             JSON {"outputs":[{"name","sections":[{"filename","content"}]}],
+- POST /compose             JSON {"outputs":[{"name","format?","sections":[{"filename","content"}]}],
                                    "assets": {"images/x.png": "<base64>"}}
-                            -> application/zip（<name>.docx）。assets の画像は本文の
-                               `![](相対パス)` に一致すれば .docx へ埋め込む。
+                            -> application/zip（<name>.<format>。format 省略時は docx）。
+                               format: docx / html / pptx / txt / md。
+                               assets の画像は視覚形式（docx / html / pptx）へ埋め込む。
 - GET  /template/{key}      -> 同梱のヒアリングシート様式（xlsx）をダウンロード
 
 `GENERATE_API_KEY` が設定されていれば `X-API-Key` を検証する。
@@ -38,6 +39,15 @@ from typing import Any
 from fastapi import FastAPI, Header, Request
 from fastapi.responses import JSONResponse, Response
 
+from app.compose_formats import (
+    SUPPORTED_FORMATS,
+    markdown_to_html,
+    markdown_to_md,
+    markdown_to_pptx,
+    markdown_to_txt,
+    normalize_format,
+)
+from app.dads import BODY, FONT_MONO, MUTED, apply_docx_theme, shade_paragraph, style_run
 from app.waiting import make_fallback_waiting_png
 
 # API キー（旧名 GENERATE_SAMPLE_API_KEY も後方互換で参照）。
@@ -174,12 +184,21 @@ def _add_code_block(doc: Any, lang: str, lines: list[str]) -> None:
 
     if lang == "mermaid":
         note = doc.add_paragraph()
-        run = note.add_run("【Mermaid 図（画像未変換のためソースを表示）】")
-        run.italic = True
+        style_run(
+            note.add_run("【Mermaid 図（画像未変換のためソースを表示）】"),
+            size=Pt(10),
+            color=MUTED,
+            italic=True,
+        )
     para = doc.add_paragraph()
-    run = para.add_run("\n".join(lines))
-    run.font.name = "Courier New"
-    run.font.size = Pt(9)
+    shade_paragraph(para)
+    para.paragraph_format.line_spacing = 1.45
+    style_run(
+        para.add_run("\n".join(lines)),
+        name=FONT_MONO,
+        size=Pt(9),
+        color=BODY,
+    )
 
 
 def _add_line_with_inline_images(doc: Any, line: str, assets: dict[str, bytes]) -> None:
@@ -226,6 +245,7 @@ def _markdown_to_docx(
 
     assets = assets or {}
     doc = Document()
+    apply_docx_theme(doc)
     doc.add_heading(name, level=0)
     for sec in sections:
         content = str(sec.get("content") or "")
@@ -397,14 +417,29 @@ def result(request_id: str, x_api_key: str | None = Header(default=None)) -> Res
     )
 
 
+def _render_output(
+    fmt: str, name: str, sections: list[dict[str, Any]], assets: dict[str, bytes]
+) -> bytes:
+    if fmt == "html":
+        return markdown_to_html(name, sections, assets)
+    if fmt == "pptx":
+        return markdown_to_pptx(name, sections, assets)
+    if fmt == "txt":
+        return markdown_to_txt(sections)
+    if fmt == "md":
+        return markdown_to_md(sections)
+    return _markdown_to_docx(name, sections, assets)
+
+
 @app.post("/compose")
 async def compose(
     request: Request, x_api_key: str | None = Header(default=None)
 ) -> Response:
-    """順序付き Markdown（出力ファイル毎）を .docx に合成して zip で返す。
+    """順序付き Markdown（出力ファイル毎）を指定形式に合成して zip で返す。
 
+    outputs[].format は docx（既定）/ html / pptx / txt / md。
     body.assets（{相対パス: base64}）に本文の `![](相対パス)` と一致する画像を渡すと、
-    ブロック／インラインいずれの画像も .docx へ埋め込む（Mermaid はクライアントが PNG 化して
+    視覚形式（docx / html / pptx）へ埋め込む（Mermaid はクライアントが PNG 化して
     画像として渡す運用）。
     """
     err = _check_key(x_api_key)
@@ -419,24 +454,42 @@ async def compose(
         return JSONResponse(status_code=400, content={"error": "outputs がありません"})
     assets = _decode_assets(body.get("assets") if isinstance(body, dict) else None)
 
-    buf = io.BytesIO()
+    unknown: list[str] = []
+    rendered: list[tuple[str, bytes]] = []
     used: set[str] = set()
+    for i, o in enumerate(outputs, 1):
+        if not isinstance(o, dict):
+            continue
+        name = str(o.get("name") or f"output{i}")
+        raw_fmt = str(o.get("format") or "docx").strip().lower().lstrip(".")
+        if raw_fmt and raw_fmt not in SUPPORTED_FORMATS:
+            unknown.append(raw_fmt)
+            continue
+        fmt = normalize_format(raw_fmt)
+        sections = o.get("sections") or []
+        if not isinstance(sections, list):
+            sections = []
+        data = _render_output(fmt, name, sections, assets)
+        arc = f"{name}.{fmt}"
+        n = 2
+        while arc in used:
+            arc = f"{name}({n}).{fmt}"
+            n += 1
+        used.add(arc)
+        rendered.append((arc, data))
+
+    if unknown and not rendered:
+        return JSONResponse(
+            status_code=422,
+            content={"error": f"未対応の出力形式です: {', '.join(sorted(set(unknown)))}"},
+        )
+    if not rendered:
+        return JSONResponse(status_code=400, content={"error": "合成対象の内容がありません"})
+
+    buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        for i, o in enumerate(outputs, 1):
-            if not isinstance(o, dict):
-                continue
-            name = str(o.get("name") or f"output{i}")
-            sections = o.get("sections") or []
-            if not isinstance(sections, list):
-                sections = []
-            docx = _markdown_to_docx(name, sections, assets)
-            arc = f"{name}.docx"
-            n = 2
-            while arc in used:
-                arc = f"{name}({n}).docx"
-                n += 1
-            used.add(arc)
-            zf.writestr(arc, docx)
+        for arc, data in rendered:
+            zf.writestr(arc, data)
     return Response(
         content=buf.getvalue(),
         media_type="application/zip",

--- a/procuretech-generate-app/requirements.txt
+++ b/procuretech-generate-app/requirements.txt
@@ -3,4 +3,5 @@ uvicorn[standard]==0.34.0
 python-multipart==0.0.31
 openpyxl==3.1.5
 python-docx==1.1.2
+python-pptx==1.0.2
 Pillow>=10.4.0

--- a/procuretech-generate-app/tests/test_compose_formats.py
+++ b/procuretech-generate-app/tests/test_compose_formats.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import io
+import zipfile
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.compose_formats import markdown_to_html, markdown_to_md, markdown_to_txt
+from app.main import app
+
+SECTIONS = [
+    {"filename": "a.md", "content": "# 背景\n\n本文です。\n\n```mermaid\ngraph TD\nA-->B\n```\n"},
+    {"filename": "b.md", "content": "## 目的\n\n- 項目1\n- 項目2\n\n![図](images/z.png)\n"},
+]
+
+
+def test_markdown_to_md_joins_and_keeps_mermaid():
+    body = markdown_to_md(SECTIONS).decode("utf-8")
+    assert "# 背景" in body
+    assert "```mermaid" in body
+    assert "![図](images/z.png)" in body
+
+
+def test_markdown_to_txt_strips_and_placeholders():
+    body = markdown_to_txt(SECTIONS).decode("utf-8")
+    assert "背景" in body
+    assert "```" not in body
+    assert "[図]" in body
+    assert "[画像: images/z.png]" in body
+    assert "・ 項目1" in body
+
+
+def test_markdown_to_html_embeds_css_and_data_uri():
+    html = markdown_to_html("文書", SECTIONS, {"images/z.png": b"PNG"}).decode("utf-8")
+    assert "<style>" in html
+    assert "data:image/png;base64," in html
+    assert "本文です。" in html
+    assert "#0017C1" in html
+    assert "Noto Sans JP" in html
+
+
+def test_compose_zip_respects_format():
+    client = TestClient(app)
+    res = client.post(
+        "/compose",
+        json={
+            "outputs": [
+                {"name": "文書", "format": "md", "sections": SECTIONS},
+                {"name": "メモ", "format": "txt", "sections": SECTIONS},
+            ]
+        },
+    )
+    assert res.status_code == 200
+    with zipfile.ZipFile(io.BytesIO(res.content)) as zf:
+        names = set(zf.namelist())
+        assert "文書.md" in names
+        assert "メモ.txt" in names
+        assert "```mermaid" in zf.read("文書.md").decode("utf-8")
+
+
+def test_compose_unknown_format_is_422():
+    client = TestClient(app)
+    res = client.post(
+        "/compose",
+        json={"outputs": [{"name": "x", "format": "pdf", "sections": SECTIONS}]},
+    )
+    assert res.status_code == 422
+
+
+def test_markdown_to_pptx_if_available():
+    pytest.importorskip("pptx")
+    from app.compose_formats import markdown_to_pptx
+
+    data = markdown_to_pptx("文書", SECTIONS, {})
+    assert data[:2] == b"PK"
+
+
+def test_markdown_to_docx_uses_dads():
+    pytest.importorskip("docx")
+    from app.dads import FONT, hex_of, ACCENT
+    from app.main import _markdown_to_docx
+
+    data = _markdown_to_docx("文書", SECTIONS, {})
+    assert data[:2] == b"PK"
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        styles = zf.read("word/styles.xml").decode("utf-8")
+        header = zf.read("word/header1.xml").decode("utf-8")
+    assert FONT in styles
+    assert hex_of(ACCENT) in header


### PR DESCRIPTION
## Summary
- Markdown エディタの書き出しを `docx` 固定から `docx` / `html` / `pptx` / `txt` / `md` に広げる。
- `docx` はテーマの `/compose`（調達仕様書なら spec-app / pandoc）、それ以外は generate-app へ振り分ける。
- generate-app の視覚形式（docx / html / pptx）の見た目をデジタル庁デザインシステム（DADS）に揃える。xlsx / pdf は対象外。

## Test plan
- [ ] エディタの「書き出し・統合」で各形式（docx / html / pptx / txt / md）を追加し、書き出せること
- [ ] 調達仕様書テーマの docx は従来どおり spec-app / pandoc のスタイルであること
- [ ] 素の文書の docx と html / pptx が DADS（Blue 900・Noto Sans JP）であること
- [ ] 視覚形式だけ Mermaid が PNG 化され、md / txt では ` ```mermaid ` のまま残ること
- [ ] `kind=excel` の見積・一次審査表は従来どおりテーマの `/excel` であること


Made with [Cursor](https://cursor.com)