### PR TITLE
fix(whisper): 大きな音声が nginx 64MB 上限で文字起こしできない問題を直す

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ## [Unreleased]
 
+- 文字起こしなど大きな添付が 64MB 上限で 413 になる問題を修正（nginx `client_max_body_size` を 256MB に。超過時は分割を案内する JSON）。履歴には音声の base64 本文を残さない
 - 情報化企画書ナビの専用ページ／API／Compose profile／exAppId を `procuretech-navigator` に揃える。旧 URL `/procuretech` はリダイレクト／エイリアス。既存のピン留めは起動時に付け替える
 - ナビゲーションシート（`procuretech-hearing`）を追加。複数資料から自由項目の Excel を作り、`procuretech-generate-app` の入力とする（詳細は `docs/procuretech-hearing.md`）。専用ページ `/procuretech-hearing`。Markdown エディタの「ヒアリングシートから生成」は生成 API の起動（`/health`）でテーマを出し分け（generate-app は常時、spec-app はオプション）
 

--- a/backend/app/exapp_history.py
+++ b/backend/app/exapp_history.py
@@ -1,0 +1,30 @@
+"""AI アプリ実行履歴向けの入力整形。
+
+backend/app/main.py から切り離し、回帰テストが FastAPI 無しで読めるようにする。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def history_inputs(inputs: Any) -> Any:
+    """履歴用に inputs.files の本文(base64)を落とす。ファイル名は残す。"""
+    if not isinstance(inputs, dict):
+        return inputs
+    files = inputs.get("files")
+    if not isinstance(files, list):
+        return inputs
+    slim_files: list[Any] = []
+    for entry in files:
+        if not isinstance(entry, dict):
+            slim_files.append(entry)
+            continue
+        inner = []
+        for f in entry.get("files") or []:
+            if isinstance(f, dict):
+                inner.append({"filename": f.get("filename", "file"), "content": ""})
+            else:
+                inner.append(f)
+        slim_files.append({**entry, "files": inner})
+    return {**inputs, "files": slim_files}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,6 +36,7 @@ from fastapi.responses import (
     StreamingResponse,
 )
 
+from app.exapp_history import history_inputs
 from shared import ssrfguard
 
 from . import (
@@ -941,28 +942,6 @@ def _redact_for_audit(inputs: Any) -> Any:
             continue
         out[k] = v
     return out
-
-
-def _history_inputs(inputs: Any) -> Any:
-    """履歴用に inputs.files の本文(base64)を落とす。ファイル名は残す。"""
-    if not isinstance(inputs, dict):
-        return inputs
-    files = inputs.get("files")
-    if not isinstance(files, list):
-        return inputs
-    slim_files: list[Any] = []
-    for entry in files:
-        if not isinstance(entry, dict):
-            slim_files.append(entry)
-            continue
-        inner = []
-        for f in entry.get("files") or []:
-            if isinstance(f, dict):
-                inner.append({"filename": f.get("filename", "file"), "content": ""})
-            else:
-                inner.append(f)
-        slim_files.append({**entry, "files": inner})
-    return {**inputs, "files": slim_files}
 
 
 def _is_http_url(url: Any) -> bool:
@@ -2709,7 +2688,7 @@ async def invoke_exapp(request: Request) -> JSONResponse:
                     "exAppId": ex_app_id,
                     "exAppName": app_def.get("exAppName", ""),
                     "userId": user_id,
-                    "inputs": _history_inputs(inputs),
+                    "inputs": history_inputs(inputs),
                     "outputs": outputs,
                     "status": status,
                     "progress": "",
@@ -2920,7 +2899,7 @@ async def invoke_exapp_stream(request: Request) -> Any:
                     "exAppId": ex_app_id,
                     "exAppName": app_def.get("exAppName", ""),
                     "userId": user_id,
-                    "inputs": _history_inputs(inputs),
+                    "inputs": history_inputs(inputs),
                     "outputs": outputs,
                     "status": status,
                     "progress": "",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -206,7 +206,7 @@ WHISPER_APP_URL = os.environ.get("WHISPER_APP_URL", "http://whisper-app:8002/inv
 _WHISPER_FORM = (
     '{'
     '"audio":{"type":"file","title":"音声ファイル",'
-    '"desc":"文字起こしする音声を添付してください。",'
+    '"desc":"文字起こしする音声を添付してください（目安180MBまで）。",'
     '"accept":"audio/*,.mp3,.wav,.m4a,.aac,.flac,.ogg","multiple":false,"required":true},'
     '"language":{"type":"select","title":"言語",'
     '"items":[{"title":"自動判定","value":"auto"},{"title":"日本語","value":"ja"},'
@@ -233,6 +233,7 @@ WHISPER_SEED: dict[str, Any] = {
         "3. 「実行」を押すと、タイムスタンプ付きの文字起こし結果が表示されます。\n\n"
         "## コツ・注意\n\n"
         "- 長い音声は処理に時間がかかります。区切って投入すると安定します。\n"
+        "- ファイルの目安は 180MB までです。それを超える場合は分割してください。\n"
         "- 雑音が少なくクリアな音声ほど精度が上がります。\n"
         "- 固有名詞や専門用語は誤変換されることがあります。結果は必ず確認してください。\n"
         "- 文字起こし結果はコピーして、そのままチャットで要約・議事録化に使えます。"
@@ -940,6 +941,28 @@ def _redact_for_audit(inputs: Any) -> Any:
             continue
         out[k] = v
     return out
+
+
+def _history_inputs(inputs: Any) -> Any:
+    """履歴用に inputs.files の本文(base64)を落とす。ファイル名は残す。"""
+    if not isinstance(inputs, dict):
+        return inputs
+    files = inputs.get("files")
+    if not isinstance(files, list):
+        return inputs
+    slim_files: list[Any] = []
+    for entry in files:
+        if not isinstance(entry, dict):
+            slim_files.append(entry)
+            continue
+        inner = []
+        for f in entry.get("files") or []:
+            if isinstance(f, dict):
+                inner.append({"filename": f.get("filename", "file"), "content": ""})
+            else:
+                inner.append(f)
+        slim_files.append({**entry, "files": inner})
+    return {**inputs, "files": slim_files}
 
 
 def _is_http_url(url: Any) -> bool:
@@ -2686,7 +2709,7 @@ async def invoke_exapp(request: Request) -> JSONResponse:
                     "exAppId": ex_app_id,
                     "exAppName": app_def.get("exAppName", ""),
                     "userId": user_id,
-                    "inputs": inputs,
+                    "inputs": _history_inputs(inputs),
                     "outputs": outputs,
                     "status": status,
                     "progress": "",
@@ -2897,7 +2920,7 @@ async def invoke_exapp_stream(request: Request) -> Any:
                     "exAppId": ex_app_id,
                     "exAppName": app_def.get("exAppName", ""),
                     "userId": user_id,
-                    "inputs": inputs,
+                    "inputs": _history_inputs(inputs),
                     "outputs": outputs,
                     "status": status,
                     "progress": "",

--- a/genai-web/packages/web/src/features/exapp/components/ExAppChat.tsx
+++ b/genai-web/packages/web/src/features/exapp/components/ExAppChat.tsx
@@ -206,7 +206,14 @@ export const ExAppChat = ({ exApp, fileAttachEnabled = false }: Props) => {
       dropEmptyAssistant();
       if (isApiError(error)) {
         const data = error.data as { error?: string };
-        setError(data?.error || GENERIC_ERROR);
+        if (error.status === 413) {
+          setError(
+            data?.error ||
+              'ファイルが大きすぎます。音声はおおよそ180MBまでです。分割してから再度お試しください。',
+          );
+        } else {
+          setError(data?.error || GENERIC_ERROR);
+        }
       } else {
         setError(GENERIC_ERROR);
       }

--- a/genai-web/packages/web/src/features/exapp/hooks/useExAppInvokeState.ts
+++ b/genai-web/packages/web/src/features/exapp/hooks/useExAppInvokeState.ts
@@ -15,6 +15,12 @@ export const useExAppInvokeState = () => {
       store.setExAppResponse(null);
       if (isApiError(error)) {
         const data = error.data as { error?: string };
+        if (error.status === 413) {
+          throw new Error(
+            data?.error ||
+              'ファイルが大きすぎます。音声はおおよそ180MBまでです。分割してから再度お試しください。',
+          );
+        }
         throw new Error(
           data?.error ||
             '処理中にエラーが発生しました。時間をおいて再度お試しください。解消しない場合は管理者にお問い合わせください。',

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -23,8 +23,9 @@ http {
     sendfile      on;
     server_tokens off;
 
-    # 添付ファイルのアップロード上限（必要に応じて調整）
-    client_max_body_size 64m;
+    # 文字起こしは音声を JSON(base64) で送るため、元ファイルより約 1.3〜1.4 倍になる。
+    # 会議録音（おおよそ 180MB）まで通す。超過時は JSON 413 を返す。
+    client_max_body_size 256m;
 
     # 入口レート制限（LGWAN 内の連打・スキャン緩和）
     limit_req_zone $binary_remote_addr zone=kc_login:10m rate=5r/s;
@@ -66,6 +67,13 @@ http {
         # 起動順の前後で proxy が落ちないようにする（未起動時は 502 を返す）。
         resolver 127.0.0.11 valid=30s ipv6=off;
 
+        error_page 413 @too_large;
+        location @too_large {
+            default_type application/json;
+            charset utf-8;
+            return 413 '{"error":"ファイルが大きすぎます。音声はおおよそ180MBまでです。分割してから再度お試しください。","error_code":"CONTEXT_TOO_LARGE"}';
+        }
+
         # --- OpenAPI（本番では遮断）---
         location = /api/docs { return 404; }
         location ^~ /api/docs/ { return 404; }
@@ -90,7 +98,7 @@ http {
             proxy_buffering    off;
             proxy_read_timeout 3600s;
             proxy_send_timeout 3600s;
-            client_max_body_size 64m;
+            client_max_body_size 256m;
         }
 
         # --- SAML 認証開始（レート制限）---
@@ -196,7 +204,7 @@ http {
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;
             proxy_buffering off;
-            client_max_body_size 64m;
+            client_max_body_size 256m;
         }
 
         # --- 日程調整ゲスト（別ホストの公開プロキシがここへ戻す場合。UI と同居可）---

--- a/proxy/nginx.http.conf
+++ b/proxy/nginx.http.conf
@@ -20,7 +20,8 @@ http {
     sendfile      on;
     server_tokens off;
 
-    client_max_body_size 64m;
+    # 文字起こしは音声を JSON(base64) で送るため、元ファイルより約 1.3〜1.4 倍になる。
+    client_max_body_size 256m;
 
     map $http_upgrade $connection_upgrade {
         default upgrade;
@@ -33,6 +34,13 @@ http {
         server_name _;
 
         resolver 127.0.0.11 valid=30s ipv6=off;
+
+        error_page 413 @too_large;
+        location @too_large {
+            default_type application/json;
+            charset utf-8;
+            return 413 '{"error":"ファイルが大きすぎます。音声はおおよそ180MBまでです。分割してから再度お試しください。","error_code":"CONTEXT_TOO_LARGE"}';
+        }
 
         location /api/ {
             set $backend_upstream http://backend:8000;

--- a/proxy/nginx.verify.conf
+++ b/proxy/nginx.verify.conf
@@ -21,7 +21,9 @@ http {
     sendfile      on;
     server_tokens off;
 
-    client_max_body_size 64m;
+    # 文字起こしは音声を JSON(base64) で送るため、元ファイルより約 1.3〜1.4 倍になる。
+    # 会議録音（おおよそ 180MB）まで通す。超過時は JSON 413 を返す。
+    client_max_body_size 256m;
 
     limit_req_zone $binary_remote_addr zone=kc_login:10m rate=5r/s;
     limit_req_zone $binary_remote_addr zone=api_auth:10m rate=10r/s;
@@ -33,6 +35,13 @@ http {
         server_name _;
 
         resolver 127.0.0.11 valid=30s ipv6=off;
+
+        error_page 413 @too_large;
+        location @too_large {
+            default_type application/json;
+            charset utf-8;
+            return 413 '{"error":"ファイルが大きすぎます。音声はおおよそ180MBまでです。分割してから再度お試しください。","error_code":"CONTEXT_TOO_LARGE"}';
+        }
 
         location = /api/docs { return 404; }
         location ^~ /api/docs/ { return 404; }
@@ -55,7 +64,7 @@ http {
             proxy_buffering    off;
             proxy_read_timeout 3600s;
             proxy_send_timeout 3600s;
-            client_max_body_size 64m;
+            client_max_body_size 256m;
         }
 
         location ^~ /api/auth/ {

--- a/tests/test_history_inputs.py
+++ b/tests/test_history_inputs.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from app.main import _history_inputs
+
+
+def test_history_inputs_strips_file_content() -> None:
+    slim = _history_inputs(
+        {
+            "language": "auto",
+            "files": [
+                {
+                    "key": "audio",
+                    "files": [{"filename": "a.mp3", "content": "AAAA"}],
+                }
+            ],
+        }
+    )
+    assert slim["language"] == "auto"
+    assert slim["files"][0]["files"][0]["filename"] == "a.mp3"
+    assert slim["files"][0]["files"][0]["content"] == ""
+
+
+def test_history_inputs_leaves_non_file_payloads() -> None:
+    payload = {"language": "ja"}
+    assert _history_inputs(payload) == payload
+    assert _history_inputs("x") == "x"

--- a/tests/test_history_inputs.py
+++ b/tests/test_history_inputs.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from app.main import _history_inputs
+from app.exapp_history import history_inputs
 
 
 def test_history_inputs_strips_file_content() -> None:
-    slim = _history_inputs(
+    slim = history_inputs(
         {
             "language": "auto",
             "files": [
@@ -22,5 +22,5 @@ def test_history_inputs_strips_file_content() -> None:
 
 def test_history_inputs_leaves_non_file_payloads() -> None:
     payload = {"language": "ja"}
-    assert _history_inputs(payload) == payload
-    assert _history_inputs("x") == "x"
+    assert history_inputs(payload) == payload
+    assert history_inputs("x") == "x"


### PR DESCRIPTION
## Summary
- 文字起こしは音声を JSON(base64) で送るため、会議録音（約 100MB 超）が nginx の `client_max_body_size 64m` で 413 になり、Whisper まで届いていなかった
- 上限を 256MB（目安 180MB）に上げ、超過時は分割を案内する JSON を返す
- 履歴には音声の base64 本文を残さず、413 時の画面文言も分かりやすくする

## Test plan
- [ ] 100MB 超の mp3 を文字起こしアプリで実行し、413 にならず処理が始まること
- [ ] 256MB を超える送信で「ファイルが大きすぎます」と出ること
- [ ] 成功後の実行履歴に音声本文（巨大な base64）が残っていないこと
- [ ] `tests/test_history_inputs.py` が通ること


Made with [Cursor](https://cursor.com)