### PR TITLE
fix(backend): LLM 応答から reasoning を画面に出さない

### DIFF
--- a/backend/app/llm.py
+++ b/backend/app/llm.py
@@ -191,6 +191,16 @@ def _content_text(content: Any) -> str:
     return str(content or "")
 
 
+def _assistant_visible_text(part: dict[str, Any]) -> str:
+    """ユーザ向け本文。reasoning / reasoning_content は出さない。"""
+    content = part.get("content")
+    if isinstance(content, str) and content:
+        return content
+    if content is not None and not isinstance(content, str):
+        return _content_text(content)
+    return ""
+
+
 def _is_image_prompt_task(
     messages: list[dict[str, Any]], request_id: str | None = None
 ) -> bool:
@@ -282,12 +292,7 @@ async def _complete(
         data = res.json()
     choices = data.get("choices") or [{}]
     message = choices[0].get("message") or {}
-    return (
-        message.get("content")
-        or message.get("reasoning_content")
-        or message.get("reasoning")
-        or ""
-    )
+    return _assistant_visible_text(message)
 
 
 def _extract_doc_texts_full(message: dict[str, Any]) -> list[tuple[str, str]]:
@@ -390,12 +395,7 @@ async def chat_once(
         data = res.json()
     choices = data.get("choices") or [{}]
     message = choices[0].get("message") or {}
-    answer = (
-        message.get("content")
-        or message.get("reasoning_content")
-        or message.get("reasoning")
-        or ""
-    )
+    answer = _assistant_visible_text(message)
     return _notes_prefix(notes) + answer
 
 
@@ -487,13 +487,7 @@ async def chat_stream(
                         continue
                     choice = (chunk.get("choices") or [{}])[0]
                     delta = choice.get("delta") or {}
-                    # vLLM reasoning は content が null で reasoning / reasoning_content に載る
-                    text = (
-                        delta.get("content")
-                        or delta.get("reasoning_content")
-                        or delta.get("reasoning")
-                        or ""
-                    )
+                    text = _assistant_visible_text(delta)
                     if text:
                         yield json.dumps({"text": text}, ensure_ascii=False) + "\n"
                     if choice.get("finish_reason"):

--- a/tests/test_llm_image_prompt.py
+++ b/tests/test_llm_image_prompt.py
@@ -47,3 +47,10 @@ def test_chat_payload_merges_image_extra_after_provider() -> None:
     )
     assert payload["chat_template_kwargs"] == {"enable_thinking": False}
     assert payload["response_format"]["type"] == "json_schema"
+
+
+def test_assistant_visible_text_skips_reasoning() -> None:
+    llm = load_service_module("backend/app/llm.py")
+    assert llm._assistant_visible_text({"content": "こんにちは", "reasoning": "think"}) == "こんにちは"
+    assert llm._assistant_visible_text({"content": None, "reasoning_content": "think"}) == ""
+    assert llm._assistant_visible_text({"content": "", "reasoning": "think"}) == ""


### PR DESCRIPTION
## Summary
- 共通の `/predict` / `/predict/stream` で、モデルが返す `reasoning` / `reasoning_content` を画面に出さない。
- 本文は `content` だけを使う。チャット、文章生成、翻訳、ダイアグラム、プロンプトテンプレートに共通。
- gpt-oss 系が思考過程を別フィールドに載せる場合に、英語の前置きが本文に混ざるのを防ぐ。

## Test plan
- [ ] `tests/test_llm_image_prompt.py` の `test_assistant_visible_text_skips_reasoning` が通る
- [ ] gpt-oss（さくら / Ollama Cloud）で短い挨拶を送り、思考過程の英語が出ず本文だけになる
- [ ] gpt-4.1 など reasoning を出さないモデルの応答が変わらない


Made with [Cursor](https://cursor.com)