### PR TITLE
fix(web): CompositionEditor の未使用 mutateProject を削除する

### DIFF
--- a/genai-web/packages/web/src/open-genai/procuretech-editor/ProcuretechEditorPage.tsx
+++ b/genai-web/packages/web/src/open-genai/procuretech-editor/ProcuretechEditorPage.tsx
@@ -438,7 +438,6 @@ const composeUiFromResult = (
 // テーマ既定を初期表示し、プロジェクト単位で並べ替え・ON/OFF・出力追加を上書きできる。
 const CompositionEditor = ({ projectId }: { projectId: string }) => {
   const { data, isLoading, mutate } = useEditorComposition(projectId);
-  const { mutate: mutateProject } = useEditorProject(projectId);
   const actions = useEditorActions();
   const { downloadCarrier } = useDownloadArtifactCarrier();
   const [outputs, setOutputs] = useState<EditorCompositionOutput[]>([]);


### PR DESCRIPTION
## Summary
- `CompositionEditor` で宣言だけして使っていない `mutateProject` を削除する
- `noUnusedLocals` により本番 web ビルドが TS6133 で落ちるのを直す（実際の `mutateProject` は別コンポーネント側のみ）

## Test plan
- [ ] `packages/web` の本番ビルド（`tsc` / `vite build`）が通る
- [ ] 書き出し・統合タブの合成定義エディタが従来どおり動く


Made with [Cursor](https://cursor.com)