### PR TITLE
feat(auth): 前面プロキシ出口 IP からは運用者フォームを出さず SAML にする

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -47,6 +47,8 @@ INTERNAL_SIGNING_SECRET=please-change-to-a-long-random-secret
 
 # 運用者ホスト専用の ID/PW ログイン（Keycloak と別経路）。
 # Host が一致し、かつ OPERATOR_USERS が空でないときだけ /auth/login がフォームになる。
+# 前面プロキシがオリジンへ Host を運用者 FQDN で送る場合は、出口 IP を書いて SAML へ回す。
+# OPERATOR_SAML_SOURCE_IPS=203.0.113.10
 # パスワードは bcrypt ハッシュ。生成例:
 #   python3 -c "import bcrypt,getpass; p=getpass.getpass(); print(bcrypt.hashpw(p.encode(), bcrypt.gensalt()).decode())"
 # OPERATOR_LOGIN_HOSTS=ops.example.lg.jp

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,7 +22,7 @@ import time
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
-from urllib.parse import quote, unquote
+from urllib.parse import quote, unquote, urlparse
 
 import httpx
 from fastapi import FastAPI, Header, HTTPException, Query, Request
@@ -1236,10 +1236,18 @@ async def _prepare_saml_request(request: Request) -> dict[str, Any]:
         form = {k: v for k, v in raw.items()}
     # リバースプロキシ配下では request.url.scheme が http のままになるため、
     # X-Forwarded-* を優先して Recipient 検証用の公開 URL を組み立てる。
+    # 前面プロキシがオリジンへ運用者 Host で来る場合は、PUBLIC_URL のホストで検証する。
     forwarded_proto = request.headers.get("x-forwarded-proto", request.url.scheme)
     host = request.headers.get("x-forwarded-host") or request.headers.get(
         "host", "localhost:8000"
     )
+    if ops_login.from_saml_source(request):
+        public = ops_login.public_frontend()
+        parsed = urlparse(public) if public else None
+        if parsed and parsed.hostname:
+            host = parsed.hostname
+            if parsed.scheme in ("http", "https"):
+                forwarded_proto = parsed.scheme
     forwarded_port = request.headers.get("x-forwarded-port")
     if forwarded_port:
         server_port = forwarded_port
@@ -1409,7 +1417,7 @@ async def auth_logout(
 
 @app.post("/auth/ops")
 async def auth_ops(request: Request) -> Response:
-    """運用者ホスト専用の ID/PW ログイン。それ以外の Host では 404。"""
+    """運用者ホスト専用の ID/PW ログイン。Host 不一致または SAML 出口 IP からは 404。"""
     if not ops_login.enabled(request):
         return JSONResponse(status_code=404, content={"error": "not found"})
     error, location, _user = await ops_login.handle_post(

--- a/backend/app/ops_login.py
+++ b/backend/app/ops_login.py
@@ -1,6 +1,7 @@
 """運用者ホスト専用の ID/PW ログイン（Keycloak とは別経路）。
 
 OPERATOR_LOGIN_HOSTS に含まれる Host かつ OPERATOR_USERS が空でないときだけ有効。
+OPERATOR_SAML_SOURCE_IPS（前面プロキシ出口など）からのアクセスは Host が一致しても無効。
 それ以外は呼び出し側が従来の SAML へ進む。
 """
 
@@ -31,6 +32,34 @@ def request_host(request: Any) -> str:
 def operator_hosts() -> set[str]:
     raw = os.environ.get("OPERATOR_LOGIN_HOSTS") or ""
     return {part.strip().lower() for part in raw.split(",") if part.strip()}
+
+
+def saml_source_ips() -> set[str]:
+    raw = os.environ.get("OPERATOR_SAML_SOURCE_IPS") or ""
+    return {part.strip() for part in raw.split(",") if part.strip()}
+
+
+def request_peer_ip(request: Any) -> str:
+    """nginx の X-Real-IP（$remote_addr）。X-Forwarded-For は使わない。"""
+    real = (request.headers.get("x-real-ip") or "").split(",")[0].strip()
+    if real:
+        return real
+    client = getattr(request, "client", None)
+    return (getattr(client, "host", None) or "").strip()
+
+
+def from_saml_source(request: Any) -> bool:
+    ip = request_peer_ip(request)
+    return bool(ip) and ip in saml_source_ips()
+
+
+def public_frontend() -> str:
+    return (os.environ.get("FRONTEND_URL") or os.environ.get("PUBLIC_URL") or "").rstrip("/")
+
+
+def public_host() -> str:
+    host = (urlparse(public_frontend()).hostname or "").strip().lower()
+    return host
 
 
 def load_users() -> list[dict[str, Any]]:
@@ -71,6 +100,8 @@ def load_users() -> list[dict[str, Any]]:
 
 
 def enabled(request: Any) -> bool:
+    if from_saml_source(request):
+        return False
     hosts = operator_hosts()
     if not hosts or not load_users():
         return False
@@ -78,6 +109,10 @@ def enabled(request: Any) -> bool:
 
 
 def request_origin(request: Any) -> str:
+    if from_saml_source(request):
+        public = public_frontend()
+        if public:
+            return public
     proto = (request.headers.get("x-forwarded-proto") or request.url.scheme or "https").split(",")[0].strip()
     if proto not in ("http", "https"):
         proto = "https"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -156,6 +156,7 @@ services:
       - SAML_IDP_METADATA_URL=${SAML_IDP_METADATA_URL:-http://keycloak:8080/kc/realms/open-genai/protocol/saml/descriptor}
       - APP_TITLE=${APP_TITLE:-${VITE_APP_TITLE:-Open GENAI}}
       - OPERATOR_LOGIN_HOSTS=${OPERATOR_LOGIN_HOSTS:-}
+      - OPERATOR_SAML_SOURCE_IPS=${OPERATOR_SAML_SOURCE_IPS:-}
       - OPERATOR_USERS=${OPERATOR_USERS:-}
     volumes:
       - backend_data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,7 @@ services:
       - SAML_SP_SLS_URL=${PUBLIC_URL:-http://localhost}/api/auth/saml/sls
       - APP_TITLE=${APP_TITLE:-${VITE_APP_TITLE:-Open GENAI}}
       - OPERATOR_LOGIN_HOSTS=${OPERATOR_LOGIN_HOSTS:-}
+      - OPERATOR_SAML_SOURCE_IPS=${OPERATOR_SAML_SOURCE_IPS:-}
       - OPERATOR_USERS=${OPERATOR_USERS:-}
       # backend(コンテナ内)から IdP メタデータを取得する URL（Keycloak relative /kc）
       - SAML_IDP_METADATA_URL=${SAML_IDP_METADATA_URL:-http://keycloak:8080/kc/realms/open-genai/protocol/saml/descriptor}

--- a/tests/test_ops_login.py
+++ b/tests/test_ops_login.py
@@ -9,16 +9,32 @@ from conftest import load_service_module
 
 
 def _mod(**env: str):
-    for key in ("OPERATOR_LOGIN_HOSTS", "OPERATOR_USERS", "APP_TITLE"):
+    for key in (
+        "OPERATOR_LOGIN_HOSTS",
+        "OPERATOR_USERS",
+        "OPERATOR_SAML_SOURCE_IPS",
+        "APP_TITLE",
+        "FRONTEND_URL",
+        "PUBLIC_URL",
+    ):
         os.environ.pop(key, None)
     os.environ.update(env)
     return load_service_module("backend/app/ops_login.py")
 
 
-def _req(host: str, *, xf_host: str | None = None, proto: str = "https", redirect: str | None = None):
+def _req(
+    host: str,
+    *,
+    xf_host: str | None = None,
+    proto: str = "https",
+    redirect: str | None = None,
+    real_ip: str | None = None,
+):
     headers = {"host": host, "x-forwarded-proto": proto}
     if xf_host:
         headers["x-forwarded-host"] = xf_host
+    if real_ip:
+        headers["x-real-ip"] = real_ip
     params = {"redirect": redirect} if redirect else {}
     return SimpleNamespace(
         headers=headers,
@@ -41,6 +57,24 @@ def test_enabled_only_on_operator_host() -> None:
     assert mod.enabled(_req("paris.procuretech.jp")) is True
     assert mod.enabled(_req("paris.procuretech.bhc.asp.lgwan.jp")) is False
     assert mod.find_user("ops@example.jp")["email"] == "ops@example.jp"
+
+
+def test_saml_source_ip_skips_operator_form() -> None:
+    hashed = bcrypt.hashpw(b"secret", bcrypt.gensalt()).decode()
+    users = json.dumps(
+        [{"email": "ops@example.jp", "name": "運用", "password_hash": hashed, "groups": ["SystemAdminGroup"]}]
+    )
+    mod = _mod(
+        OPERATOR_LOGIN_HOSTS="ops.example.lg.jp",
+        OPERATOR_USERS=users,
+        OPERATOR_SAML_SOURCE_IPS="203.0.113.10",
+        FRONTEND_URL="https://front.example.lg.jp",
+    )
+    front = _req("ops.example.lg.jp", real_ip="203.0.113.10")
+    assert mod.enabled(front) is False
+    assert mod.request_origin(front) == "https://front.example.lg.jp"
+    assert mod.public_host() == "front.example.lg.jp"
+    assert mod.enabled(_req("ops.example.lg.jp", real_ip="198.51.100.20")) is True
 
 
 def test_safe_redirect_rejects_foreign_host() -> None:


### PR DESCRIPTION
## Summary
- `OPERATOR_SAML_SOURCE_IPS` に一致する `X-Real-IP` では運用者 ID/PW フォームを出さず SAML へ進む
- そのとき ACS Recipient 検証は `PUBLIC_URL` / `FRONTEND_URL` のホストで行う（前面プロキシがオリジンへ運用者 Host を付ける場合のずれを防ぐ）
- compose と `.env.prod.example` に受け渡しを追加。実 IP は含めない

## Test plan
- [ ] `tests/test_ops_login.py` が通る
- [ ] 出口 IP を設定した閉域アクセスで Keycloak SAML になる
- [ ] 同じ Host でも出口 IP 以外は従来どおり運用者フォーム
- [ ] ACS の Recipient が公開 URL 側になる


Made with [Cursor](https://cursor.com)