### PR TITLE
feat(procuretech-generate): PPTX を LLM と DADS レイアウトで構成する

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -635,10 +635,11 @@ services:
     restart: unless-stopped
 
   # 文書生成・合成サービス（公開の汎用リファレンス実装 / 既定の合成バックエンド）。
-  # procuretech-editor プロファイルで同時起動し、テーマ無しの「素の文書」の Word 化を担う
+  # procuretech-editor プロファイルで同時起動し、テーマ無しの「素の文書」の合成を担う
   # （EDITOR_COMPOSE_URL=http://procuretech-generate-app:8016）。テーマ固有の非公開サービス
-  # （例: 調達仕様書=spec-app）を差し替える際の契約リファレンスにもなる。LLM/Dify 非依存で、
-  # 同梱のヒアリングシート（materials/hearing/hearing-sample.xlsx）から生成〜合成まで動作する。
+  # （例: 調達仕様書=spec-app）を差し替える際の契約リファレンスにもなる。
+  # /generate は同梱ヒアリングシートから章を作る（LLM なし）。/compose の pptx は
+  # OPENAI_BASE_URL があれば LLM で layout を選び、無ければ決定論変換する。
   procuretech-generate-app:
     profiles: ["procuretech-editor"]
     build: ./procuretech-generate-app
@@ -646,6 +647,13 @@ services:
     environment:
       - GENERATE_API_KEY=${EDITOR_COMPOSE_API_KEY:-${EDITOR_GENERATE_API_KEY:-}}
       - GENERATE_PROCESS_SECONDS=${GENERATE_PROCESS_SECONDS:-2}
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-ollama}
+      - PROCURETECH_MODEL=${PROCURETECH_MODEL:-${DEFAULT_MODEL:-qwen2.5:7b}}
+      - GENERATE_PPTX_LLM=${GENERATE_PPTX_LLM:-1}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "${PROCURETECH_GENERATE_PORT:-8016}:8016"
     restart: unless-stopped

--- a/docs/procuretech-generate-contract.md
+++ b/docs/procuretech-generate-contract.md
@@ -102,6 +102,10 @@
   - **docx**: テーマ固有サービス（例: spec-app / pandoc）またはリファレンス実装（python-docx）。
   - **html / pptx / txt / md**: 公開リファレンス実装 `procuretech-generate-app` が担う。
     エディタは docx をテーマの `/compose` へ、それ以外を `EDITOR_COMPOSE_URL` へ振り分ける。
+    pptx は既定で LLM（`OPENAI_BASE_URL`、空なら Ollama）が章・節から layout を選び、
+    決定論レンダラ（デジタル庁デザインシステム）で描く。簡潔化したスライドの根拠原文は
+    スピーカーノートに残す。`GENERATE_PPTX_LLM=0` または LLM 失敗時は見出し分割の
+    決定論変換へ落とす。
 - `reference` は任意（Word のスタイル参照ドキュメントの種別など）。docx 以外では無視してよい。
 - `assets` は任意。本文が参照する**画像を `{相対パス: base64}`** で渡す。視覚形式（docx / html / pptx）では
   画像を埋め込む。html は data URI で単一ファイルにする。md / txt は画像を埋め込まない。

--- a/procuretech-generate-app/app/compose_formats.py
+++ b/procuretech-generate-app/app/compose_formats.py
@@ -461,29 +461,36 @@ def markdown_to_pptx(
 
     slide = None
     body_lines: list[tuple[str, bool]] = []
+    text_flushed = False
     in_code = False
     code_lang = ""
 
     def flush_text(*, narrow: bool = False) -> None:
-        nonlocal body_lines
+        nonlocal body_lines, text_flushed
         if slide is None or not body_lines:
             body_lines = []
             return
+        # 同じ座標に重ねない（本文のあと画像、そのあとまた本文、で文字が重なっていた）。
+        top = Inches(4.55) if text_flushed else Inches(1.4)
+        height = Inches(2.15) if text_flushed else Inches(5.3)
         width = Inches(6.6) if narrow else Inches(11.9)
-        box = slide.shapes.add_textbox(Inches(0.7), Inches(1.4), width, Inches(5.3))
+        box = slide.shapes.add_textbox(Inches(0.7), top, width, height)
         tf = box.text_frame
         tf.word_wrap = True
         for i, (line, is_bullet) in enumerate(body_lines):
             p = tf.paragraphs[0] if i == 0 else tf.add_paragraph()
             text = f"•   {line}" if is_bullet else line
-            _style_paragraph(p, text, size=Pt(18), color=_PPTX_BODY, space_after=Pt(12), space_before=Pt(2))
+            _style_paragraph(p, text, size=Pt(16), color=_PPTX_BODY, space_after=Pt(8), space_before=Pt(0))
+            p.line_spacing = 1.35
         body_lines = []
+        text_flushed = True
 
     def new_slide(title: str) -> None:
-        nonlocal slide
+        nonlocal slide, text_flushed
         flush_text()
         slide = prs.slides.add_slide(blank)
         _add_content_chrome(slide, prs, title)
+        text_flushed = False
 
     def add_image(rel: str) -> None:
         data = assets.get(rel)

--- a/procuretech-generate-app/app/llm.py
+++ b/procuretech-generate-app/app/llm.py
@@ -1,0 +1,91 @@
+"""OpenAI 互換 chat/completions（PPTX プランナ用）。editor-app の llm.py と同型。"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import httpx
+
+OLLAMA_BASE_URL = os.environ.get(
+    "OLLAMA_BASE_URL", "http://host.docker.internal:11434"
+).rstrip("/")
+OPENAI_BASE_URL = (os.environ.get("OPENAI_BASE_URL") or f"{OLLAMA_BASE_URL}/v1").rstrip("/")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY") or "ollama"
+PROCURETECH_MODEL = (
+    os.environ.get("PROCURETECH_MODEL") or os.environ.get("DEFAULT_MODEL") or "qwen2.5:7b"
+)
+REQUEST_TIMEOUT = float(os.environ.get("GENERATE_LLM_TIMEOUT", "120"))
+DEFAULT_MAX_TOKENS = int(os.environ.get("GENERATE_LLM_MAX_TOKENS", "4096"))
+
+
+def llm_enabled() -> bool:
+    """未指定時は ON。テストとオフラインは GENERATE_PPTX_LLM=0。
+
+    editor と同様、OPENAI_BASE_URL が空なら OLLAMA_BASE_URL /v1 を使う。
+    以前は OPENAI_BASE_URL 必須にしていたため、Ollama だけの環境では
+    決定論変換に落ちて見た目が変わらなかった。
+    """
+    flag = (os.environ.get("GENERATE_PPTX_LLM") or "1").strip().lower()
+    return flag not in {"0", "false", "off", "no"}
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {OPENAI_API_KEY}",
+        "Content-Type": "application/json",
+    }
+
+
+def _extra_body() -> dict[str, Any]:
+    raw = (os.environ.get("PROCURETECH_EXTRA_BODY") or "").strip()
+    if raw:
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+    return {"chat_template_kwargs": {"enable_thinking": False}}
+
+
+def _message_text(message: dict[str, Any]) -> str:
+    content = message.get("content")
+    if isinstance(content, str) and content.strip():
+        return content.strip()
+    for key in ("reasoning_content", "reasoning"):
+        value = message.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return content.strip() if isinstance(content, str) else ""
+
+
+def chat(
+    messages: list[dict[str, str]],
+    *,
+    temperature: float = 0.1,
+    model: str | None = None,
+    max_tokens: int | None = None,
+) -> str:
+    payload: dict[str, Any] = {
+        "model": model or PROCURETECH_MODEL,
+        "messages": messages,
+        "stream": False,
+        "temperature": temperature,
+        "max_tokens": max_tokens if max_tokens is not None else DEFAULT_MAX_TOKENS,
+    }
+    payload.update(_extra_body())
+    with httpx.Client(timeout=REQUEST_TIMEOUT) as client:
+        res = client.post(
+            f"{OPENAI_BASE_URL}/chat/completions",
+            json=payload,
+            headers=_headers(),
+        )
+        res.raise_for_status()
+        data = res.json()
+    choices = data.get("choices") or [{}]
+    text = _message_text(choices[0].get("message") or {})
+    if not text:
+        raise ValueError("モデルの応答本文が空です")
+    return text

--- a/procuretech-generate-app/app/main.py
+++ b/procuretech-generate-app/app/main.py
@@ -1,10 +1,11 @@
 """文書生成・合成サービス（公開の汎用リファレンス実装 / 既定の合成バックエンド）。
 
 Open GENAI の `procuretech-editor` から呼ばれる pluggable な生成/合成 API の
-「そのまま動く」実装。LLM/Dify には依存せず、同梱の簡単なヒアリングシート
-（`materials/hearing/hearing-sample.xlsx`）を読み取り、章別 Markdown を生成し、
-Word(.docx) 合成まで一通り行える。テーマ固有の非公開サービス（例: 調達仕様書=spec-app）を
-差し替える際の雛形であり、テーマ無しの「素の文書」の Word 化の既定バックエンドでもある。
+「そのまま動く」実装。`/generate` は LLM/Dify に依存せず、同梱の簡単なヒアリングシート
+（`materials/hearing/hearing-sample.xlsx`）を読み取り、章別 Markdown を生成する。
+`/compose` の pptx は任意で OpenAI 互換 LLM がレイアウトを選び、失敗時は決定論変換へ落とす。
+テーマ固有の非公開サービス（例: 調達仕様書=spec-app）を差し替える際の雛形であり、
+テーマ無しの「素の文書」の合成の既定バックエンドでもある。
 
 契約:
 - POST /generate            multipart: 任意キーの Excel / form: username, doc_type, options
@@ -48,6 +49,8 @@ from app.compose_formats import (
     normalize_format,
 )
 from app.dads import BODY, FONT_MONO, MUTED, apply_docx_theme, shade_paragraph, style_run
+from app.pptx_layouts import render_deck
+from app.pptx_plan import plan_deck
 from app.waiting import make_fallback_waiting_png
 
 # API キー（旧名 GENERATE_SAMPLE_API_KEY も後方互換で参照）。
@@ -423,6 +426,11 @@ def _render_output(
     if fmt == "html":
         return markdown_to_html(name, sections, assets)
     if fmt == "pptx":
+        deck = plan_deck(name, sections, assets)
+        if deck:
+            print(f"[generate] pptx: LLM deck ({len(deck.get('slides') or [])} slides)")
+            return render_deck(deck, assets)
+        print("[generate] pptx: fallback to heading split")
         return markdown_to_pptx(name, sections, assets)
     if fmt == "txt":
         return markdown_to_txt(sections)

--- a/procuretech-generate-app/app/pptx_catalog.py
+++ b/procuretech-generate-app/app/pptx_catalog.py
@@ -1,0 +1,362 @@
+"""PPTX レイアウトカタログ（slide-builder の ID / スロット形を正とする）。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+SLIDE_TYPES = frozenset({"cover", "section", "content", "case-study", "ending"})
+DEFAULT_LAYOUT = "parallel-items"
+
+LAYOUT_IDS: tuple[str, ...] = (
+    "kpi-three-col",
+    "kpi-formula",
+    "kpi-logic-tree",
+    "text-data-emphasis",
+    "doughnut-three-col",
+    "two-col-text-chart",
+    "pie-chart-highlight",
+    "stacked-bar-chart",
+    "horizontal-bar-ranking",
+    "step-flow",
+    "timeline",
+    "vertical-timeline",
+    "funnel",
+    "pyramid",
+    "cycle",
+    "step-up",
+    "comparison-table",
+    "before-after-split",
+    "matrix-quadrant",
+    "pricing-table",
+    "schedule-list",
+    "checklist-table",
+    "ceo-message",
+    "member-grid",
+    "member-three-col",
+    "venn-diagram",
+    "three-way-relation",
+    "radial-spread",
+    "convergence",
+    "containment",
+    "business-concept",
+    "tam-concentric",
+    "tam-parallel",
+    "channel-mapping",
+    "user-pain-points",
+    "quote",
+    "chat-dialogue",
+    "year-list",
+    "three-column",
+    "three-step-column",
+    "parallel-items",
+    "numbered-feature-cards",
+    "awards-parallel",
+    "fullscreen-photo",
+    "logo-wall",
+    "location-map",
+    "case-two-col",
+    "qa-grid",
+)
+
+LAYOUT_ID_SET = frozenset(LAYOUT_IDS)
+
+# 図的で、画像（Mermaid PNG 含む）があるときは画像 layout を優先する。
+DIAGRAM_LAYOUTS = frozenset(
+    {
+        "venn-diagram",
+        "three-way-relation",
+        "radial-spread",
+        "convergence",
+        "containment",
+        "funnel",
+        "pyramid",
+        "cycle",
+        "kpi-logic-tree",
+        "channel-mapping",
+        "tam-concentric",
+        "matrix-quadrant",
+    }
+)
+
+NUMERIC_LAYOUTS = frozenset(
+    {
+        "kpi-three-col",
+        "kpi-formula",
+        "text-data-emphasis",
+        "doughnut-three-col",
+        "two-col-text-chart",
+        "pie-chart-highlight",
+        "stacked-bar-chart",
+        "horizontal-bar-ranking",
+    }
+)
+
+SELECTION_GUIDE = """\
+内容のタイプ → 推奨 layout（避けるべきもの）
+- 数値KPI: kpi-three-col / text-data-emphasis（本文に数値があるときだけ）
+- 機能・要点 3-4個: parallel-items / numbered-feature-cards（kpi-three-col は使わない）
+- 要件・チェック: checklist-table / numbered-feature-cards
+- Before/After 比較: comparison-table / before-after-split
+- 時系列・沿革: timeline / vertical-timeline / year-list
+- 手順・プロセス（画像なし）: step-flow / three-step-column
+- 人物紹介: ceo-message / member-grid / member-three-col
+- Q&A: qa-grid
+- 引用: quote
+- 表・料金・日程: pricing-table / schedule-list
+- 節に画像または Mermaid PNG がある図的内容: fullscreen-photo または two-col-text-chart ではなく
+  画像を主にした layout（fullscreen-photo）。venn-diagram / cycle / radial-spread 等は画像が無いときだけ。
+- 数値が本文に無いときは KPI・チャート系を選ばない。
+"""
+
+
+def content_nonempty(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (int, float, bool)):
+        return True
+    if isinstance(value, list):
+        return any(content_nonempty(item) for item in value)
+    if isinstance(value, dict):
+        return any(content_nonempty(item) for item in value.values())
+    return True
+
+
+def normalize_layout(raw: Any) -> str:
+    name = str(raw or "").strip()
+    return name if name in LAYOUT_ID_SET else DEFAULT_LAYOUT
+
+
+def minimal_fixture(layout: str) -> dict[str, Any]:
+    """テスト・未知 content の最低限サンプル。"""
+    fixtures: dict[str, dict[str, Any]] = {
+        "kpi-three-col": {
+            "items": [
+                {"value": "120%", "label": "成長率"},
+                {"value": "80", "label": "件数"},
+                {"value": "4.5", "label": "評価"},
+            ]
+        },
+        "kpi-formula": {
+            "kpiName": "CVR",
+            "numerator": "CV数",
+            "denominator": "訪問者数",
+            "annotations": ["注釈"],
+        },
+        "kpi-logic-tree": {
+            "root": {"label": "成果"},
+            "branches": [
+                {"label": "入力", "children": [{"label": "A"}]},
+                {"label": "出力", "children": [{"label": "B"}]},
+            ],
+        },
+        "text-data-emphasis": {
+            "narrative": "説明文",
+            "bigNumber": "97%",
+            "bigNumberLabel": "達成率",
+        },
+        "doughnut-three-col": {
+            "charts": [
+                {"title": "部門A", "labels": ["X", "Y"], "values": [60, 40]},
+                {"title": "部門B", "labels": ["X", "Y"], "values": [30, 70]},
+            ]
+        },
+        "two-col-text-chart": {
+            "left": {"heading": "見出し", "body": "説明"},
+            "right": {"chartType": "bar", "data": {"labels": ["A", "B"], "values": [30, 70]}},
+        },
+        "pie-chart-highlight": {
+            "data": {"labels": ["A", "B", "C"], "values": [50, 30, 20]},
+            "highlight": {"value": "50%", "message": "Aが半数"},
+        },
+        "stacked-bar-chart": {
+            "categories": ["Q1", "Q2"],
+            "series": [{"name": "A", "values": [10, 20]}, {"name": "B", "values": [5, 8]}],
+        },
+        "horizontal-bar-ranking": {
+            "items": [{"label": "項目A", "value": 85}, {"label": "項目B", "value": 60}]
+        },
+        "step-flow": {
+            "steps": [
+                {"label": "計画", "description": "要件"},
+                {"label": "実行", "description": "実装"},
+            ]
+        },
+        "timeline": {
+            "items": [
+                {"date": "2024/04", "title": "開始", "description": "発足"},
+                {"date": "2024/10", "title": "完了", "description": "稼働"},
+            ]
+        },
+        "vertical-timeline": {
+            "items": [
+                {"date": "2024/04", "title": "開始", "description": "発足"},
+                {"date": "2024/10", "title": "完了", "description": "稼働"},
+            ]
+        },
+        "funnel": {
+            "heading": "流入",
+            "body": "説明",
+            "steps": [{"label": "認知"}, {"label": "検討"}, {"label": "決定"}],
+        },
+        "pyramid": {
+            "levels": [
+                {"label": "方針", "description": "上位"},
+                {"label": "施策", "description": "下位"},
+            ]
+        },
+        "cycle": {
+            "items": [{"label": "計画"}, {"label": "実行"}, {"label": "評価"}],
+            "centerText": "改善",
+        },
+        "step-up": {
+            "steps": [
+                {"label": "基礎", "description": "土台"},
+                {"label": "応用", "description": "展開"},
+            ]
+        },
+        "comparison-table": {
+            "beforeTitle": "導入前",
+            "afterTitle": "導入後",
+            "rows": [{"category": "コスト", "before": "100", "after": "50"}],
+        },
+        "before-after-split": {
+            "before": {"title": "Before", "points": ["手作業"]},
+            "after": {"title": "After", "points": ["自動化"]},
+        },
+        "matrix-quadrant": {
+            "axisX": {"low": "低", "high": "高"},
+            "axisY": {"low": "低", "high": "高"},
+            "quadrants": [
+                {"title": "Q1", "description": "説明"},
+                {"title": "Q2", "description": "説明"},
+                {"title": "Q3", "description": "説明"},
+                {"title": "Q4", "description": "説明"},
+            ],
+        },
+        "pricing-table": {
+            "headers": [{"text": "項目"}, {"text": "内容"}],
+            "rows": [[{"text": "容量"}, {"text": "10GB"}]],
+        },
+        "schedule-list": {
+            "phases": [
+                {"phase": "Phase1", "period": "4-5月", "owner": "開発", "details": "設計"}
+            ]
+        },
+        "checklist-table": {
+            "headers": ["項目", "状態", "備考"],
+            "items": [{"label": "環境", "checked": True, "note": "完了"}],
+        },
+        "ceo-message": {
+            "name": "山田太郎",
+            "role": "担当",
+            "message": "本文",
+        },
+        "member-grid": {
+            "members": [
+                {"name": "田中", "role": "設計", "bio": "経歴"},
+                {"name": "佐藤", "role": "開発", "bio": "経歴"},
+            ]
+        },
+        "member-three-col": {
+            "members": [
+                {"name": "田中", "role": "設計", "bio": "経歴"},
+                {"name": "佐藤", "role": "開発", "bio": "経歴"},
+                {"name": "鈴木", "role": "運用", "bio": "経歴"},
+            ]
+        },
+        "venn-diagram": {
+            "items": [{"label": "技術"}, {"label": "業務"}],
+            "overlapText": "接点",
+        },
+        "three-way-relation": {
+            "nodes": [{"label": "A"}, {"label": "B"}, {"label": "C"}],
+            "relations": [{"label": "連携"}],
+        },
+        "radial-spread": {
+            "center": {"label": "中核"},
+            "items": [{"label": "機能A"}, {"label": "機能B"}],
+        },
+        "convergence": {
+            "target": {"label": "目標"},
+            "items": [{"label": "要素A"}, {"label": "要素B"}],
+        },
+        "containment": {
+            "outer": {"label": "基盤"},
+            "inner": [{"label": "モジュールA", "description": "説明"}],
+        },
+        "business-concept": {
+            "a": {"title": "概念A", "description": "説明"},
+            "b": {"title": "概念B", "description": "説明"},
+        },
+        "tam-concentric": {
+            "rings": [{"label": "全体", "value": "100"}, {"label": "対象", "value": "30"}]
+        },
+        "tam-parallel": {
+            "items": [{"label": "全体", "value": "100"}, {"label": "対象", "value": "30"}]
+        },
+        "channel-mapping": {
+            "phases": ["認知", "検討", "決定"],
+            "channels": [{"label": "案内", "startPhase": 0, "endPhase": 1}],
+        },
+        "user-pain-points": {"painPoints": ["検索が遅い", "重複が多い"]},
+        "quote": {"text": "引用文", "author": "著者", "role": "役職"},
+        "chat-dialogue": {
+            "messages": [
+                {"speaker": "質問", "text": "内容は？"},
+                {"speaker": "回答", "text": "次のとおりです。"},
+            ]
+        },
+        "year-list": {"items": [{"year": "2020", "description": "開始"}]},
+        "three-column": {
+            "columns": [
+                {"heading": "A", "body": "説明"},
+                {"heading": "B", "body": "説明"},
+                {"heading": "C", "body": "説明"},
+            ]
+        },
+        "three-step-column": {
+            "steps": [
+                {"title": "分析", "description": "現状"},
+                {"title": "設計", "description": "方針"},
+                {"title": "実装", "description": "構築"},
+            ]
+        },
+        "parallel-items": {
+            "items": [
+                {"heading": "要点1", "description": "説明"},
+                {"heading": "要点2", "description": "説明"},
+            ]
+        },
+        "numbered-feature-cards": {
+            "items": [
+                {"title": "機能1", "description": "説明"},
+                {"title": "機能2", "description": "説明"},
+            ]
+        },
+        "awards-parallel": {
+            "items": [{"value": "1", "label": "実績", "description": "2025"}],
+            "footerMessage": "注釈",
+        },
+        "fullscreen-photo": {
+            "headline": "見出し",
+            "subMessages": ["補足"],
+        },
+        "logo-wall": {"logos": [{"name": "組織A"}, {"name": "組織B"}]},
+        "location-map": {
+            "locations": [{"name": "本社", "posX": 40, "posY": 50, "isHQ": True}]
+        },
+        "case-two-col": {
+            "companyName": "事例",
+            "info": [{"key": "分野", "value": "行政"}],
+            "metrics": [{"key": "効果", "value": "改善"}],
+        },
+        "qa-grid": {
+            "items": [
+                {"q": "質問1", "a": "回答1"},
+                {"q": "質問2", "a": "回答2"},
+            ]
+        },
+    }
+    return dict(fixtures.get(layout) or fixtures[DEFAULT_LAYOUT])

--- a/procuretech-generate-app/app/pptx_layouts.py
+++ b/procuretech-generate-app/app/pptx_layouts.py
@@ -1,0 +1,849 @@
+"""deck JSON を DADS トークンで描く決定論レンダラ（python-pptx）。"""
+
+from __future__ import annotations
+
+import io
+from typing import Any, Callable
+
+from app.dads import ACCENT, BODY, FONT, INK, MUTED, ON_ACCENT, PAPER, RULE, SURFACE
+from app.pptx_catalog import DEFAULT_LAYOUT, LAYOUT_ID_SET, content_nonempty, normalize_layout
+
+RenderFn = Callable[[Any, Any, dict[str, Any], dict[str, bytes]], None]
+_REGISTRY: dict[str, RenderFn] = {}
+
+
+def register(name: str) -> Callable[[RenderFn], RenderFn]:
+    def deco(fn: RenderFn) -> RenderFn:
+        _REGISTRY[name] = fn
+        return fn
+
+    return deco
+
+
+def _rgb(rgb: tuple[int, int, int]) -> Any:
+    from pptx.dml.color import RGBColor
+
+    return RGBColor(*rgb)
+
+
+def _set_run_font(
+    run: Any,
+    *,
+    size: Any,
+    color: tuple[int, int, int],
+    bold: bool = False,
+    name: str = FONT,
+) -> None:
+    from lxml import etree
+    from pptx.oxml.ns import qn
+
+    if size is not None:
+        run.font.size = size
+    run.font.bold = bold
+    run.font.color.rgb = _rgb(color)
+    run.font.name = name
+    r_pr = run._r.get_or_add_rPr()
+    for tag in ("a:latin", "a:ea", "a:cs"):
+        el = r_pr.find(qn(tag))
+        if el is None:
+            el = etree.SubElement(r_pr, qn(tag))
+        el.set("typeface", name)
+
+
+def _fill_slide(slide: Any, rgb: tuple[int, int, int] = PAPER) -> None:
+    fill = slide.background.fill
+    fill.solid()
+    fill.fore_color.rgb = _rgb(rgb)
+
+
+def _no_line(shape: Any) -> None:
+    shape.line.fill.background()
+
+
+def _solid(shape: Any, rgb: tuple[int, int, int]) -> None:
+    shape.fill.solid()
+    shape.fill.fore_color.rgb = _rgb(rgb)
+    _no_line(shape)
+
+
+def _rect(slide: Any, left: Any, top: Any, width: Any, height: Any, rgb: tuple[int, int, int]) -> Any:
+    from pptx.enum.shapes import MSO_SHAPE
+
+    shape = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, left, top, width, height)
+    _solid(shape, rgb)
+    return shape
+
+
+def _oval(slide: Any, left: Any, top: Any, width: Any, height: Any, rgb: tuple[int, int, int]) -> Any:
+    from pptx.enum.shapes import MSO_SHAPE
+
+    shape = slide.shapes.add_shape(MSO_SHAPE.OVAL, left, top, width, height)
+    _solid(shape, rgb)
+    return shape
+
+
+def _style_p(
+    paragraph: Any,
+    text: str,
+    *,
+    size: Any,
+    color: tuple[int, int, int],
+    bold: bool = False,
+    align: Any = None,
+    space_after: Any | None = None,
+) -> None:
+    from pptx.enum.text import PP_ALIGN
+
+    paragraph.text = str(text or "")
+    paragraph.alignment = align or PP_ALIGN.LEFT
+    if space_after is not None:
+        paragraph.space_after = space_after
+    for run in paragraph.runs:
+        _set_run_font(run, size=size, color=color, bold=bold)
+
+
+def _textbox(
+    slide: Any,
+    left: Any,
+    top: Any,
+    width: Any,
+    height: Any,
+    text: str,
+    *,
+    size: Any,
+    color: tuple[int, int, int] = BODY,
+    bold: bool = False,
+    align: Any = None,
+) -> Any:
+    box = slide.shapes.add_textbox(left, top, width, height)
+    box.text_frame.word_wrap = True
+    _style_p(box.text_frame.paragraphs[0], text, size=size, color=color, bold=bold, align=align)
+    return box
+
+
+def _lines(
+    slide: Any,
+    left: Any,
+    top: Any,
+    width: Any,
+    height: Any,
+    lines: list[str],
+    *,
+    size: Any,
+    color: tuple[int, int, int] = BODY,
+    bullet: bool = False,
+) -> None:
+    from pptx.util import Pt
+
+    box = slide.shapes.add_textbox(left, top, width, height)
+    tf = box.text_frame
+    tf.word_wrap = True
+    for i, line in enumerate(lines):
+        p = tf.paragraphs[0] if i == 0 else tf.add_paragraph()
+        text = f"•  {line}" if bullet else line
+        _style_p(p, text, size=size, color=color, space_after=Pt(8))
+
+
+def _card(
+    slide: Any,
+    left: Any,
+    top: Any,
+    width: Any,
+    height: Any,
+    heading: str,
+    body: str = "",
+    *,
+    index: int | None = None,
+) -> None:
+    from pptx.enum.text import PP_ALIGN
+    from pptx.util import Inches, Pt
+
+    _rect(slide, left, top, width, height, SURFACE)
+    _rect(slide, left, top, Inches(0.08), height, ACCENT)
+    title_left = left + Inches(0.22)
+    title_width = width - Inches(0.35)
+    if index is not None:
+        _oval(slide, left + Inches(0.18), top + Inches(0.16), Inches(0.32), Inches(0.32), ACCENT)
+        _textbox(
+            slide,
+            left + Inches(0.18),
+            top + Inches(0.16),
+            Inches(0.32),
+            Inches(0.32),
+            str(index),
+            size=Pt(11),
+            color=ON_ACCENT,
+            bold=True,
+            align=PP_ALIGN.CENTER,
+        )
+        title_left = left + Inches(0.58)
+        title_width = width - Inches(0.72)
+    _textbox(slide, title_left, top + Inches(0.14), title_width, Inches(0.4), heading, size=Pt(14), color=INK, bold=True)
+    if body:
+        _textbox(
+            slide,
+            title_left,
+            top + Inches(0.52),
+            title_width,
+            height - Inches(0.65),
+            body,
+            size=Pt(12),
+            color=BODY,
+        )
+
+
+def _add_notes(slide: Any, notes: str) -> None:
+    text = (notes or "").strip()
+    if not text:
+        return
+    frame = slide.notes_slide.notes_text_frame
+    frame.text = text
+    for p in frame.paragraphs:
+        for run in p.runs:
+            _set_run_font(run, size=None, color=BODY)
+
+
+def _add_title_slide(prs: Any, title: str, subtitle: str = "") -> Any:
+    from pptx.util import Emu, Inches, Pt
+
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    _fill_slide(slide)
+    _rect(slide, Inches(0), Inches(0), prs.slide_width, Inches(1.05), ACCENT)
+    _textbox(slide, Inches(0.7), Inches(0.32), Inches(12.0), Inches(0.45), "資料", size=Pt(14), color=ON_ACCENT, bold=True)
+    box = slide.shapes.add_textbox(Inches(0.7), Inches(2.35), Inches(12.0), Inches(2.2))
+    box.text_frame.word_wrap = True
+    _style_p(box.text_frame.paragraphs[0], title, size=Pt(36), color=INK, bold=True)
+    if subtitle:
+        _textbox(slide, Inches(0.7), Inches(4.6), Inches(12.0), Inches(0.8), subtitle, size=Pt(16), color=MUTED)
+    _rect(slide, Inches(0.7), Inches(5.5), Inches(3.2), Inches(0.04), ACCENT)
+    _rect(slide, Inches(0), Emu(prs.slide_height - Inches(0.28)), prs.slide_width, Inches(0.28), SURFACE)
+    return slide
+
+
+def _add_section_slide(prs: Any, title: str) -> Any:
+    from pptx.util import Inches, Pt
+
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    _fill_slide(slide)
+    _rect(slide, Inches(0), Inches(0), Inches(0.16), prs.slide_height, ACCENT)
+    _textbox(slide, Inches(0.9), Inches(2.8), Inches(11.5), Inches(1.6), title, size=Pt(32), color=INK, bold=True)
+    return slide
+
+
+def _add_ending_slide(prs: Any, title: str, subtitle: str = "") -> Any:
+    from pptx.util import Inches, Pt
+
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    _fill_slide(slide)
+    _rect(slide, Inches(0), Inches(0), prs.slide_width, Inches(0.16), ACCENT)
+    _textbox(slide, Inches(0.7), Inches(2.6), Inches(12.0), Inches(1.4), title or "ご清聴ありがとうございました", size=Pt(28), color=INK, bold=True)
+    if subtitle:
+        _textbox(slide, Inches(0.7), Inches(4.2), Inches(12.0), Inches(0.7), subtitle, size=Pt(16), color=MUTED)
+    return slide
+
+
+def _add_content_chrome(slide: Any, prs: Any, title: str) -> None:
+    from pptx.util import Inches, Pt
+
+    _fill_slide(slide)
+    _rect(slide, Inches(0), Inches(0), prs.slide_width, Inches(0.08), ACCENT)
+    _textbox(slide, Inches(0.7), Inches(0.28), Inches(12.0), Inches(0.75), title, size=Pt(22), color=INK, bold=True)
+    _rect(slide, Inches(0.7), Inches(1.08), Inches(11.9), Inches(0.012), RULE)
+
+
+def _add_footers(prs: Any) -> None:
+    from pptx.enum.text import PP_ALIGN
+    from pptx.util import Emu, Inches, Pt
+
+    total = len(prs.slides)
+    for i, slide in enumerate(prs.slides, start=1):
+        if i == 1:
+            continue
+        _rect(
+            slide,
+            Inches(0.7),
+            Emu(prs.slide_height - Inches(0.42)),
+            Inches(11.9),
+            Inches(0.01),
+            RULE,
+        )
+        box = slide.shapes.add_textbox(
+            Inches(11.4), Emu(prs.slide_height - Inches(0.38)), Inches(1.3), Inches(0.3)
+        )
+        p = box.text_frame.paragraphs[0]
+        p.alignment = PP_ALIGN.RIGHT
+        run = p.add_run()
+        run.text = f"{i} / {total}"
+        _set_run_font(run, size=Pt(10), color=MUTED)
+
+
+def _picture(slide: Any, rel: str, assets: dict[str, bytes], left: Any, top: Any, width: Any) -> bool:
+    data = assets.get(rel)
+    if not data:
+        return False
+    try:
+        slide.shapes.add_picture(io.BytesIO(data), left, top, width=width)
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _placeholder(slide: Any, left: Any, top: Any, width: Any, height: Any, label: str) -> None:
+    from pptx.util import Pt
+
+    _rect(slide, left, top, width, height, SURFACE)
+    _textbox(slide, left, top + height / 3, width, height / 3, label or "画像", size=Pt(12), color=MUTED)
+
+
+def _add_table(slide: Any, left: Any, top: Any, width: Any, height: Any, rows: list[list[str]]) -> None:
+    if not rows:
+        return
+    cols = max(len(r) for r in rows)
+    table_shape = slide.shapes.add_table(len(rows), cols, left, top, width, height)
+    table = table_shape.table
+    for r_i, row in enumerate(rows):
+        for c_i in range(cols):
+            cell = table.cell(r_i, c_i)
+            cell.text = row[c_i] if c_i < len(row) else ""
+            for p in cell.text_frame.paragraphs:
+                for run in p.runs:
+                    _set_run_font(run, size=None, color=INK if r_i == 0 else BODY, bold=r_i == 0)
+            fill = cell.fill
+            fill.solid()
+            fill.fore_color.rgb = _rgb(SURFACE if r_i == 0 else PAPER)
+
+
+def _chart(
+    slide: Any,
+    left: Any,
+    top: Any,
+    width: Any,
+    height: Any,
+    labels: list[str],
+    series: list[tuple[str, list[float]]],
+    kind: str = "bar",
+) -> None:
+    from pptx.chart.data import CategoryChartData
+    from pptx.enum.chart import XL_CHART_TYPE
+
+    data = CategoryChartData()
+    data.categories = labels or ["A"]
+    if not series:
+        data.add_series("値", (1,))
+    else:
+        for name, values in series:
+            data.add_series(name or "値", tuple(values or [0]))
+    chart_type = {
+        "bar": XL_CHART_TYPE.BAR_CLUSTERED,
+        "column": XL_CHART_TYPE.COLUMN_CLUSTERED,
+        "stacked": XL_CHART_TYPE.COLUMN_STACKED,
+        "pie": XL_CHART_TYPE.PIE,
+        "doughnut": XL_CHART_TYPE.DOUGHNUT,
+    }.get(kind, XL_CHART_TYPE.BAR_CLUSTERED)
+    slide.shapes.add_chart(chart_type, left, top, width, height, data)
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    return value if isinstance(value, list) else [value]
+
+
+def _item_heading(item: Any) -> str:
+    if isinstance(item, str):
+        return item
+    if not isinstance(item, dict):
+        return str(item)
+    for key in ("heading", "title", "label", "name", "q", "year", "date", "phase"):
+        if item.get(key):
+            return str(item[key])
+    return ""
+
+
+def _item_body(item: Any) -> str:
+    if not isinstance(item, dict):
+        return ""
+    for key in ("description", "body", "detail", "text", "a", "note", "message", "bio"):
+        if item.get(key):
+            return str(item[key])
+    return ""
+
+
+def _items_from(content: dict[str, Any]) -> list[dict[str, str]]:
+    raw = (
+        content.get("items")
+        or content.get("steps")
+        or content.get("members")
+        or content.get("columns")
+        or content.get("painPoints")
+        or content.get("levels")
+        or content.get("logos")
+    )
+    out: list[dict[str, str]] = []
+    for item in _as_list(raw):
+        if isinstance(item, str):
+            out.append({"heading": item, "body": ""})
+        elif isinstance(item, dict):
+            out.append({"heading": _item_heading(item), "body": _item_body(item)})
+    return [x for x in out if x["heading"] or x["body"]]
+
+
+# --- layouts ---
+
+
+@register("parallel-items")
+@register("numbered-feature-cards")
+@register("three-column")
+@register("three-step-column")
+@register("awards-parallel")
+def _render_cards(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.util import Inches
+
+    items = _items_from(content)[:4]
+    if not items:
+        return
+    n = max(len(items), 1)
+    gap = Inches(0.2)
+    total_w = Inches(11.9)
+    w = (total_w - gap * (n - 1)) / n
+    top = Inches(1.4)
+    h = Inches(5.0)
+    for i, item in enumerate(items):
+        left = Inches(0.7) + (w + gap) * i
+        heading = item["heading"] or item["body"]
+        body = item["body"] if item["heading"] else ""
+        _card(slide, left, top, w, h, heading, body, index=i + 1)
+
+
+@register("step-flow")
+@register("step-up")
+def _render_steps(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    _render_cards(slide, prs, content, assets)
+
+
+@register("user-pain-points")
+def _render_pains(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.util import Inches, Pt
+
+    points = [str(p) for p in _as_list(content.get("painPoints") or content.get("items"))][:6]
+    _lines(slide, Inches(0.7), Inches(1.45), Inches(11.9), Inches(5.2), points, size=Pt(18), bullet=True)
+
+
+@register("quote")
+def _render_quote(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.util import Inches, Pt
+
+    _rect(slide, Inches(0.7), Inches(1.5), Inches(0.1), Inches(4.6), ACCENT)
+    _textbox(slide, Inches(1.1), Inches(1.7), Inches(11.2), Inches(3.2), str(content.get("text") or ""), size=Pt(20), color=INK)
+    who = " / ".join(x for x in (content.get("author"), content.get("role"), content.get("company")) if x)
+    if who:
+        _textbox(slide, Inches(1.1), Inches(5.2), Inches(11.2), Inches(0.5), who, size=Pt(14), color=MUTED)
+
+
+@register("chat-dialogue")
+def _render_chat(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.util import Inches, Pt
+
+    messages = _as_list(content.get("messages"))[:4]
+    top = 1.4
+    for i, msg in enumerate(messages):
+        if isinstance(msg, dict):
+            speaker = str(msg.get("speaker") or "")
+            text = str(msg.get("text") or "")
+        else:
+            speaker, text = "", str(msg)
+        left = 0.7 if i % 2 == 0 else 4.0
+        _rect(slide, Inches(left), Inches(top), Inches(8.4), Inches(1.15), SURFACE)
+        _textbox(slide, Inches(left + 0.2), Inches(top + 0.08), Inches(8.0), Inches(0.3), speaker, size=Pt(11), color=MUTED, bold=True)
+        _textbox(slide, Inches(left + 0.2), Inches(top + 0.4), Inches(8.0), Inches(0.65), text, size=Pt(14), color=BODY)
+        top += 1.3
+
+
+@register("qa-grid")
+def _render_qa(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.util import Inches
+
+    items = _as_list(content.get("items"))[:4]
+    positions = [(0.7, 1.4), (7.0, 1.4), (0.7, 4.15), (7.0, 4.15)]
+    for item, (x, y) in zip(items, positions):
+        q = _item_heading(item) if not isinstance(item, dict) else str(item.get("q") or _item_heading(item))
+        a = _item_body(item) if not isinstance(item, dict) else str(item.get("a") or _item_body(item))
+        _card(slide, Inches(x), Inches(y), Inches(5.6), Inches(2.5), q, a)
+
+
+@register("year-list")
+@register("timeline")
+def _render_timeline(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.enum.text import PP_ALIGN
+    from pptx.util import Inches, Pt
+
+    items = _as_list(content.get("items") or content.get("steps"))[:6]
+    if not items:
+        return
+    n = len(items)
+    y = Inches(3.4)
+    _rect(slide, Inches(0.8), y, Inches(11.6), Inches(0.04), ACCENT)
+    for i, item in enumerate(items):
+        x = Inches(0.8) + Inches(11.6) * (i / max(n - 1, 1))
+        _oval(slide, x - Inches(0.1), y - Inches(0.08), Inches(0.2), Inches(0.2), ACCENT)
+        heading = _item_heading(item)
+        body = _item_body(item)
+        _textbox(slide, x - Inches(0.85), Inches(1.4), Inches(1.8), Inches(1.7), heading, size=Pt(12), color=INK, bold=True, align=PP_ALIGN.CENTER)
+        _textbox(slide, x - Inches(0.85), Inches(3.7), Inches(1.8), Inches(2.2), body, size=Pt(11), color=BODY, align=PP_ALIGN.CENTER)
+
+
+@register("vertical-timeline")
+@register("schedule-list")
+def _render_vtimeline(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.util import Inches, Pt
+
+    items = _as_list(content.get("items") or content.get("phases") or content.get("steps"))[:6]
+    _rect(slide, Inches(2.15), Inches(1.4), Inches(0.04), Inches(5.2), ACCENT)
+    top = 1.4
+    for item in items:
+        if isinstance(item, dict):
+            heading = str(item.get("date") or item.get("phase") or item.get("period") or _item_heading(item))
+            body = " ".join(
+                str(item.get(k) or "")
+                for k in ("title", "description", "details", "owner", "period")
+                if item.get(k) and str(item.get(k)) != heading
+            )
+        else:
+            heading, body = str(item), ""
+        _oval(slide, Inches(2.02), Inches(top + 0.08), Inches(0.3), Inches(0.3), ACCENT)
+        _textbox(slide, Inches(2.55), Inches(top), Inches(9.8), Inches(0.35), heading, size=Pt(14), color=INK, bold=True)
+        if body:
+            _textbox(slide, Inches(2.55), Inches(top + 0.32), Inches(9.8), Inches(0.45), body, size=Pt(12), color=BODY)
+        top += 0.9
+
+
+@register("comparison-table")
+@register("checklist-table")
+@register("pricing-table")
+def _render_tables(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.util import Inches
+
+    rows: list[list[str]] = []
+    raw_rows = content.get("rows") or []
+    if raw_rows and isinstance(raw_rows[0], dict) and "category" in raw_rows[0]:
+        rows = [["項目", str(content.get("beforeTitle") or "前"), str(content.get("afterTitle") or "後")]]
+        for row in raw_rows:
+            rows.append([str(row.get("category") or ""), str(row.get("before") or ""), str(row.get("after") or "")])
+    elif content.get("items"):
+        headers = [str(h) for h in _as_list(content.get("headers") or ["項目", "状態", "備考"])]
+        rows.append(headers)
+        for item in content["items"]:
+            if isinstance(item, dict):
+                checked = "済" if item.get("checked") else "—"
+                rows.append([str(item.get("label") or ""), checked, str(item.get("note") or "")])
+    elif content.get("headers") and content.get("rows"):
+        headers = content["headers"]
+        if headers and isinstance(headers[0], dict):
+            rows.append([str(h.get("text") or "") for h in headers])
+        else:
+            rows.append([str(h) for h in headers])
+        for row in content["rows"]:
+            if row and isinstance(row[0], dict):
+                rows.append([str(c.get("text") or "") for c in row])
+            else:
+                rows.append([str(c) for c in row])
+    _add_table(slide, Inches(0.7), Inches(1.4), Inches(11.9), Inches(5.1), rows)
+
+
+@register("before-after-split")
+def _render_ba(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.util import Inches, Pt
+
+    for x, key in ((0.7, "before"), (7.05, "after")):
+        block = content.get(key) if isinstance(content.get(key), dict) else {}
+        _rect(slide, Inches(x), Inches(1.4), Inches(5.55), Inches(5.1), SURFACE)
+        _textbox(slide, Inches(x + 0.25), Inches(1.55), Inches(5.1), Inches(0.45), str(block.get("title") or key), size=Pt(16), color=INK, bold=True)
+        points = [str(p) for p in _as_list(block.get("points"))]
+        _lines(slide, Inches(x + 0.25), Inches(2.15), Inches(5.1), Inches(4.1), points, size=Pt(14), bullet=True)
+
+
+@register("kpi-three-col")
+@register("tam-parallel")
+def _render_kpis(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.enum.text import PP_ALIGN
+    from pptx.util import Inches, Pt
+
+    items = _as_list(content.get("items"))[:3]
+    n = max(len(items), 1)
+    w = Inches(11.9) / n - Inches(0.15)
+    for i, item in enumerate(items):
+        left = Inches(0.7) + (w + Inches(0.2)) * i
+        if isinstance(item, dict):
+            value = str(item.get("value") or "")
+            label = str(item.get("label") or "")
+        else:
+            value, label = str(item), ""
+        _rect(slide, left, Inches(2.0), w, Inches(3.4), SURFACE)
+        _textbox(slide, left, Inches(2.4), w, Inches(1.4), value, size=Pt(36), color=ACCENT, bold=True, align=PP_ALIGN.CENTER)
+        _textbox(slide, left, Inches(4.0), w, Inches(0.8), label, size=Pt(14), color=INK, align=PP_ALIGN.CENTER)
+
+
+@register("text-data-emphasis")
+def _render_emphasis(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.enum.text import PP_ALIGN
+    from pptx.util import Inches, Pt
+
+    _textbox(slide, Inches(0.7), Inches(1.5), Inches(7.0), Inches(4.8), str(content.get("narrative") or ""), size=Pt(18), color=BODY)
+    _rect(slide, Inches(8.1), Inches(2.0), Inches(4.4), Inches(3.6), SURFACE)
+    _textbox(slide, Inches(8.1), Inches(2.4), Inches(4.4), Inches(1.6), str(content.get("bigNumber") or ""), size=Pt(40), color=ACCENT, bold=True, align=PP_ALIGN.CENTER)
+    _textbox(slide, Inches(8.1), Inches(4.2), Inches(4.4), Inches(0.7), str(content.get("bigNumberLabel") or ""), size=Pt(14), color=INK, align=PP_ALIGN.CENTER)
+
+
+@register("kpi-formula")
+def _render_formula(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.enum.text import PP_ALIGN
+    from pptx.util import Inches, Pt
+
+    _textbox(slide, Inches(0.7), Inches(2.0), Inches(11.9), Inches(0.6), str(content.get("kpiName") or "指標"), size=Pt(18), color=INK, bold=True, align=PP_ALIGN.CENTER)
+    _textbox(
+        slide,
+        Inches(0.7),
+        Inches(3.0),
+        Inches(11.9),
+        Inches(1.2),
+        f"{content.get('numerator') or ''}  /  {content.get('denominator') or ''}",
+        size=Pt(28),
+        color=ACCENT,
+        bold=True,
+        align=PP_ALIGN.CENTER,
+    )
+    notes = [str(a) for a in _as_list(content.get("annotations"))]
+    if notes:
+        _lines(slide, Inches(0.7), Inches(4.6), Inches(11.9), Inches(1.6), notes, size=Pt(12))
+
+
+@register("kpi-logic-tree")
+@register("radial-spread")
+@register("convergence")
+@register("containment")
+@register("venn-diagram")
+@register("three-way-relation")
+@register("funnel")
+@register("pyramid")
+@register("cycle")
+@register("tam-concentric")
+@register("matrix-quadrant")
+@register("channel-mapping")
+@register("business-concept")
+def _render_diagram_fallback(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    """関係図系は簡易カード列。本図は Mermaid PNG 側を優先する。"""
+    items = _items_from(content)
+    if not items:
+        extra = []
+        for key in ("center", "root", "target", "outer", "a", "b"):
+            block = content.get(key)
+            if isinstance(block, dict) and (block.get("label") or block.get("title")):
+                extra.append({"heading": str(block.get("label") or block.get("title")), "body": str(block.get("description") or "")})
+        items = extra
+    if items:
+        _render_cards(slide, prs, {"items": items}, assets)
+        return
+    from pptx.util import Inches, Pt
+
+    _textbox(slide, Inches(0.7), Inches(2.4), Inches(11.9), Inches(2.0), "図は本文の画像または Mermaid を参照", size=Pt(16), color=MUTED)
+
+
+@register("doughnut-three-col")
+@register("pie-chart-highlight")
+@register("two-col-text-chart")
+@register("stacked-bar-chart")
+@register("horizontal-bar-ranking")
+def _render_charts(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.util import Inches, Pt
+
+    if content.get("charts"):
+        charts = _as_list(content["charts"])[:3]
+        n = max(len(charts), 1)
+        w = Inches(11.9) / n - Inches(0.1)
+        for i, ch in enumerate(charts):
+            left = Inches(0.7) + (w + Inches(0.15)) * i
+            labels = [str(x) for x in _as_list(ch.get("labels"))]
+            values = [float(v) for v in _as_list(ch.get("values"))]
+            _textbox(slide, left, Inches(1.35), w, Inches(0.35), str(ch.get("title") or ""), size=Pt(12), color=INK, bold=True)
+            _chart(slide, left, Inches(1.8), w, Inches(4.6), labels, [("値", values)], "doughnut")
+        return
+    if content.get("left") or content.get("right"):
+        left = content.get("left") if isinstance(content.get("left"), dict) else {}
+        right = content.get("right") if isinstance(content.get("right"), dict) else {}
+        _textbox(slide, Inches(0.7), Inches(1.4), Inches(5.8), Inches(0.5), str(left.get("heading") or ""), size=Pt(16), color=INK, bold=True)
+        _textbox(slide, Inches(0.7), Inches(2.0), Inches(5.8), Inches(4.4), str(left.get("body") or ""), size=Pt(14), color=BODY)
+        data = right.get("data") if isinstance(right.get("data"), dict) else {}
+        labels = [str(x) for x in _as_list(data.get("labels"))]
+        values = [float(v) for v in _as_list(data.get("values"))]
+        kind = "doughnut" if str(right.get("chartType") or "") == "doughnut" else "column"
+        _chart(slide, Inches(6.8), Inches(1.5), Inches(5.7), Inches(5.0), labels, [("値", values)], kind)
+        return
+    if content.get("data"):
+        data = content["data"] if isinstance(content["data"], dict) else {}
+        labels = [str(x) for x in _as_list(data.get("labels"))]
+        values = [float(v) for v in _as_list(data.get("values"))]
+        _chart(slide, Inches(0.7), Inches(1.4), Inches(7.4), Inches(5.1), labels, [("値", values)], "pie")
+        hi = content.get("highlight") if isinstance(content.get("highlight"), dict) else {}
+        _rect(slide, Inches(8.4), Inches(2.2), Inches(4.1), Inches(3.2), SURFACE)
+        _textbox(slide, Inches(8.5), Inches(2.5), Inches(3.9), Inches(1.2), str(hi.get("value") or ""), size=Pt(28), color=ACCENT, bold=True)
+        _textbox(slide, Inches(8.5), Inches(3.8), Inches(3.9), Inches(1.2), str(hi.get("message") or ""), size=Pt(13), color=BODY)
+        return
+    if content.get("categories") and content.get("series"):
+        labels = [str(x) for x in content["categories"]]
+        series = [(str(s.get("name") or "値"), [float(v) for v in _as_list(s.get("values"))]) for s in content["series"] if isinstance(s, dict)]
+        _chart(slide, Inches(0.7), Inches(1.4), Inches(11.9), Inches(5.1), labels, series, "stacked")
+        return
+    items = _as_list(content.get("items"))
+    labels = [_item_heading(it) for it in items]
+    values = []
+    for it in items:
+        try:
+            values.append(float(it.get("value") if isinstance(it, dict) else 0))
+        except (TypeError, ValueError):
+            values.append(0)
+    _chart(slide, Inches(0.7), Inches(1.4), Inches(11.9), Inches(5.1), labels, [("値", values)], "bar")
+
+
+@register("ceo-message")
+def _render_ceo(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.util import Inches, Pt
+
+    photo = str(content.get("photo") or content.get("path") or "")
+    if not _picture(slide, photo, assets, Inches(0.7), Inches(1.5), Inches(3.4)):
+        _placeholder(slide, Inches(0.7), Inches(1.5), Inches(3.4), Inches(4.6), str(content.get("name") or ""))
+    _textbox(slide, Inches(4.4), Inches(1.5), Inches(8.1), Inches(0.45), str(content.get("name") or ""), size=Pt(20), color=INK, bold=True)
+    _textbox(slide, Inches(4.4), Inches(2.0), Inches(8.1), Inches(0.35), str(content.get("role") or ""), size=Pt(13), color=MUTED)
+    _textbox(slide, Inches(4.4), Inches(2.5), Inches(8.1), Inches(3.6), str(content.get("message") or content.get("bio") or ""), size=Pt(16), color=BODY)
+
+
+@register("member-grid")
+@register("member-three-col")
+def _render_members(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    _render_cards(slide, prs, {"items": _as_list(content.get("members"))}, assets)
+
+
+@register("fullscreen-photo")
+def _render_photo(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.util import Inches, Pt
+
+    rel = str(content.get("backgroundPath") or content.get("image") or "")
+    if not _picture(slide, rel, assets, Inches(0.7), Inches(1.35), Inches(11.9)):
+        _placeholder(slide, Inches(0.7), Inches(1.35), Inches(11.9), Inches(4.0), "図")
+    caption = str(content.get("headline") or "").strip()
+    if caption:
+        _textbox(slide, Inches(0.7), Inches(6.05), Inches(11.9), Inches(0.4), caption, size=Pt(14), color=INK, bold=True)
+
+
+@register("logo-wall")
+def _render_logos(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.enum.text import PP_ALIGN
+    from pptx.util import Inches, Pt
+
+    logos = _as_list(content.get("logos"))[:8]
+    for i, logo in enumerate(logos):
+        col, row = i % 4, i // 4
+        left = Inches(0.7) + Inches(3.05) * col
+        top = Inches(1.5) + Inches(2.5) * row
+        name = str(logo.get("name") if isinstance(logo, dict) else logo)
+        path = str(logo.get("path") if isinstance(logo, dict) else "")
+        if not _picture(slide, path, assets, left, top, Inches(2.8)):
+            _rect(slide, left, top, Inches(2.8), Inches(2.1), SURFACE)
+            _textbox(slide, left, top + Inches(0.8), Inches(2.8), Inches(0.5), name, size=Pt(14), color=INK, align=PP_ALIGN.CENTER)
+
+
+@register("location-map")
+def _render_map(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.util import Inches, Pt
+
+    _rect(slide, Inches(0.7), Inches(1.4), Inches(11.9), Inches(5.1), SURFACE)
+    for loc in _as_list(content.get("locations")):
+        if not isinstance(loc, dict):
+            continue
+        x = 0.7 + 11.9 * (float(loc.get("posX") or 50) / 100.0)
+        y = 1.4 + 5.1 * (float(loc.get("posY") or 50) / 100.0)
+        color = ACCENT if loc.get("isHQ") else BODY
+        _oval(slide, Inches(x), Inches(y), Inches(0.22), Inches(0.22), color)
+        _textbox(slide, Inches(x + 0.25), Inches(y - 0.08), Inches(2.4), Inches(0.35), str(loc.get("name") or ""), size=Pt(12), color=INK)
+
+
+@register("case-two-col")
+def _render_case(slide: Any, prs: Any, content: dict[str, Any], assets: dict[str, bytes]) -> None:
+    from pptx.util import Inches, Pt
+
+    _textbox(slide, Inches(0.7), Inches(1.35), Inches(11.9), Inches(0.45), str(content.get("companyName") or ""), size=Pt(18), color=INK, bold=True)
+    info = [f"{i.get('key')}: {i.get('value')}" for i in _as_list(content.get("info")) if isinstance(i, dict)]
+    metrics = [f"{i.get('key')}: {i.get('value')}" for i in _as_list(content.get("metrics")) if isinstance(i, dict)]
+    _lines(slide, Inches(0.7), Inches(2.0), Inches(5.8), Inches(4.4), info, size=Pt(14), bullet=True)
+    _lines(slide, Inches(6.8), Inches(2.0), Inches(5.8), Inches(4.4), metrics, size=Pt(14), bullet=True)
+
+
+def validate_deck(deck: Any) -> dict[str, Any] | None:
+    if not isinstance(deck, dict):
+        return None
+    slides = deck.get("slides")
+    if not isinstance(slides, list) or not slides:
+        return None
+    out: list[dict[str, Any]] = []
+    for raw in slides:
+        if not isinstance(raw, dict):
+            continue
+        kind = str(raw.get("type") or "content")
+        if kind not in {"cover", "section", "content", "case-study", "ending"}:
+            kind = "content"
+        slide = dict(raw)
+        slide["type"] = kind
+        if kind in {"content", "case-study"}:
+            slide["layout"] = normalize_layout(slide.get("layout"))
+            if not content_nonempty(slide.get("content")):
+                continue
+        elif not str(slide.get("title") or "").strip():
+            continue
+        out.append(slide)
+    if not out:
+        return None
+    return {"slides": out}
+
+
+def render_deck(deck: dict[str, Any], assets: dict[str, bytes] | None = None) -> bytes:
+    """検証済み deck を PPTX バイト列にする。"""
+    from pptx import Presentation
+    from pptx.util import Inches
+
+    assets = assets or {}
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    for slide_def in deck.get("slides") or []:
+        kind = slide_def.get("type")
+        notes = str(slide_def.get("notes") or "")
+        if kind == "cover":
+            slide = _add_title_slide(prs, str(slide_def.get("title") or ""), str(slide_def.get("subtitle") or ""))
+            _add_notes(slide, notes)
+            continue
+        if kind == "section":
+            slide = _add_section_slide(prs, str(slide_def.get("title") or ""))
+            _add_notes(slide, notes)
+            continue
+        if kind == "ending":
+            slide = _add_ending_slide(prs, str(slide_def.get("title") or ""), str(slide_def.get("subtitle") or ""))
+            _add_notes(slide, notes)
+            continue
+        slide = prs.slides.add_slide(prs.slide_layouts[6])
+        layout = slide_def.get("layout") if slide_def.get("layout") in LAYOUT_ID_SET else DEFAULT_LAYOUT
+        if layout != "fullscreen-photo":
+            _add_content_chrome(slide, prs, str(slide_def.get("title") or ""))
+        else:
+            _fill_slide(slide)
+            _add_content_chrome(slide, prs, str(slide_def.get("title") or ""))
+        content = slide_def.get("content") if isinstance(slide_def.get("content"), dict) else {}
+        renderer = _REGISTRY.get(layout) or _REGISTRY[DEFAULT_LAYOUT]
+        renderer(slide, prs, content, assets)
+        _add_notes(slide, notes)
+    _add_footers(prs)
+    out = io.BytesIO()
+    prs.save(out)
+    return out.getvalue()
+
+
+def registered_layouts() -> tuple[str, ...]:
+    return tuple(sorted(_REGISTRY))

--- a/procuretech-generate-app/app/pptx_plan.py
+++ b/procuretech-generate-app/app/pptx_plan.py
@@ -1,0 +1,484 @@
+"""Markdown 章から deck JSON を組み立てる（LLM は枚割りと layout、本文は機械充填）。"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.llm import chat, llm_enabled
+from app.pptx_catalog import (
+    DEFAULT_LAYOUT,
+    DIAGRAM_LAYOUTS,
+    LAYOUT_IDS,
+    NUMERIC_LAYOUTS,
+    SELECTION_GUIDE,
+    content_nonempty,
+    normalize_layout,
+)
+from app.pptx_layouts import validate_deck
+
+log = logging.getLogger("procuretech-generate")
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+_BULLET_RE = re.compile(r"^(\s*)[-*]\s+(.*)$")
+_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(\s*<?([^)>\s]+)>?")
+_NUMBER_RE = re.compile(r"([0-9]+(?:\.[0-9]+)?\s*%|[0-9]{1,3}(?:,[0-9]{3})+(?:\.[0-9]+)?|[0-9]+(?:\.[0-9]+)?)")
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*([\s\S]+?)```", re.I)
+
+
+@dataclass
+class SourceBlock:
+    filename: str
+    heading: str
+    text: str
+    images: list[str] = field(default_factory=list)
+    bullets: list[str] = field(default_factory=list)
+
+
+def _rel_of(path: str) -> str:
+    return path.replace("\\", "/").lstrip("/")
+
+
+def _is_waiting_image(rel: str) -> bool:
+    name = rel.rsplit("/", 1)[-1].lower()
+    return "waiting" in name
+
+
+def _content_images(paths: list[str]) -> list[str]:
+    return [p for p in paths if p and not _is_waiting_image(p)]
+
+
+def _plain_source(text: str) -> str:
+    """ノート用。画像記法・フェンス・見出し記号を除いた本文だけにする。"""
+    cleaned = _IMAGE_RE.sub("", text or "")
+    cleaned = re.sub(r"```[\s\S]*?```", "", cleaned)
+    cleaned = re.sub(r"`([^`]+)`", r"\1", cleaned)
+    cleaned = re.sub(r"\*\*(.+?)\*\*", r"\1", cleaned)
+    cleaned = re.sub(r"^#{1,6}\s+", "", cleaned, flags=re.M)
+    cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
+
+
+def parse_source_blocks(name: str, sections: list[dict[str, Any]]) -> list[SourceBlock]:
+    blocks: list[SourceBlock] = []
+    for sec in sections:
+        filename = str(sec.get("filename") or "section.md")
+        content = str(sec.get("content") or "")
+        current = SourceBlock(filename=filename, heading="", text="")
+        paragraphs: list[str] = []
+        in_code = False
+        for raw in content.splitlines():
+            stripped = raw.strip()
+            if stripped.startswith("```"):
+                in_code = not in_code
+                continue
+            if in_code:
+                continue
+            hm = _HEADING_RE.match(stripped)
+            if hm:
+                if current.heading or paragraphs or current.images or current.bullets:
+                    current.text = "\n".join(paragraphs).strip()
+                    blocks.append(current)
+                    paragraphs = []
+                current = SourceBlock(filename=filename, heading=hm.group(2).strip(), text="")
+                continue
+            images = list(_IMAGE_RE.finditer(stripped))
+            for im in images:
+                rel = _rel_of(im.group(2))
+                if not _is_waiting_image(rel):
+                    current.images.append(rel)
+            if images and _IMAGE_RE.sub("", stripped).strip() == "":
+                continue
+            bm = _BULLET_RE.match(raw)
+            if bm:
+                current.bullets.append(bm.group(2).strip())
+                continue
+            if stripped:
+                paragraphs.append(stripped)
+        current.text = "\n".join(paragraphs).strip()
+        if current.heading or current.text or current.bullets or current.images:
+            blocks.append(current)
+    if not blocks:
+        blocks.append(SourceBlock(filename="document.md", heading=name, text=name))
+    return blocks
+
+
+def _find_block(blocks: list[SourceBlock], source: Any) -> SourceBlock | None:
+    if not isinstance(source, dict):
+        return blocks[0] if blocks else None
+    filename = str(source.get("filename") or "")
+    heading = str(source.get("heading") or source.get("title") or "")
+    for block in blocks:
+        if filename and block.filename != filename:
+            continue
+        if heading and heading not in (block.heading,):
+            if heading not in block.heading and block.heading not in heading:
+                continue
+        return block
+    if filename:
+        for block in blocks:
+            if block.filename == filename:
+                return block
+    if heading:
+        for block in blocks:
+            if heading in block.heading or block.heading in heading:
+                return block
+    return blocks[0] if blocks else None
+
+
+def _sentences(text: str) -> list[str]:
+    parts = [p.strip() for p in re.split(r"(?<=[。．\n])", text) if p.strip()]
+    return parts or ([text.strip()] if text.strip() else [])
+
+
+def _clip(text: str, limit: int) -> str:
+    s = _plain_source(text).replace("\n", "")
+    if len(s) <= limit:
+        return s
+    return s[: max(limit - 1, 1)] + "…"
+
+
+def _block_key(block: SourceBlock) -> tuple[str, str]:
+    return (block.filename, block.heading)
+
+
+def _suggest_layout(block: SourceBlock, previous: str) -> str:
+    """章の性質と直前 layout から、連続しない見せ方を選ぶ。"""
+    heading = block.heading or ""
+    blob = f"{heading}\n{block.text}\n{' '.join(block.bullets)}"
+    images = _content_images(block.images)
+    if images:
+        return "fullscreen-photo" if previous != "fullscreen-photo" else "numbered-feature-cards"
+    if _NUMBER_RE.search(blob) and any(k in heading for k in ("規模", "KPI", "KGI", "目標", "件数", "数値")):
+        return "kpi-three-col" if previous != "kpi-three-col" else "text-data-emphasis"
+    if any(k in heading for k in ("手順", "フロー", "プロセス", "工程")):
+        return "step-flow"
+    if any(k in heading for k in ("比較", "更改", "Before", "After")):
+        return "before-after-split"
+    if any(k in heading for k in ("課題", "問題", "ペイン")):
+        return "user-pain-points"
+    if any(k in heading for k in ("スケジュール", "日程", "計画")):
+        return "schedule-list"
+    rotate = [
+        "parallel-items",
+        "numbered-feature-cards",
+        "three-column",
+        "three-step-column",
+        "checklist-table",
+        "qa-grid",
+    ]
+    for name in rotate:
+        if name != previous:
+            return name
+    return DEFAULT_LAYOUT
+
+
+def _fill_content(layout: str, block: SourceBlock) -> dict[str, Any]:
+    bullets = [_plain_source(b) for b in block.bullets if _plain_source(b)]
+    if not bullets:
+        bullets = [s for s in _sentences(_plain_source(block.text))[:6] if s]
+    images = _content_images(block.images)
+    numbers = _NUMBER_RE.findall(block.text + "\n" + "\n".join(block.bullets))
+
+    if layout == "fullscreen-photo" and images:
+        return {"image": images[0], "headline": block.heading, "subMessages": []}
+    if layout in NUMERIC_LAYOUTS and numbers:
+        if layout == "kpi-three-col":
+            items = []
+            labels = bullets or [block.heading]
+            for i, num in enumerate(numbers[:3]):
+                items.append({"value": num, "label": labels[i] if i < len(labels) else block.heading})
+            return {"items": items}
+        if layout == "text-data-emphasis":
+            return {
+                "narrative": _clip(block.text or (bullets[0] if bullets else block.heading), 80),
+                "bigNumber": numbers[0],
+                "bigNumberLabel": _clip(bullets[1] if len(bullets) > 1 else block.heading, 20),
+            }
+        if layout == "horizontal-bar-ranking":
+            items = []
+            for i, num in enumerate(numbers[:6]):
+                try:
+                    value = float(str(num).replace("%", "").replace(",", ""))
+                except ValueError:
+                    value = 0
+                label = bullets[i] if i < len(bullets) else f"項目{i + 1}"
+                items.append({"label": label, "value": value})
+            return {"items": items}
+        if layout in {"pie-chart-highlight", "doughnut-three-col", "two-col-text-chart", "stacked-bar-chart"}:
+            labels = [b[:12] for b in (bullets or ["A", "B", "C"])][:3]
+            vals = []
+            for n in numbers[: len(labels)]:
+                try:
+                    vals.append(float(str(n).replace("%", "").replace(",", "")))
+                except ValueError:
+                    vals.append(0)
+            while len(vals) < len(labels):
+                vals.append(0)
+            if layout == "two-col-text-chart":
+                return {
+                    "left": {"heading": _clip(block.heading, 24), "body": _clip(block.text, 80)},
+                    "right": {"chartType": "bar", "data": {"labels": labels, "values": vals}},
+                }
+            if layout == "stacked-bar-chart":
+                return {"categories": labels, "series": [{"name": "値", "values": vals}]}
+            if layout == "doughnut-three-col":
+                return {"charts": [{"title": block.heading, "labels": labels, "values": vals}]}
+            return {
+                "data": {"labels": labels, "values": vals},
+                "highlight": {"value": numbers[0], "message": bullets[0] if bullets else block.heading},
+            }
+        if layout == "kpi-formula":
+            return {
+                "kpiName": block.heading,
+                "numerator": bullets[0] if bullets else "分子",
+                "denominator": bullets[1] if len(bullets) > 1 else "分母",
+            }
+
+    if layout in {"checklist-table", "schedule-list"}:
+        items = [{"label": _clip(b, 40), "checked": False, "note": ""} for b in bullets[:8]]
+        if layout == "schedule-list":
+            return {"phases": [{"phase": _clip(b, 24), "period": "", "owner": "", "details": ""} for b in bullets[:6]]}
+        return {"headers": ["項目", "状態", "備考"], "items": items}
+
+    if layout in {"comparison-table", "before-after-split"}:
+        mid = max(len(bullets) // 2, 1)
+        before, after = bullets[:mid], bullets[mid:] or bullets[:1]
+        if layout == "before-after-split":
+            return {"before": {"title": "現状", "points": before}, "after": {"title": "更改後", "points": after}}
+        rows = []
+        for i, b in enumerate(before):
+            rows.append({"category": b, "before": b, "after": after[i] if i < len(after) else ""})
+        return {"beforeTitle": "現状", "afterTitle": "更改後", "rows": rows}
+
+    if layout == "qa-grid":
+        items = []
+        for i in range(0, min(len(bullets), 8), 2):
+            items.append({"q": bullets[i], "a": bullets[i + 1] if i + 1 < len(bullets) else ""})
+        if not items and block.text:
+            items = [{"q": _clip(block.heading, 24), "a": _clip(block.text, 60)}]
+        return {"items": items[:4]}
+
+    if layout == "quote":
+        src = bullets[0] if bullets else _plain_source(block.text)
+        return {"text": _clip(src, 80), "author": "", "role": ""}
+
+    if layout == "chat-dialogue":
+        msgs = []
+        for i, b in enumerate(bullets[:4]):
+            msgs.append({"speaker": "質問" if i % 2 == 0 else "回答", "text": b})
+        if not msgs:
+            msgs = [{"speaker": "本文", "text": block.text[:160] or block.heading}]
+        return {"messages": msgs}
+
+    if layout in {"ceo-message"}:
+        return {"name": _clip(block.heading, 20), "role": "", "message": _clip(block.text or " ".join(bullets), 90)}
+
+    if layout in {"member-grid", "member-three-col"}:
+        return {"members": [{"name": b, "role": "", "bio": ""} for b in bullets[:4]]}
+
+    if layout == "case-two-col":
+        return {
+            "companyName": block.heading,
+            "info": [{"key": "概要", "value": _clip(block.text or (bullets[0] if bullets else ""), 60)}],
+            "metrics": [{"key": "要点", "value": bullets[1] if len(bullets) > 1 else ""}],
+        }
+
+    if layout in {"year-list", "timeline", "vertical-timeline", "step-flow", "step-up", "three-step-column"}:
+        items = []
+        for b in bullets[:6]:
+            items.append({"date": "", "title": _clip(b, 22), "label": _clip(b, 22), "description": "", "heading": _clip(b, 22)})
+        return {"items": items, "steps": items}
+
+    if layout == "logo-wall":
+        return {"logos": [{"name": b} for b in bullets[:8]]}
+
+    if images and layout in DIAGRAM_LAYOUTS:
+        return {"image": images[0], "headline": block.heading, "subMessages": bullets[:2]}
+
+    items = []
+    for b in bullets[:4]:
+        items.append({"heading": _clip(b, 22), "description": _clip(b, 56) if len(b) > 22 else "", "title": _clip(b, 22)})
+    if not items and block.text:
+        for s in _sentences(_plain_source(block.text))[:4]:
+            items.append({"heading": _clip(s, 22), "description": _clip(s, 56)})
+    if images and not items:
+        return {"image": images[0], "headline": _clip(block.heading, 28)}
+    return {"items": items}
+
+
+def _attach_notes(slide: dict[str, Any], block: SourceBlock | None) -> None:
+    if not block:
+        return
+    original = _plain_source(
+        "\n".join(x for x in (block.text, "\n".join(f"・ {b}" for b in block.bullets)) if x)
+    )
+    if not original:
+        return
+    if len(original) < 20:
+        return
+    heading = block.heading or "本文"
+    slide["notes"] = f"元の本文（{heading}）\n{original}"
+
+
+def _outline_for_prompt(name: str, blocks: list[SourceBlock]) -> str:
+    lines = [f"文書名: {name}", "章・節:"]
+    for i, block in enumerate(blocks, 1):
+        imgs = f" 画像:{','.join(block.images)}" if block.images else ""
+        excerpt = (block.text or " ".join(block.bullets))[:280]
+        lines.append(f"{i}. file={block.filename} heading={block.heading or '(無題)'}{imgs}")
+        if excerpt:
+            lines.append(f"   抜粋: {excerpt}")
+    return "\n".join(lines)
+
+
+def _parse_llm_json(text: str) -> dict[str, Any] | None:
+    raw = text.strip()
+    m = _JSON_FENCE_RE.search(raw)
+    if m:
+        raw = m.group(1).strip()
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start < 0 or end <= start:
+        return None
+    try:
+        data = json.loads(raw[start : end + 1])
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _complete_slides(
+    name: str, planned: list[dict[str, Any]], blocks: list[SourceBlock]
+) -> dict[str, Any] | None:
+    slides: list[dict[str, Any]] = []
+    covered: set[tuple[str, str]] = set()
+    previous_layout = ""
+    if not planned or planned[0].get("type") != "cover":
+        slides.append({"type": "cover", "title": name, "subtitle": ""})
+    for raw in planned:
+        if not isinstance(raw, dict):
+            continue
+        kind = str(raw.get("type") or "content")
+        if kind == "cover":
+            title = str(raw.get("title") or name)
+            subtitle = str(raw.get("subtitle") or "")
+            existing = next((s for s in slides if s.get("type") == "cover"), None)
+            if existing:
+                existing["title"] = title or existing["title"]
+                existing["subtitle"] = subtitle
+            else:
+                slides.insert(0, {"type": "cover", "title": title, "subtitle": subtitle})
+            continue
+        if kind == "ending":
+            # 営業デッキの「ご清聴」締めは付けない。文書の章だけをスライドにする。
+            continue
+        if kind == "section":
+            title = str(raw.get("title") or "")
+            if not title:
+                continue
+            slides.append({"type": "section", "title": title, "subtitle": str(raw.get("subtitle") or "")})
+            continue
+        block = _find_block(blocks, raw.get("source"))
+        layout = normalize_layout(raw.get("layout"))
+        if block and _content_images(block.images) and layout in DIAGRAM_LAYOUTS:
+            layout = "fullscreen-photo"
+        if block and layout in NUMERIC_LAYOUTS and not _NUMBER_RE.search(block.text + " ".join(block.bullets)):
+            layout = _suggest_layout(block, previous_layout)
+        if not block:
+            continue
+        # LLM が本文を返しても使わない。要点は機械充填、全文はノート。
+        content = _fill_content(layout, block)
+        if not content_nonempty(content):
+            continue
+        slide = {
+            "type": "content" if kind != "case-study" else "case-study",
+            "title": str(raw.get("title") or block.heading or name),
+            "layout": layout,
+            "content": content,
+        }
+        _attach_notes(slide, block)
+        slides.append(slide)
+        covered.add(_block_key(block))
+        previous_layout = layout
+    for block in blocks:
+        if _block_key(block) in covered:
+            continue
+        if not (block.text or block.bullets or _content_images(block.images)):
+            continue
+        layout = _suggest_layout(block, previous_layout)
+        content = _fill_content(layout, block)
+        if not content_nonempty(content):
+            continue
+        slide = {
+            "type": "content",
+            "title": block.heading or name,
+            "layout": layout,
+            "content": content,
+        }
+        _attach_notes(slide, block)
+        slides.append(slide)
+        previous_layout = layout
+    return validate_deck({"slides": slides})
+
+
+def plan_deck(
+    name: str,
+    sections: list[dict[str, Any]],
+    assets: dict[str, bytes] | None = None,
+    *,
+    complete: Any = chat,
+) -> dict[str, Any] | None:
+    """LLM で構成し、失敗時は None（呼び出し側が決定論変換へ落とす）。"""
+    if not llm_enabled():
+        log.info("pptx plan skipped (GENERATE_PPTX_LLM=0)")
+        return None
+    blocks = parse_source_blocks(name, sections)
+    image_paths = sorted({img for b in blocks for img in b.images} | set((assets or {}).keys()))
+    user = (
+        f"{_outline_for_prompt(name, blocks)}\n"
+        f"利用可能な画像: {', '.join(image_paths) or 'なし'}\n\n"
+        "次の JSON だけを返してください。説明文は不要です。\n"
+        '{"slides":[{"type":"cover|section|content","title":"...",'
+        '"layout":"(content のみ)","source":{"filename":"...","heading":"..."}}]}\n'
+        "規則:\n"
+        "- 本文は書かない。source で章・節を指す。content は空でよい。\n"
+        "- 見出し（# / ## / ###）ごとに最低 1 枚。長い節は分割する。\n"
+        "- 同じ layout を連続で使わない。カード・手順・表・図を散らす。\n"
+        "- 「ご清聴ありがとうございました」などの締めスライドは作らない。\n"
+        "- layout は次のいずれか: " + ", ".join(LAYOUT_IDS) + "\n"
+        f"{SELECTION_GUIDE}\n"
+        "- 無い数値・固有名を作らない。\n"
+        "- 画像がある図的な節は fullscreen-photo を優先する。\n"
+    )
+    try:
+        text = complete(
+            [
+                {
+                    "role": "system",
+                    "content": "あなたはスライド構成だけを返す。本文の創作はしない。JSON のみ。",
+                },
+                {"role": "user", "content": user},
+            ]
+        )
+        data = _parse_llm_json(text)
+        if not data:
+            log.warning("pptx plan: LLM 応答を JSON として読めませんでした")
+            return None
+        planned = data.get("slides")
+        if not isinstance(planned, list):
+            log.warning("pptx plan: slides 配列がありません")
+            return None
+        deck = _complete_slides(name, planned, blocks)
+        if deck:
+            log.info("pptx plan: %s slides", len(deck.get("slides") or []))
+        else:
+            log.warning("pptx plan: 検証後の deck が空です")
+        return deck
+    except Exception as exc:  # noqa: BLE001
+        log.warning("pptx plan failed: %s", exc)
+        return None

--- a/procuretech-generate-app/requirements.txt
+++ b/procuretech-generate-app/requirements.txt
@@ -5,3 +5,4 @@ openpyxl==3.1.5
 python-docx==1.1.2
 python-pptx==1.0.2
 Pillow>=10.4.0
+httpx==0.28.1

--- a/procuretech-generate-app/tests/conftest.py
+++ b/procuretech-generate-app/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+
+# 既定では LLM を叩かない（決定論変換の回帰を保つ）。
+os.environ.setdefault("GENERATE_PPTX_LLM", "0")

--- a/procuretech-generate-app/tests/test_compose_formats.py
+++ b/procuretech-generate-app/tests/test_compose_formats.py
@@ -76,6 +76,19 @@ def test_markdown_to_pptx_if_available():
     assert data[:2] == b"PK"
 
 
+def test_compose_pptx_without_llm_uses_deterministic_path():
+    pytest.importorskip("pptx")
+    client = TestClient(app)
+    res = client.post(
+        "/compose",
+        json={"outputs": [{"name": "文書", "format": "pptx", "sections": SECTIONS}]},
+    )
+    assert res.status_code == 200
+    with zipfile.ZipFile(io.BytesIO(res.content)) as zf:
+        assert "文書.pptx" in zf.namelist()
+        assert zf.read("文書.pptx")[:2] == b"PK"
+
+
 def test_markdown_to_docx_uses_dads():
     pytest.importorskip("docx")
     from app.dads import FONT, hex_of, ACCENT

--- a/procuretech-generate-app/tests/test_pptx_layouts.py
+++ b/procuretech-generate-app/tests/test_pptx_layouts.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+
+import pytest
+
+from app.pptx_catalog import LAYOUT_IDS, DEFAULT_LAYOUT, minimal_fixture
+from app.pptx_layouts import registered_layouts, render_deck, validate_deck
+from app.pptx_plan import plan_deck
+
+
+def test_all_catalog_layouts_are_registered():
+    registered = set(registered_layouts())
+    missing = set(LAYOUT_IDS) - registered
+    assert not missing
+
+
+@pytest.mark.parametrize("layout", LAYOUT_IDS)
+def test_each_layout_renders(layout: str):
+    deck = {
+        "slides": [
+            {"type": "cover", "title": "表紙"},
+            {
+                "type": "content",
+                "title": layout,
+                "layout": layout,
+                "content": minimal_fixture(layout),
+            },
+        ]
+    }
+    data = render_deck(validate_deck(deck) or deck, {})
+    assert data[:2] == b"PK"
+
+
+def test_unknown_layout_falls_back():
+    deck = validate_deck(
+        {
+            "slides": [
+                {
+                    "type": "content",
+                    "title": "要点",
+                    "layout": "does-not-exist",
+                    "content": {"items": [{"heading": "A", "description": "B"}]},
+                }
+            ]
+        }
+    )
+    assert deck is not None
+    assert deck["slides"][0]["layout"] == DEFAULT_LAYOUT
+    assert render_deck(deck, {})[:2] == b"PK"
+
+
+def test_empty_content_slide_is_dropped():
+    deck = validate_deck(
+        {
+            "slides": [
+                {"type": "cover", "title": "表紙"},
+                {"type": "content", "title": "空", "layout": "quote", "content": {}},
+            ]
+        }
+    )
+    assert deck is not None
+    assert [s["type"] for s in deck["slides"]] == ["cover"]
+
+
+def test_notes_are_written_to_pptx():
+    deck = {
+        "slides": [
+            {"type": "cover", "title": "表紙"},
+            {
+                "type": "content",
+                "title": "課題",
+                "layout": "parallel-items",
+                "content": minimal_fixture("parallel-items"),
+                "notes": "元の本文（背景）\n現行システムは検索が遅い。",
+            },
+        ]
+    }
+    data = render_deck(deck, {})
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        notes_xml = "\n".join(
+            zf.read(name).decode("utf-8") for name in zf.namelist() if "notesSlide" in name
+        )
+    assert "現行システムは検索が遅い" in notes_xml
+    assert "元の本文" in notes_xml
+
+
+def test_plan_deck_drops_thank_you_ending(monkeypatch):
+    monkeypatch.setenv("GENERATE_PPTX_LLM", "1")
+
+    def fake_complete(messages, **kwargs):
+        return json.dumps(
+            {
+                "slides": [
+                    {"type": "cover", "title": "文書"},
+                    {
+                        "type": "content",
+                        "title": "背景",
+                        "layout": "parallel-items",
+                        "source": {"filename": "a.md", "heading": "背景"},
+                    },
+                    {"type": "ending", "title": "ご清聴ありがとうございました", "subtitle": "文書"},
+                ]
+            },
+            ensure_ascii=False,
+        )
+
+    deck = plan_deck(
+        "文書",
+        [{"filename": "a.md", "content": "# 背景\n要点です。\n"}],
+        complete=fake_complete,
+    )
+    assert deck is not None
+    assert all(s.get("type") != "ending" for s in deck["slides"])
+    assert not any("ご清聴" in str(s.get("title") or "") for s in deck["slides"])
+
+
+def test_plan_deck_disabled_returns_none():
+    assert plan_deck("文書", [{"filename": "a.md", "content": "# 背景\n本文\n"}]) is None
+
+
+def test_plan_deck_invalid_json_returns_none(monkeypatch):
+    monkeypatch.setenv("GENERATE_PPTX_LLM", "1")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://example.invalid")
+
+    def fake_complete(messages, **kwargs):
+        return "これは JSON ではありません"
+
+    assert plan_deck("文書", [{"filename": "a.md", "content": "# 背景\n本文\n"}], complete=fake_complete) is None
+
+
+def test_plan_deck_fills_from_source_and_notes(monkeypatch):
+    monkeypatch.setenv("GENERATE_PPTX_LLM", "1")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://example.invalid")
+    body = (
+        "現行システムの検索は遅く、同一案件が複数登録される問題がある。"
+        "担当者は手作業で突合しており、確認に時間がかかる。"
+    )
+    sections = [{"filename": "a.md", "content": f"# 背景\n\n{body}\n\n- 検索が遅い\n- 重複登録\n"}]
+
+    def fake_complete(messages, **kwargs):
+        return json.dumps(
+            {
+                "slides": [
+                    {"type": "cover", "title": "文書"},
+                    {
+                        "type": "content",
+                        "title": "背景",
+                        "layout": "parallel-items",
+                        "source": {"filename": "a.md", "heading": "背景"},
+                    },
+                ]
+            },
+            ensure_ascii=False,
+        )
+
+    deck = plan_deck("文書", sections, complete=fake_complete)
+    assert deck is not None
+    contents = [s for s in deck["slides"] if s["type"] == "content"]
+    assert contents
+    assert contents[0]["layout"] == "parallel-items"
+    assert contents[0]["content"]
+    assert "元の本文" in (contents[0].get("notes") or "")
+    assert "現行システム" in (contents[0].get("notes") or "")
+    assert "![" not in (contents[0].get("notes") or "")
+    assert render_deck(deck, {})[:2] == b"PK"
+
+
+def test_plan_deck_prefers_image_over_diagram(monkeypatch):
+    monkeypatch.setenv("GENERATE_PPTX_LLM", "1")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://example.invalid")
+    sections = [
+        {
+            "filename": "a.md",
+            "content": "# 構成\n\n関係を示す。\n\n![図](images/flow.png)\n",
+        }
+    ]
+
+    def fake_complete(messages, **kwargs):
+        return json.dumps(
+            {
+                "slides": [
+                    {"type": "cover", "title": "文書"},
+                    {
+                        "type": "content",
+                        "title": "構成",
+                        "layout": "venn-diagram",
+                        "source": {"filename": "a.md", "heading": "構成"},
+                    },
+                ]
+            }
+        )
+
+    deck = plan_deck("文書", sections, complete=fake_complete)
+    assert deck is not None
+    content = next(s for s in deck["slides"] if s.get("title") == "構成")
+    assert content["type"] == "content"
+    assert content["layout"] == "fullscreen-photo"
+    assert content["content"].get("image") == "images/flow.png"
+
+
+def test_notes_strip_markdown_and_skip_waiting_images(monkeypatch):
+    monkeypatch.setenv("GENERATE_PPTX_LLM", "1")
+    sections = [
+        {
+            "filename": "section2.md",
+            "content": (
+                "# 業務の手順\n\n"
+                    "催事申込みは次の手順で行う。内閣府からの連絡を受けて公開する。\n\n"
+                "![待ち](images/1788672411_df5da618_waiting.png)\n"
+                "![図](images/flow.png)\n"
+            ),
+        }
+    ]
+
+    def fake_complete(messages, **kwargs):
+        return json.dumps(
+            {
+                "slides": [
+                    {"type": "cover", "title": "文書"},
+                    {
+                        "type": "content",
+                        "title": "業務の手順",
+                        "layout": "fullscreen-photo",
+                        "source": {"filename": "section2.md", "heading": "業務の手順"},
+                    },
+                ]
+            }
+        )
+
+    deck = plan_deck("文書", sections, complete=fake_complete)
+    assert deck is not None
+    content = next(s for s in deck["slides"] if s.get("title") == "業務の手順")
+    assert content["content"].get("image") == "images/flow.png"
+    notes = content.get("notes") or ""
+    assert "催事申込み" in notes
+    assert "![" not in notes
+    assert "waiting" not in notes
+    assert "section2.md" not in notes
+    assert not content["content"].get("subMessages")
+
+
+def test_plan_ignores_llm_body_and_covers_all_headings(monkeypatch):
+    monkeypatch.setenv("GENERATE_PPTX_LLM", "1")
+    long_a = "現行システムの検索は遅く、同一案件が複数登録される問題がある。" * 2
+    long_b = "催事申込みはWebフォームから受け付け、職員が専用端末で確認する。" * 2
+    sections = [
+        {
+            "filename": "a.md",
+            "content": f"# 背景\n\n{long_a}\n\n## 手順\n\n{long_b}\n",
+        }
+    ]
+
+    def fake_complete(messages, **kwargs):
+        return json.dumps(
+            {
+                "slides": [
+                    {"type": "cover", "title": "文書"},
+                    {
+                        "type": "content",
+                        "title": "背景",
+                        "layout": "parallel-items",
+                        "source": {"filename": "a.md", "heading": "背景"},
+                        "content": {"items": [{"heading": long_a, "description": long_a}]},
+                    },
+                ]
+            },
+            ensure_ascii=False,
+        )
+
+    deck = plan_deck("文書", sections, complete=fake_complete)
+    assert deck is not None
+    contents = [s for s in deck["slides"] if s["type"] == "content"]
+    assert len(contents) >= 2
+    shown = json.dumps(contents[0]["content"], ensure_ascii=False)
+    assert long_a not in shown
+    assert "…" in shown or len(shown) < len(long_a)
+    assert "元の本文" in (contents[0].get("notes") or "")
+    assert long_a[:20] in (contents[0].get("notes") or "")
+    layouts = [s["layout"] for s in contents]
+    assert len(set(layouts)) >= 2


### PR DESCRIPTION
## Summary
- generate-app の pptx 合成で、LLM が章・節から多様な layout を選び、python-pptx がデジタル庁デザインシステムで描く。
- スライドは要点のみ。根拠の原文はスピーカーノートへ。待ち画像や Markdown 記法はノートに出さない。
- LLM 未設定・失敗時は従来の見出し分割へ落とす。営業デッキの「ご清聴」締めは付けない。

## Test plan
- [ ] `OPENAI_BASE_URL` または Ollama がある環境で pptx を書き出し、layout が章ごとに分かれること
- [ ] 長い本文はスライド上で短く、ノートに原文があること
- [ ] `GENERATE_PPTX_LLM=0` では従来の見出し分割であること
- [ ] 末尾に「ご清聴ありがとうございました」が付かないこと
- [ ] CI（python-regression / web-regression / pip-audit）が成功すること


Made with [Cursor](https://cursor.com)