### PR TITLE
共通アプリの表示と紹介文を編集画面で変えられるようにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ## [Unreleased]
 
+- チャット／文章生成／翻訳／画像生成／ダイアグラム／ナレッジ管理を共通アプリのカタログに載せ、「AIアプリの編集」で名前・紹介・使い方・公開ステータスを変えられるようにした。下書きにするとおすすめ・アプリ一覧・ピン留め対象から消える。シード再適用でも管理者が直した公開ステータスは保持する
 - 文字起こしなど大きな添付が 64MB 上限で 413 になる問題を修正（nginx `client_max_body_size` を 256MB に。超過時は分割を案内する JSON）。履歴には音声の base64 本文を残さない
 - 情報化企画書ナビの専用ページ／API／Compose profile／exAppId を `procuretech-navigator` に揃える。旧 URL `/procuretech` はリダイレクト／エイリアス。既存のピン留めは起動時に付け替える
 - ナビゲーションシート（`procuretech-hearing`）を追加。複数資料から自由項目の Excel を作り、`procuretech-generate-app` の入力とする（詳細は `docs/procuretech-hearing.md`）。専用ページ `/procuretech-hearing`。Markdown エディタの「ヒアリングシートから生成」は生成 API の起動（`/health`）でテーマを出し分け（generate-app は常時、spec-app はオプション）

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -202,6 +202,115 @@ RAG_SEED: dict[str, Any] = {
 # 専用ページ /knowledge に統合済み（旧 rag-tags / rag-register / rag-maintain）。
 
 
+def _builtin_seed(
+    ex_app_id: str,
+    name: str,
+    description: str,
+    how_to_use: str,
+    route: str,
+) -> dict[str, Any]:
+    """源内の汎用／専用ページを、共通アプリ編集のカタログとして登録する。"""
+    return {
+        "exAppId": ex_app_id,
+        "teamId": COMMON_TEAM_ID,
+        "exAppName": name,
+        "endpoint": f"http://127.0.0.1/builtin/{ex_app_id}",
+        "apiKey": "",
+        "config": json.dumps({"builtin": True, "route": route}, ensure_ascii=False),
+        "placeholder": "",
+        "description": description,
+        "howToUse": how_to_use,
+        "copyable": False,
+        "status": "published",
+    }
+
+
+CHAT_SEED = _builtin_seed(
+    "chat",
+    "チャット",
+    "着想や整理のための壁打ち",
+    (
+        "## このアプリでできること\n\n"
+        "着想や整理のための壁打ちに使います。質問やメモを入力すると、"
+        "生成AIが返答します。\n\n"
+        "## 操作手順\n\n"
+        "1. 下部の入力欄に質問や整理したい内容を書きます。\n"
+        "2. 必要ならファイルを添付します。\n"
+        "3. 送信すると会話が始まります。続きも同じ画面で聞けます。\n"
+    ),
+    "/chat",
+)
+GENERATE_SEED = _builtin_seed(
+    "generate",
+    "文章を生成",
+    "手元の情報をもとに文章を作成",
+    (
+        "## 想定用途\n\n"
+        "ビジネスメールや記事などの文章をAIが代行して作成できます。"
+        "文書のドラフティングに役立ちます。\n\n"
+        "## 操作方法\n\n"
+        "文章の元になる情報と、文章の形式を入力して実行します。"
+        "利用するAIモデルは画面上部で選べます。\n"
+    ),
+    "/generate",
+)
+TRANSLATE_SEED = _builtin_seed(
+    "translate",
+    "翻訳",
+    "手元の文章を他の言語に翻訳",
+    (
+        "## 想定用途\n\n"
+        "文章を英語／日本語／中国語／韓国語／フランス語／スペイン語／ドイツ語の"
+        "いずれかに翻訳できます。カジュアルな文体などの指定もできます。\n\n"
+        "## 操作方法\n\n"
+        "翻訳したい文章だけを入力し、言語を選んで実行します。"
+        "「翻訳して」といった指示は不要です。\n"
+    ),
+    "/translate",
+)
+IMAGE_SEED = _builtin_seed(
+    "image",
+    "画像を生成",
+    "プロンプトから資料用の挿絵やイメージ案を作成",
+    (
+        "## このアプリでできること\n\n"
+        "プロンプト（文章）から画像を生成します。資料の挿絵やイメージ案、"
+        "たたき台づくりに役立ちます。画像生成サーバが止まっているときは"
+        "メニューに出ません。\n\n"
+        "## 操作方法\n\n"
+        "入力欄に生成したい画像の内容を書いて送信します（英語推奨・具体的に）。\n"
+    ),
+    "/image",
+)
+DIAGRAM_SEED = _builtin_seed(
+    "diagram",
+    "ダイアグラムを生成",
+    "テキストからフローチャートやマインドマップを作成",
+    (
+        "## 想定用途\n\n"
+        "文章を元に、フローチャート／円グラフ／マインドマップなどの"
+        "ダイアグラムを生成できます。\n\n"
+        "## 操作方法\n\n"
+        "図にしたい文章を入力して実行します。生成された図の正確性は"
+        "利用者が確認してください。\n"
+    ),
+    "/diagram",
+)
+KNOWLEDGE_SEED = _builtin_seed(
+    "knowledge",
+    "ナレッジ管理",
+    "共有・所属チームの資料を登録／管理（検索は「ナレッジ検索」）",
+    (
+        "## このアプリでできること\n\n"
+        "共有ナレッジや所属チームの資料を登録・分類・管理します。"
+        "検索は「ナレッジ検索」アプリから行います。\n\n"
+        "## 操作方法\n\n"
+        "対象スコープを選び、ドキュメント管理／登録／タグ管理のタブで操作します。\n"
+    ),
+    "/knowledge",
+)
+
+
 # 文字起こし(Whisper) AI アプリ
 WHISPER_APP_URL = os.environ.get("WHISPER_APP_URL", "http://whisper-app:8002/invoke")
 _WHISPER_FORM = (
@@ -649,6 +758,12 @@ def _ensure_team_rag_search() -> None:
 
 
 EXAPP_SEEDS = [
+    CHAT_SEED,
+    GENERATE_SEED,
+    TRANSLATE_SEED,
+    IMAGE_SEED,
+    DIAGRAM_SEED,
+    KNOWLEDGE_SEED,
     RAG_SEED,
     WHISPER_SEED,
     AUDIT_SEED,
@@ -2518,10 +2633,21 @@ async def list_exapps(request: Request) -> list[Any]:
         candidates = [
             a for a in candidates if a.get("exAppId") not in ADMIN_ONLY_EXAPP_IDS
         ]
+    # 組み込みカタログは下書きも含めて返す（メニュー表示の判定用。ヘルス不要）
+    seen = {(a["teamId"], a["exAppId"]) for a in candidates}
+    for builtin in teams_store.list_builtin_exapps():
+        if builtin.get("exAppId") in RETIRED_SEED_EXAPP_IDS:
+            continue
+        key = (builtin["teamId"], builtin["exAppId"])
+        if key not in seen:
+            candidates.append(builtin)
+            seen.add(key)
+    service_apps = [a for a in candidates if not teams_store.is_builtin_exapp(a)]
+    builtin_apps = [a for a in candidates if teams_store.is_builtin_exapp(a)]
     checks = await asyncio.gather(
-        *[_is_app_up(a["endpoint"]) for a in candidates], return_exceptions=True
+        *[_is_app_up(a["endpoint"]) for a in service_apps], return_exceptions=True
     )
-    return [a for a, ok in zip(candidates, checks) if ok is True]
+    return [a for a, ok in zip(service_apps, checks) if ok is True] + builtin_apps
 
 
 @app.get("/my/app-pins")
@@ -2626,6 +2752,11 @@ async def invoke_exapp(request: Request) -> JSONResponse:
     app_def = teams_store.get_exapp(team_id, ex_app_id)
     if not app_def:
         return JSONResponse(status_code=404, content={"error": "AI アプリが見つかりません"})
+    if teams_store.is_builtin_exapp(app_def):
+        return JSONResponse(
+            status_code=400,
+            content={"error": "組み込みアプリは専用ページから利用してください"},
+        )
 
     # 管理者限定 exApp（監査ログ参照 等）は非管理者の実行を拒否
     if ex_app_id in ADMIN_ONLY_EXAPP_IDS and not _is_system_admin(claims):
@@ -2832,6 +2963,11 @@ async def invoke_exapp_stream(request: Request) -> Any:
     app_def = teams_store.get_exapp(team_id, ex_app_id)
     if not app_def:
         return JSONResponse(status_code=404, content={"error": "AI アプリが見つかりません"})
+    if teams_store.is_builtin_exapp(app_def):
+        return JSONResponse(
+            status_code=400,
+            content={"error": "組み込みアプリは専用ページから利用してください"},
+        )
 
     if ex_app_id in ADMIN_ONLY_EXAPP_IDS and not _is_system_admin(claims):
         return _forbidden("このアプリの実行には管理者権限が必要です")
@@ -3053,6 +3189,11 @@ async def get_exapp_schema(request: Request) -> JSONResponse:
     app_def = teams_store.get_exapp(team_id, ex_app_id)
     if not app_def:
         return JSONResponse(status_code=404, content={"error": "AI アプリが見つかりません"})
+    if teams_store.is_builtin_exapp(app_def):
+        return JSONResponse(
+            status_code=400,
+            content={"error": "組み込みアプリは専用ページから利用してください"},
+        )
 
     # 管理者限定アプリのフォーム定義は非管理者に返さない
     if ex_app_id in ADMIN_ONLY_EXAPP_IDS and not _is_system_admin(claims):
@@ -3117,6 +3258,11 @@ async def resolve_exapp_schema(request: Request) -> JSONResponse:
     app_def = teams_store.get_exapp(team_id, ex_app_id)
     if not app_def:
         return JSONResponse(status_code=404, content={"error": "AI アプリが見つかりません"})
+    if teams_store.is_builtin_exapp(app_def):
+        return JSONResponse(
+            status_code=400,
+            content={"error": "組み込みアプリは専用ページから利用してください"},
+        )
 
     if ex_app_id in ADMIN_ONLY_EXAPP_IDS and not _is_system_admin(claims):
         return JSONResponse(status_code=404, content={"error": "AI アプリが見つかりません"})
@@ -6623,7 +6769,11 @@ async def delete_exapp(team_id: str, ex_app_id: str, request: Request) -> JSONRe
     claims = _claims_from_request(request)
     if not _can_manage_team(claims, team_id):
         return _forbidden()
-    teams_store.delete_exapp(team_id, ex_app_id)
+    if not teams_store.delete_exapp(team_id, ex_app_id):
+        return JSONResponse(
+            status_code=400,
+            content={"error": "組み込みアプリは削除できません。非表示にする場合は下書きにしてください"},
+        )
     return JSONResponse(content={})
 
 

--- a/backend/app/teams_store.py
+++ b/backend/app/teams_store.py
@@ -27,8 +27,9 @@ COMMON_TEAM_ID = "00000000-0000-0000-0000-000000000000"
 ADMIN_TEAM_ID = "00000000-0000-0000-0000-0000000000a1"
 ADMIN_TEAM_NAME = "管理者ツール"
 
-# GenU 組み込み機能（DB 未登録）の itemId。共通チームのアプリとしてピン留め対象になる。
-GENU_APP_IDS = frozenset({"chat", "generate", "translate", "image", "diagram"})
+# GenU 組み込み機能の itemId。共通チームのカタログ（名前・紹介・公開）として登録し、
+# ピン留め対象にもする。knowledge は専用ページだが同じカタログで出し分ける。
+GENU_APP_IDS = frozenset({"chat", "generate", "translate", "image", "diagram", "knowledge"})
 
 # 利用者ごとのピン留め上限
 MAX_APP_PINS = 8
@@ -190,7 +191,7 @@ def upsert_seed_exapp(app: dict[str, Any]) -> None:
     """
     with _lock, _connect() as conn:
         exists = conn.execute(
-            "SELECT exAppId, teamId, exAppName, description, howToUse"
+            "SELECT exAppId, teamId, exAppName, description, howToUse, status"
             " FROM exapps WHERE exAppId = ?",
             (app["exAppId"],),
         ).fetchone()
@@ -201,6 +202,8 @@ def upsert_seed_exapp(app: dict[str, Any]) -> None:
             name = (exists["exAppName"] or "").strip() or app.get("exAppName", "")
             description = (exists["description"] or "").strip() or app.get("description", "")
             how_to_use = (exists["howToUse"] or "").strip() or app.get("howToUse", "")
+            # 公開ステータスは管理者がメニュー表示の切り替えに使うので上書きしない
+            status = (exists["status"] or "").strip() or app.get("status", "published")
             # teamId もシード定義へ揃える（管理者アプリを専用チームへ移設する移行も兼ねる）
             conn.execute(
                 "UPDATE exapps SET teamId=?, exAppName=?, endpoint=?, apiKey=?, config=?,"
@@ -216,7 +219,7 @@ def upsert_seed_exapp(app: dict[str, Any]) -> None:
                     description,
                     how_to_use,
                     1 if app.get("copyable") else 0,
-                    app.get("status", "published"),
+                    status,
                     now,
                     app["exAppId"],
                 ),
@@ -840,11 +843,42 @@ def create_exapp(team_id: str, data: dict[str, Any]) -> dict[str, Any]:
     return _row_to_exapp(r)
 
 
+def is_builtin_exapp(app: dict[str, Any] | None) -> bool:
+    """源内の汎用ページ（チャット等）をカタログ登録した組み込みアプリか。"""
+    if not app:
+        return False
+    try:
+        cfg = json.loads(app.get("config") or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return False
+    return bool(cfg.get("builtin"))
+
+
+def list_builtin_exapps() -> list[dict[str, Any]]:
+    """組み込みカタログ（下書き含む）。メニュー表示の判定用。"""
+    teams = {t["teamId"]: t["teamName"] for t in list_teams()}
+    with _lock, _connect() as conn:
+        rows = conn.execute("SELECT * FROM exapps").fetchall()
+    result = []
+    for r in rows:
+        app = _row_to_exapp(r)
+        if is_builtin_exapp(app):
+            result.append({**app, "teamName": teams.get(app["teamId"], "")})
+    return result
+
+
 def update_exapp(team_id: str, ex_app_id: str, data: dict[str, Any]) -> dict[str, Any] | None:
     current = get_exapp(team_id, ex_app_id)
     if not current:
         return None
-    merged = {**current, **{k: v for k, v in data.items() if v is not None}}
+    incoming = {k: v for k, v in data.items() if v is not None}
+    if is_builtin_exapp(current):
+        incoming = {
+            k: incoming[k]
+            for k in ("exAppName", "description", "howToUse", "status")
+            if k in incoming
+        }
+    merged = {**current, **incoming}
     merged["createdDate"] = current["createdDate"]
     with _lock, _connect() as conn:
         _write_exapp(conn, ex_app_id, team_id, merged)
@@ -854,7 +888,11 @@ def update_exapp(team_id: str, ex_app_id: str, data: dict[str, Any]) -> dict[str
     return _row_to_exapp(r)
 
 
-def delete_exapp(team_id: str, ex_app_id: str) -> None:
+def delete_exapp(team_id: str, ex_app_id: str) -> bool:
+    """削除する。組み込みカタログは削除不可（False）。"""
+    current = get_exapp(team_id, ex_app_id)
+    if current and is_builtin_exapp(current):
+        return False
     with _lock, _connect() as conn:
         conn.execute(
             "DELETE FROM exapps WHERE teamId = ? AND exAppId = ?",
@@ -864,6 +902,7 @@ def delete_exapp(team_id: str, ex_app_id: str) -> None:
             "DELETE FROM user_app_pins WHERE teamId = ? AND itemId = ?",
             (team_id, ex_app_id),
         )
+    return True
 
 
 def reassign_exapp_refs(team_id: str, old_id: str, new_id: str) -> None:
@@ -948,7 +987,11 @@ def list_user_app_pins(user_id: str) -> list[dict[str, Any]]:
 def _is_pinnable_app(user_id: str, team_id: str, item_id: str, is_system_admin: bool) -> bool:
     """ピン留め可能か（本人が見える公開 exApp、または共通チームの GenU 機能）。"""
     if team_id == COMMON_TEAM_ID and item_id in GENU_APP_IDS:
-        return True
+        app = get_exapp(COMMON_TEAM_ID, item_id)
+        # 未シード環境の後方互換。登録済みなら公開中だけピン留め可。
+        if app is None:
+            return True
+        return app.get("status") == "published"
     visible = list_visible_exapps(user_id, is_system_admin)
     return any(a["teamId"] == team_id and a["exAppId"] == item_id for a in visible)
 

--- a/genai-web/OPENGENAI_PATCHES.md
+++ b/genai-web/OPENGENAI_PATCHES.md
@@ -33,7 +33,9 @@ upstream のバージョンアップ後は、本ファイルの差分箇所を�
 | `packages/web/src/features/landing/LandingPage.tsx` | 「ピン留め」セクション（`PinnedAppsSection`）を Suspense 境界で追加 / 既定「画像を生成」カードを SD 稼働時のみ表示 |
 | `packages/web/src/features/exapps/components/ExAppList.tsx` | 各カードにピン留めボタンを付与 |
 | `packages/web/src/features/exapps/components/ExAppListCard.tsx` | 任意 prop `pinControl` でピンボタンを描画 |
-| `packages/web/src/features/exapps/hooks/useGenUApps.ts` | 「画像を生成」を SD ヘルスチェック(`useImageAvailable`)で出し分け |
+| `packages/web/src/features/exapps/hooks/useGenUApps.ts` | 「画像を生成」を SD ヘルスチェック(`useImageAvailable`)で出し分け。カタログの公開ステータスと紹介文に追従 |
+| `packages/web/src/layout/navItems.ts` | おすすめも同じカタログ（下書きは非表示・文言はレジストリ） |
+| `packages/web/src/features/exapps/utils/builtinExApp.ts` | 組み込みカタログ判定 |
 
 ### 画像生成(SD)ヘルスチェックによる表示出し分け
 

--- a/genai-web/packages/web/src/features/chat-history/components/ChatListItem.tsx
+++ b/genai-web/packages/web/src/features/chat-history/components/ChatListItem.tsx
@@ -12,7 +12,8 @@ import { useChatList } from '@/hooks/useChatList';
 import { useHighlight } from '@/hooks/useHighlight';
 import { decomposeId } from '@/utils/decomposeId';
 import { focus } from '@/utils/focus';
-import { getChatHistoryLink, getUsecaseLabel, resolveChatUsecase } from '@/utils/usecasePath';
+import { useUsecaseLabelFn } from '@/features/exapps/hooks/useUsecaseLabel';
+import { getChatHistoryLink, resolveChatUsecase } from '@/utils/usecasePath';
 
 type Props = {
   className?: string;
@@ -22,6 +23,7 @@ type Props = {
 };
 
 export const ChatListItem = (props: Props) => {
+  const usecaseLabel = useUsecaseLabelFn();
   const { className, chat, onUpdateTitle, highlightWords } = props;
 
   const [isEditing, setIsEditing] = useState(false);
@@ -101,7 +103,7 @@ export const ChatListItem = (props: Props) => {
                 to={getChatHistoryLink(chat)}
               >
                 <span className='text-dns-14N-130 text-solid-gray-600 no-underline'>
-                  {getUsecaseLabel(usecase)}
+                  {usecaseLabel(usecase)}
                 </span>
                 <div className='flex w-full items-center justify-start'>
                   <div className='relative flex-1'>

--- a/genai-web/packages/web/src/features/chat/ChatPage.tsx
+++ b/genai-web/packages/web/src/features/chat/ChatPage.tsx
@@ -92,7 +92,7 @@ export const ChatPage = () => {
     }
   }, [messages, setContent, shouldAutoSubmit, search, state]);
 
-  const { title } = useChatTitle(chatTitle);
+  const { title, appName = 'チャット', description } = useChatTitle(chatTitle);
 
   const { accept, fileUploadable } = useFileUploadable();
 
@@ -180,10 +180,10 @@ export const ChatPage = () => {
               chatId
                 ? [
                     { label: 'ホーム', to: '/' },
-                    { label: 'チャット', to: '/chat' },
+                    { label: appName, to: '/chat' },
                     { label: title },
                   ]
-                : [{ label: 'ホーム', to: '/' }, { label: 'チャット' }]
+                : [{ label: 'ホーム', to: '/' }, { label: appName }]
             }
             className='mb-4'
           />
@@ -200,6 +200,9 @@ export const ChatPage = () => {
               </Button>
             )}
           </div>
+          {!chatId && description && (
+            <p className='mt-2 text-std-16N-170 text-solid-gray-700'>{description}</p>
+          )}
         </div>
 
         <div className='flex justify-between gap-10 xl:gap-16'>

--- a/genai-web/packages/web/src/features/chat/components/ChatHistorySidebar.tsx
+++ b/genai-web/packages/web/src/features/chat/components/ChatHistorySidebar.tsx
@@ -3,10 +3,12 @@ import { Button } from '@/components/ui/dads/Button';
 import { linkDefaultStyle } from '@/components/ui/dads/Link';
 import { decomposeId } from '@/utils/decomposeId';
 import { formatDateTime } from '@/utils/formatDateTime';
-import { getChatHistoryLink, getUsecaseLabel, resolveChatUsecase } from '@/utils/usecasePath';
+import { useUsecaseLabelFn } from '@/features/exapps/hooks/useUsecaseLabel';
+import { getChatHistoryLink, resolveChatUsecase } from '@/utils/usecasePath';
 import { useChatHistorySidebar } from '../hooks/useChatHistorySidebar';
 
 export const ChatHistorySidebar = () => {
+  const usecaseLabel = useUsecaseLabelFn();
   const { displayedChats, isLoading } = useChatHistorySidebar();
   const { chatId } = useParams();
 
@@ -51,7 +53,7 @@ export const ChatHistorySidebar = () => {
                       {formatDateTime(chat.createdDate)}
                     </time>
                     <span className='text-dns-14N-130 text-solid-gray-600'>
-                      {getUsecaseLabel(usecase)}
+                      {usecaseLabel(usecase)}
                     </span>
                     <p
                       className={`${linkDefaultStyle} group-hover/history:text-blue-900 group-hover/history:decoration-[calc(3/16*1rem)] group-aria-[current='page']/history:font-bold group-aria-[current='page']/history:text-blue-1000!`}

--- a/genai-web/packages/web/src/features/chat/hooks/useChatTitle.ts
+++ b/genai-web/packages/web/src/features/chat/hooks/useChatTitle.ts
@@ -1,15 +1,24 @@
 import { useParams } from 'react-router';
+import { useFetchExApp } from '@/features/exapp/hooks/useFetchExApp';
+import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
 import { useChatList } from '@/hooks/useChatList';
+
+const FALLBACK_APP_NAME = 'チャット';
 
 export const useChatTitle = (chatTitleFromStore?: string) => {
   const { chatId } = useParams();
   const { getChatTitle } = useChatList();
+  const { data: chatApp } = useFetchExApp(COMMON_EXAPPS_TEAM_ID, 'chat');
+  const appName = (chatApp?.exAppName || '').trim() || FALLBACK_APP_NAME;
+  const description = (chatApp?.description || '').trim();
 
-  const pageTitle = chatId ? getChatTitle(chatId) || 'チャット' : 'チャット';
-  const title = chatId ? pageTitle : chatTitleFromStore || 'チャット';
+  const pageTitle = chatId ? getChatTitle(chatId) || appName : appName;
+  const title = chatId ? pageTitle : chatTitleFromStore || appName;
 
   return {
     title,
     pageTitle,
+    appName,
+    description,
   };
 };

--- a/genai-web/packages/web/src/features/exapp/ExAppPage.tsx
+++ b/genai-web/packages/web/src/features/exapp/ExAppPage.tsx
@@ -1,6 +1,7 @@
 import { Suspense, useEffect, useMemo } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-import { useLocation, useParams } from 'react-router';
+import { Navigate, useLocation, useParams } from 'react-router';
+import { builtinRouteOf } from '@/features/exapps/utils/builtinExApp';
 import { PageTitle } from '@/components/PageTitle';
 import { Divider } from '@/components/ui/dads/Divider';
 import { ErrorText } from '@/components/ui/dads/ErrorText';
@@ -34,6 +35,7 @@ export const ExAppPage = () => {
     isLoading: isExAppLoading,
     error: exAppFetchError,
   } = useFetchExApp(teamId, exAppId);
+  const builtinRoute = builtinRouteOf(exApp?.config);
 
   useEffect(() => {
     clear();
@@ -118,6 +120,10 @@ export const ExAppPage = () => {
   const pageTitle = exApp?.exAppName
     ? `${exApp.exAppName}${APP_TITLE ? ` | ${APP_TITLE}` : ''}`
     : undefined;
+
+  if (builtinRoute) {
+    return <Navigate to={builtinRoute} replace />;
+  }
 
   return (
     <LayoutBody>

--- a/genai-web/packages/web/src/features/exapp/components/ManagedAppHeader.tsx
+++ b/genai-web/packages/web/src/features/exapp/components/ManagedAppHeader.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { PiBookOpenBold } from 'react-icons/pi';
 import { BreadcrumbsNav } from '@/components/ui/BreadcrumbsNav';
 import { Disclosure, DisclosureSummary } from '@/components/ui/dads/Disclosure';
-import { useFetchExApp } from '@/features/exapp/hooks/useFetchExApp';
+import { useRegisteredAppMeta } from '@/features/exapp/hooks/useRegisteredAppMeta';
 import { ExAppHeader } from './ExAppHeader';
 import { ExAppUsageMarkdownRenderer } from './ExAppUsageMarkdownRenderer';
 
@@ -35,20 +35,26 @@ export const ManagedAppHeader = (props: Props) => {
     enabled = true,
     children,
   } = props;
-  const { data: exApp } = useFetchExApp(enabled ? teamId : '', enabled ? exAppId : '');
+  const { title, description, howToUse: howTo, exApp } = useRegisteredAppMeta(
+    teamId,
+    exAppId,
+    fallbackTitle,
+    fallbackDescription,
+    enabled,
+  );
 
   if (exApp && !breadcrumbItems && !children) {
     return <ExAppHeader exApp={exApp} />;
   }
 
-  const title = (exApp?.exAppName || '').trim() || fallbackTitle;
-  const description = (exApp?.description || '').trim() || fallbackDescription;
-  const howTo = (exApp?.howToUse || '').trim();
-  const crumbs = breadcrumbItems ?? [
+  const defaultCrumbs = [
     { label: 'ホーム', to: '/' },
     { label: 'AIアプリ', to: '/apps' },
     { label: title },
   ];
+  const crumbs = (breadcrumbItems ?? defaultCrumbs).map((c) =>
+    c.label === fallbackTitle ? { ...c, label: title } : c,
+  );
 
   return (
     <div className='flex flex-col gap-4'>

--- a/genai-web/packages/web/src/features/exapp/hooks/useRegisteredAppMeta.ts
+++ b/genai-web/packages/web/src/features/exapp/hooks/useRegisteredAppMeta.ts
@@ -1,0 +1,18 @@
+import { APP_TITLE } from '@/constants';
+import { useFetchExApp } from '@/features/exapp/hooks/useFetchExApp';
+
+/** 「AIアプリの編集」に登録した名前・紹介を、専用ページの見出し／タブに使う。 */
+export const useRegisteredAppMeta = (
+  teamId: string,
+  exAppId: string,
+  fallbackTitle: string,
+  fallbackDescription = '',
+  enabled = true,
+) => {
+  const { data: exApp, isLoading } = useFetchExApp(enabled ? teamId : '', enabled ? exAppId : '');
+  const title = (exApp?.exAppName || '').trim() || fallbackTitle;
+  const description = (exApp?.description || '').trim() || fallbackDescription;
+  const howToUse = (exApp?.howToUse || '').trim();
+  const documentTitle = `${title}${APP_TITLE ? ` | ${APP_TITLE}` : ''}`;
+  return { title, description, howToUse, documentTitle, exApp, isLoading };
+};

--- a/genai-web/packages/web/src/features/exapps/hooks/useExAppCatalog.ts
+++ b/genai-web/packages/web/src/features/exapps/hooks/useExAppCatalog.ts
@@ -1,0 +1,9 @@
+import type { ListExAppsResponse } from 'genai-web';
+import useSWR from 'swr';
+import { teamApiFetcher } from '@/lib/fetcher';
+
+/** おすすめ／組み込み一覧の表示判定用。suspense せず、未取得時は loaded=false。 */
+export const useExAppCatalog = () => {
+  const { data } = useSWR<ListExAppsResponse>('exapps', teamApiFetcher);
+  return { apps: data ?? [], loaded: Boolean(data) };
+};

--- a/genai-web/packages/web/src/features/exapps/hooks/useExApps.ts
+++ b/genai-web/packages/web/src/features/exapps/hooks/useExApps.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useParams } from 'react-router';
 import { KNOWLEDGE_EXAPP_IDS } from '@/layout/navItems';
 import { uniqBy } from '@/utils/uniqBy';
+import { isBuiltinExApp } from '../utils/builtinExApp';
 import { useExAppStore } from '../stores/useExAppStore';
 import type { ExAppOptions } from '../types';
 import { useFetchExApps } from './useFetchExApps';
@@ -29,7 +30,10 @@ export const useExApps = () => {
 
       // draft と、/knowledge へ集約済みの旧管理系（タグ/登録/管理）は一覧から除外
       const publishedExApps = newExApps.filter(
-        (exApp) => exApp.status !== 'draft' && !KNOWLEDGE_EXAPP_IDS.has(exApp.exAppId),
+        (exApp) =>
+          exApp.status !== 'draft' &&
+          !KNOWLEDGE_EXAPP_IDS.has(exApp.exAppId) &&
+          !isBuiltinExApp(exApp),
       );
 
       const newTeamOptions = uniqBy(

--- a/genai-web/packages/web/src/features/exapps/hooks/useGenUApps.ts
+++ b/genai-web/packages/web/src/features/exapps/hooks/useGenUApps.ts
@@ -1,59 +1,76 @@
 import { useImageAvailable } from '@/open-genai/image-health/useImageAvailable';
 import { isUseCaseEnabled } from '@/utils/isUseCaseEnabled';
+import { useExAppCatalog } from './useExAppCatalog';
+import { isCatalogListed } from '../utils/builtinExApp';
 import { ExAppOptions } from '../types';
 
 export const useGenUApps = () => {
   // 画像生成は SD サーバの稼働状況に応じて出し分ける（他アプリのヘルスチェックに準拠）
   const imageAvailable = useImageAvailable();
+  const { apps, loaded } = useExAppCatalog();
+  const metaById = new Map(
+    apps.map((a) => [
+      a.exAppId,
+      {
+        name: (a.exAppName || '').trim(),
+        description: (a.description || '').trim(),
+      },
+    ]),
+  );
+  const nameOf = (id: string, fallback: string) => metaById.get(id)?.name || fallback;
+  const descOf = (id: string, fallback: string) => metaById.get(id)?.description || fallback;
+  const listed = (id: string) => isCatalogListed(id, apps, loaded);
 
-  const genUApps: ExAppOptions[string]['exApps'] = [
-    {
-      label: 'チャット',
+  const genUApps: ExAppOptions[string]['exApps'] = [];
+
+  if (listed('chat')) {
+    genUApps.push({
+      label: nameOf('chat', 'チャット'),
       value: 'chat',
-      description: '着想や整理のための壁打ち',
-    },
-    {
-      label: '文章を生成',
+      description: descOf('chat', '着想や整理のための壁打ち'),
+    });
+  }
+  if (isUseCaseEnabled('generate') && listed('generate')) {
+    genUApps.push({
+      label: nameOf('generate', '文章を生成'),
       value: 'generate',
-      description: '手元の情報をもとに文章を作成',
-    },
-    ...(isUseCaseEnabled('translate')
-      ? [
-          {
-            label: '翻訳',
-            value: 'translate',
-            description: '手元の文章を他の言語に翻訳',
-          },
-        ]
-      : []),
-
-    ...(isUseCaseEnabled('image') && imageAvailable
-      ? [
-          {
-            label: '画像を生成',
-            value: 'image',
-            description: '文章や単語から画像を生成',
-          },
-        ]
-      : []),
-    ...(isUseCaseEnabled('diagram')
-      ? [
-          {
-            label: 'ダイアグラムを生成',
-            value: 'diagram',
-            description: 'テキストからフローチャートやマインドマップを作成',
-          },
-        ]
-      : []),
+      description: descOf('generate', '手元の情報をもとに文章を作成'),
+    });
+  }
+  if (isUseCaseEnabled('translate') && listed('translate')) {
+    genUApps.push({
+      label: nameOf('translate', '翻訳'),
+      value: 'translate',
+      description: descOf('translate', '手元の文章を他の言語に翻訳'),
+    });
+  }
+  if (isUseCaseEnabled('image') && imageAvailable && listed('image')) {
+    genUApps.push({
+      label: nameOf('image', '画像を生成'),
+      value: 'image',
+      description: descOf('image', '文章や単語から画像を生成'),
+    });
+  }
+  if (isUseCaseEnabled('diagram') && listed('diagram')) {
+    genUApps.push({
+      label: nameOf('diagram', 'ダイアグラムを生成'),
+      value: 'diagram',
+      description: descOf('diagram', 'テキストからフローチャートやマインドマップを作成'),
+    });
+  }
+  if (listed('knowledge')) {
     // 旧 rag-tags / rag-register / rag-maintain を集約した専用ページ。
-    {
-      label: 'ナレッジ管理',
+    genUApps.push({
+      label: nameOf('knowledge', 'ナレッジ管理'),
       value: 'knowledge',
-      description: '共有・所属チームの資料を登録／管理（検索は「ナレッジ検索」）',
-    },
-    // 文字起こし(transcribe)はクラウド(Amazon Transcribe)依存のため除外。
-    // ローカルの「文字起こし（ローカル Whisper）」AIアプリで代替している。
-  ];
+      description: descOf(
+        'knowledge',
+        '共有・所属チームの資料を登録／管理（検索は「ナレッジ検索」）',
+      ),
+    });
+  }
+  // 文字起こし(transcribe)はクラウド(Amazon Transcribe)依存のため除外。
+  // ローカルの「文字起こし（ローカル Whisper）」AIアプリで代替している。
 
   return { genUApps };
 };

--- a/genai-web/packages/web/src/features/exapps/hooks/useUsecaseLabel.ts
+++ b/genai-web/packages/web/src/features/exapps/hooks/useUsecaseLabel.ts
@@ -1,0 +1,28 @@
+import { useExAppCatalog } from '@/features/exapps/hooks/useExAppCatalog';
+import { getUsecaseLabel } from '@/utils/usecasePath';
+
+const USECASE_EXAPP_IDS: Record<string, string> = {
+  '/chat': 'chat',
+  '/image': 'image',
+  '/diagram': 'diagram',
+  '/generate': 'generate',
+  '/translate': 'translate',
+};
+
+/** 利用履歴などに出すユースケース名。登録済みなら「AIアプリの編集」の名前を使う。 */
+export const useUsecaseLabelFn = () => {
+  const { apps, loaded } = useExAppCatalog();
+  const names = new Map(
+    apps.map((a) => [a.exAppId, (a.exAppName || '').trim()] as const),
+  );
+  return (usecase: string) => {
+    if (loaded) {
+      const id = USECASE_EXAPP_IDS[usecase];
+      const name = id ? names.get(id) : '';
+      if (name) {
+        return name;
+      }
+    }
+    return getUsecaseLabel(usecase);
+  };
+};

--- a/genai-web/packages/web/src/features/exapps/utils/builtinExApp.ts
+++ b/genai-web/packages/web/src/features/exapps/utils/builtinExApp.ts
@@ -1,0 +1,60 @@
+import type { ExApp, ExAppStatus } from 'genai-web';
+
+/** 源内の汎用／専用ページを、共通アプリ編集のカタログとして扱う ID */
+export const BUILTIN_EXAPP_IDS = new Set([
+  'chat',
+  'generate',
+  'translate',
+  'image',
+  'diagram',
+  'knowledge',
+]);
+
+type CatalogApp = Pick<ExApp, 'exAppId'> & {
+  config?: string;
+  status?: ExAppStatus;
+};
+
+export const isBuiltinConfig = (config?: string): boolean => {
+  try {
+    return (JSON.parse(config || '{}') as { builtin?: boolean }).builtin === true;
+  } catch {
+    return false;
+  }
+};
+
+export const isBuiltinExApp = (app: { config?: string; exAppId?: string }): boolean => {
+  if (isBuiltinConfig(app.config)) {
+    return true;
+  }
+  return Boolean(app.exAppId && BUILTIN_EXAPP_IDS.has(app.exAppId));
+};
+
+export const builtinRouteOf = (config?: string): string | null => {
+  try {
+    const cfg = JSON.parse(config || '{}') as { builtin?: boolean; route?: string };
+    if (cfg.builtin && typeof cfg.route === 'string' && cfg.route.startsWith('/')) {
+      return cfg.route;
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+};
+
+/** カタログ取得後、公開中ならメニューに出す。未取得時は従来どおり出す。 */
+export const isCatalogListed = (
+  id: string,
+  apps: CatalogApp[],
+  loaded: boolean,
+): boolean => {
+  if (!loaded) {
+    return true;
+  }
+  const app = apps.find((a) => a.exAppId === id);
+  if (app) {
+    return app.status !== 'draft';
+  }
+  // 未シードの組み込みはフォールバック表示。実 exApp が一覧に無い＝非公開または停止
+  return BUILTIN_EXAPP_IDS.has(id);
+};

--- a/genai-web/packages/web/src/features/generate-diagram/GenerateDiagramPage.tsx
+++ b/genai-web/packages/web/src/features/generate-diagram/GenerateDiagramPage.tsx
@@ -1,6 +1,7 @@
 import { PageTitle } from '@/components/PageTitle';
 import { Divider } from '@/components/ui/dads/Divider';
-import { APP_TITLE } from '@/constants';
+import { useRegisteredAppMeta } from '@/features/exapp/hooks/useRegisteredAppMeta';
+import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
 import { DiagramGenerateForm } from '@/features/generate-diagram/components/DiagramGenerateForm';
 import { DiagramGeneratingStep } from '@/features/generate-diagram/components/DiagramGeneratingStep';
 import { DiagramHeader } from '@/features/generate-diagram/components/DiagramHeader';
@@ -19,6 +20,11 @@ import { useUsecasePath } from '@/hooks/useUsecasePath';
 import { LayoutBody } from '@/layout/LayoutBody';
 
 export const GenerateDiagramPage = () => {
+  const { documentTitle } = useRegisteredAppMeta(
+    COMMON_EXAPPS_TEAM_ID,
+    'diagram',
+    'ダイアグラムを生成',
+  );
   const { usecase, chatId } = useUsecasePath();
   const { loading, messages } = useDiagram(usecase, chatId);
 
@@ -43,7 +49,7 @@ export const GenerateDiagramPage = () => {
 
   return (
     <LayoutBody>
-      <PageTitle title={`ダイアグラムを生成${APP_TITLE ? ` | ${APP_TITLE}` : ''}`} />
+      <PageTitle title={documentTitle} />
       <div className='mx-auto p-6 max-w-(--page-width) lg:p-8'>
         <DiagramHeader />
         <Divider className='my-6' />

--- a/genai-web/packages/web/src/features/generate-diagram/components/DiagramHeader.tsx
+++ b/genai-web/packages/web/src/features/generate-diagram/components/DiagramHeader.tsx
@@ -1,54 +1,45 @@
-import { PiBookOpenBold } from 'react-icons/pi';
-import { BreadcrumbsNav } from '@/components/ui/BreadcrumbsNav';
 import { Disclosure, DisclosureSummary } from '@/components/ui/dads/Disclosure';
+import { ManagedAppHeader } from '@/features/exapp/components/ManagedAppHeader';
+import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
 import { ModelSelector } from './ModelSelector';
 
 export const DiagramHeader = () => {
   return (
     <div className='mb-6 flex flex-col gap-4'>
-      <BreadcrumbsNav
-        items={[
-          { label: 'ホーム', to: '/' },
-          { label: 'AIアプリ', to: '/apps' },
-          { label: 'ダイアグラムを生成' },
-        ]}
-      />
-      <h1 className='flex justify-start text-std-20B-160 lg:text-std-24B-150'>
-        ダイアグラムを生成
-      </h1>
-      <ModelSelector />
-      <Disclosure className='rounded-8 border border-solid-gray-420 bg-solid-gray-50 px-4 py-3'>
-        <DisclosureSummary>
-          <span className='flex items-center text-std-16B-150'>
-            <PiBookOpenBold className='mr-2 size-5 flex-none' />
-            使い方（クリックで開閉）
-          </span>
-        </DisclosureSummary>
-        <div className='prose prose-sm mt-3 max-w-full'>
-          <h2>想定用途</h2>
-        <p>
-          文章を元に、フローチャート/円グラフ/マインドマップなどのダイアグラムの生成をすることができます。
-        </p>
-        <h3>アプリ個別の留意点</h3>
-        <p>
-          長文を入力する場合は処理が著しく重くなる場合がありますので、その場合は入力テキストの内容を単純化するなど工夫してください。なお、生成されたチャート等の正確性は利用者で確認してください。
-        </p>
-        <h3>入力例</h3>
-        <p>図にしたい任意の文章を入力してください。</p>
-        <h2>操作方法</h2>
-        <p>
-          図にしたい任意の文章を入力します。AIを選択すると、生成AIが適切な図を選択し、生成します。AIモデルのプルダウンより利用するAIモデルを選択してください。利用するAIモデルによって、結果が変わることがあります。
-        </p>
-        <Disclosure className='my-4'>
-          <DisclosureSummary>仕組み</DisclosureSummary>
-          <div className='pl-7'>
+      <ManagedAppHeader
+        teamId={COMMON_EXAPPS_TEAM_ID}
+        exAppId='diagram'
+        fallbackTitle='ダイアグラムを生成'
+        fallbackDescription='テキストからフローチャートやマインドマップを作成'
+        fallbackHowTo={
+          <div className='prose prose-sm mt-3 max-w-full'>
+            <h2>想定用途</h2>
             <p>
-              生成AIの機能を活用し、図を作成するよう入力プロンプトに指示して図を返答させています。特別な文書は読み込ませていません。利用するモデルは管理者の設定により切り替えられます。
+              文章を元に、フローチャート/円グラフ/マインドマップなどのダイアグラムの生成をすることができます。
             </p>
+            <h3>アプリ個別の留意点</h3>
+            <p>
+              長文を入力する場合は処理が著しく重くなる場合がありますので、その場合は入力テキストの内容を単純化するなど工夫してください。なお、生成されたチャート等の正確性は利用者で確認してください。
+            </p>
+            <h3>入力例</h3>
+            <p>図にしたい任意の文章を入力してください。</p>
+            <h2>操作方法</h2>
+            <p>
+              図にしたい任意の文章を入力します。AIを選択すると、生成AIが適切な図を選択し、生成します。AIモデルのプルダウンより利用するAIモデルを選択してください。利用するモデルによって、結果が変わることがあります。
+            </p>
+            <Disclosure className='my-4'>
+              <DisclosureSummary>仕組み</DisclosureSummary>
+              <div className='pl-7'>
+                <p>
+                  生成AIの機能を活用し、図を作成するよう入力プロンプトに指示して図を返答させています。特別な文書は読み込ませていません。利用するモデルは管理者の設定により切り替えられます。
+                </p>
+              </div>
+            </Disclosure>
           </div>
-        </Disclosure>
-        </div>
-      </Disclosure>
+        }
+      >
+        <ModelSelector />
+      </ManagedAppHeader>
     </div>
   );
 };

--- a/genai-web/packages/web/src/features/generate-image/GenerateImagePage.tsx
+++ b/genai-web/packages/web/src/features/generate-image/GenerateImagePage.tsx
@@ -1,14 +1,14 @@
 import { useCallback, useState } from 'react';
-import { PiBookOpenBold } from 'react-icons/pi';
 import { useNavigate } from 'react-router';
 import { PageTitle } from '@/components/PageTitle';
-import { BreadcrumbsNav } from '@/components/ui/BreadcrumbsNav';
 import { Button } from '@/components/ui/dads/Button';
 import { Disclosure, DisclosureSummary } from '@/components/ui/dads/Disclosure';
+import { ManagedAppHeader } from '@/features/exapp/components/ManagedAppHeader';
+import { useRegisteredAppMeta } from '@/features/exapp/hooks/useRegisteredAppMeta';
+import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
 import { RightPanelCloseIcon } from '@/components/ui/icons/RightPanelClose';
 import { RightPanelOpenIcon } from '@/components/ui/icons/RightPanelOpen';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
-import { APP_TITLE } from '@/constants';
 import { ChatHistorySidebar } from '@/features/chat/components/ChatHistorySidebar';
 import { useGenerateImageHandler } from '@/features/generate-image/hooks/useGenerateImageHandler';
 import { usePersistImageResult } from '@/features/generate-image/hooks/usePersistImageResult';
@@ -32,6 +32,11 @@ import { SketchMaskDialogs } from './components/SketchMaskDialogs';
 import { Canvas } from './types';
 
 export const GenerateImagePage = () => {
+  const { title: appName, documentTitle } = useRegisteredAppMeta(
+    COMMON_EXAPPS_TEAM_ID,
+    'image',
+    '画像を生成',
+  );
   const {
     prompt,
     setPrompt,
@@ -179,77 +184,75 @@ export const GenerateImagePage = () => {
   const breadcrumbItems = [
     { label: 'ホーム', to: '/' },
     { label: 'AIアプリ', to: '/apps' },
-    { label: '画像を生成', to: chatId ? undefined : '/image' },
+    { label: appName, to: chatId ? undefined : '/image' },
     ...(chatTitle ? [{ label: chatTitle }] : []),
   ];
 
   return (
     <>
-      <PageTitle title={`画像を生成${APP_TITLE ? ` | ${APP_TITLE}` : ''}`} />
+      <PageTitle title={documentTitle} />
       <div className='mx-auto max-w-(--page-width) min-h-[calc(100dvh-var(--header-height))] pt-6 px-6 lg:px-8 lg:pt-8'>
-        <div className='mb-3.5'>
-          <BreadcrumbsNav items={breadcrumbItems} className='mb-4' />
-          <h1 className='flex justify-start text-std-20B-160 lg:text-std-24B-150'>画像を生成</h1>
-        </div>
-
-        <Disclosure className='mb-6 rounded-8 border border-solid-gray-420 bg-solid-gray-50 px-4 py-3'>
-          <DisclosureSummary>
-            <span className='flex items-center text-std-16B-150'>
-              <PiBookOpenBold className='mr-2 size-5 flex-none' />
-              使い方（クリックで開閉）
-            </span>
-          </DisclosureSummary>
-          <div className='prose prose-sm mt-3 max-w-full'>
-            <h2>このアプリでできること</h2>
-            <p>
-              プロンプト（文章）から画像を生成します。資料の挿絵やイメージ案の作成、
-              たたき台づくりに役立ちます。
-            </p>
-            <h3>操作方法</h3>
-            <ol>
-              <li>下部の入力欄に、生成したい画像の内容を入力して送信します（英語推奨・具体的に）。</li>
-              <li>右側の「生成結果」に画像が表示されます。</li>
-              <li>
-                「詳細設定」を開くと、ネガティブプロンプト・画像サイズ・ステップ数・シード・
-                スタイルなどを調整できます。
-              </li>
-              <li>スケッチ／マスク機能で、下絵や修正したい範囲を指定した生成もできます。</li>
-            </ol>
-            <h3>入力例・コツ</h3>
-            <ul>
-              <li>
-                プロンプトは具体的に。例:{' '}
-                <code>a flat vector illustration of a city hall, simple, clean</code>
-              </li>
-              <li>
-                避けたい要素はネガティブプロンプトに。例: <code>blurry, text, watermark</code>
-              </li>
-              <li>ステップ数を増やすと描き込みが増えますが、生成に時間がかかります。</li>
-            </ul>
-            <h3>前提（Stable Diffusion）</h3>
-            <p>
-              画像の描画にはホスト上の AUTOMATIC1111 互換サーバ（既定: ポート <code>7860</code>
-              ）が必要です。未起動の場合は別ターミナルで{' '}
-              <code>python3 scripts/mock-sd-server.py</code>（検証用）または Stable Diffusion
-              WebUI を <code>--api --listen --port 7860</code> 付きで起動してください。
-            </p>
-            <Disclosure className='my-4'>
-              <DisclosureSummary>仕組み・注意</DisclosureSummary>
-              <div className='pl-7'>
+        <div className='mb-6'>
+          <ManagedAppHeader
+            teamId={COMMON_EXAPPS_TEAM_ID}
+            exAppId='image'
+            fallbackTitle='画像を生成'
+            fallbackDescription='プロンプトから資料用の挿絵やイメージ案を作成'
+            breadcrumbItems={breadcrumbItems}
+            fallbackHowTo={
+              <div className='prose prose-sm mt-3 max-w-full'>
+                <h2>このアプリでできること</h2>
+                <p>
+                  プロンプト（文章）から画像を生成します。資料の挿絵やイメージ案の作成、
+                  たたき台づくりに役立ちます。
+                </p>
+                <h3>操作方法</h3>
+                <ol>
+                  <li>下部の入力欄に、生成したい画像の内容を入力して送信します（英語推奨・具体的に）。</li>
+                  <li>右側の「生成結果」に画像が表示されます。</li>
+                  <li>
+                    「詳細設定」を開くと、ネガティブプロンプト・画像サイズ・ステップ数・シード・
+                    スタイルなどを調整できます。
+                  </li>
+                  <li>スケッチ／マスク機能で、下絵や修正したい範囲を指定した生成もできます。</li>
+                </ol>
+                <h3>入力例・コツ</h3>
                 <ul>
-                  <li>生成AI（画像生成モデル）がプロンプトに基づいて画像を生成します。</li>
-                  <li>同じ入力でも生成結果は毎回変わることがあります（シード固定で再現性を高められます）。</li>
-                  <li>生成画像の公開・配布時は、著作権・肖像権にご注意ください。</li>
+                  <li>
+                    プロンプトは具体的に。例:{' '}
+                    <code>a flat vector illustration of a city hall, simple, clean</code>
+                  </li>
+                  <li>
+                    避けたい要素はネガティブプロンプトに。例: <code>blurry, text, watermark</code>
+                  </li>
+                  <li>ステップ数を増やすと描き込みが増えますが、生成に時間がかかります。</li>
                 </ul>
+                <h3>前提（Stable Diffusion）</h3>
+                <p>
+                  画像の描画にはホスト上の AUTOMATIC1111 互換サーバ（既定: ポート <code>7860</code>
+                  ）が必要です。未起動の場合は別ターミナルで{' '}
+                  <code>python3 scripts/mock-sd-server.py</code>（検証用）または Stable Diffusion
+                  WebUI を <code>--api --listen --port 7860</code> 付きで起動してください。
+                </p>
+                <Disclosure className='my-4'>
+                  <DisclosureSummary>仕組み・注意</DisclosureSummary>
+                  <div className='pl-7'>
+                    <ul>
+                      <li>生成AI（画像生成モデル）がプロンプトに基づいて画像を生成します。</li>
+                      <li>同じ入力でも生成結果は毎回変わることがあります（シード固定で再現性を高められます）。</li>
+                      <li>生成画像の公開・配布時は、著作権・肖像権にご注意ください。</li>
+                    </ul>
+                  </div>
+                </Disclosure>
               </div>
-            </Disclosure>
-          </div>
-        </Disclosure>
+            }
+          />
+        </div>
 
         <div className='flex gap-6 xl:gap-8'>
           <div className='flex min-w-0 flex-1 justify-between gap-12 xl:gap-16'>
           <div className='flex min-w-0 flex-1 flex-col'>
-            <GenerateImageStickyHeader />
+            <GenerateImageStickyHeader title={appName} />
 
             <div className='flex-1 pt-4 pb-6 px-2'>
               <GenerateImageAssistant

--- a/genai-web/packages/web/src/features/generate-image/components/GenerateImageStickyHeader.tsx
+++ b/genai-web/packages/web/src/features/generate-image/components/GenerateImageStickyHeader.tsx
@@ -2,7 +2,12 @@ import { useRef } from 'react';
 import { ModelSelector } from '@/features/generate-image/components/ModelSelector';
 import { useStickyHeader } from '@/features/generate-image/hooks/useStickyHeader';
 
-export const GenerateImageStickyHeader = () => {
+type Props = {
+  title?: string;
+};
+
+export const GenerateImageStickyHeader = (props: Props) => {
+  const title = props.title || '画像を生成';
   const sentinelRef = useRef<HTMLDivElement>(null);
   const isSticky = useStickyHeader(sentinelRef);
 
@@ -20,7 +25,7 @@ export const GenerateImageStickyHeader = () => {
             aria-hidden={true}
             className='hidden text-std-16B-170 group-data-[is-sticky="true"]/sticky:block'
           >
-            画像を生成
+            {title}
           </p>
           <ModelSelector />
         </div>

--- a/genai-web/packages/web/src/features/generate-text/GenerateTextPage.tsx
+++ b/genai-web/packages/web/src/features/generate-text/GenerateTextPage.tsx
@@ -1,6 +1,7 @@
 import { PageTitle } from '@/components/PageTitle';
 import { Divider } from '@/components/ui/dads/Divider';
-import { APP_TITLE } from '@/constants';
+import { useRegisteredAppMeta } from '@/features/exapp/hooks/useRegisteredAppMeta';
+import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
 import { GenerateTextForm } from '@/features/generate-text/components/GenerateTextForm';
 import { GenerateTextHeader } from '@/features/generate-text/components/GenerateTextHeader';
 import { GenerateTextResult } from '@/features/generate-text/components/GenerateTextResult';
@@ -15,6 +16,11 @@ import { useReset } from './hooks/useReset';
 import { useSetDefaultValues } from './hooks/useSetDefaultValues';
 
 export const GenerateTextPage = () => {
+  const { documentTitle } = useRegisteredAppMeta(
+    COMMON_EXAPPS_TEAM_ID,
+    'generate',
+    '文章を生成',
+  );
   const { usecase, chatId } = useUsecasePath();
   const { loading, messages, postChat } = useChat(usecase, chatId);
 
@@ -54,7 +60,7 @@ export const GenerateTextPage = () => {
 
   return (
     <LayoutBody>
-      <PageTitle title={`文章を生成${APP_TITLE ? ` | ${APP_TITLE}` : ''}`} />
+      <PageTitle title={documentTitle} />
       <div className='mx-auto p-6 max-w-(--page-width) lg:p-8'>
         <GenerateTextHeader />
         <Divider className='my-6' />

--- a/genai-web/packages/web/src/features/generate-text/components/GenerateTextHeader.tsx
+++ b/genai-web/packages/web/src/features/generate-text/components/GenerateTextHeader.tsx
@@ -1,88 +1,81 @@
-import { PiBookOpenBold } from 'react-icons/pi';
-import { BreadcrumbsNav } from '@/components/ui/BreadcrumbsNav';
 import { Disclosure, DisclosureSummary } from '@/components/ui/dads/Disclosure';
+import { ManagedAppHeader } from '@/features/exapp/components/ManagedAppHeader';
+import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
 import { ModelSelector } from './ModelSelector';
 
 export const GenerateTextHeader = () => {
   return (
     <div className='mb-6 flex flex-col gap-4'>
-      <BreadcrumbsNav
-        items={[
-          { label: 'ホーム', to: '/' },
-          { label: 'AIアプリ', to: '/apps' },
-          { label: '文章を生成' },
-        ]}
-      />
-      <h1 className='flex justify-start text-std-20B-160 lg:text-std-24B-150'>文章を生成</h1>
-      <ModelSelector />
-      <Disclosure className='rounded-8 border border-solid-gray-420 bg-solid-gray-50 px-4 py-3'>
-        <DisclosureSummary>
-          <span className='flex items-center text-std-16B-150'>
-            <PiBookOpenBold className='mr-2 size-5 flex-none' />
-            使い方（クリックで開閉）
-          </span>
-        </DisclosureSummary>
-        <div className='prose prose-sm mt-3 max-w-full'>
-          <h2>想定用途</h2>
-        <p>
-          ビジネスメールや記事などの文章をAIが代行して作成することができます。文書のドラフティングに役立ちます。
-        </p>
-        <h3>アプリ個別の留意点</h3>
-        <p>本アプリは生成AIを使用しています。以下のリスクと対応をご理解ください：</p>
-        <Disclosure className='my-4'>
-          <DisclosureSummary>リスクの例と対応アクション</DisclosureSummary>
-          <div className='pl-7'>
-            <dl>
-              <div>
-                <dt className='mb-2 font-bold'>リスクの例：</dt>
-                <dd className='ml-0'>
-                  <ul>
-                    <li>ハルシネーション（でたらめ）：事実と異なる不正確な情報を生成するおそれ</li>
-                    <li>最新性の欠如：古い情報に基づく回答を生成するおそれ</li>
-                    <li>バイアス：偏った見解や政府の公式見解と異なる判断を生成するおそれ</li>
-                    <li>著作権侵害：保護された著作物を不適切に生成するおそれ</li>
-                    <li>倫理的問題：道徳的に問題のある判断や提案を生成するおそれ</li>
-                    <li>
-                      再現性や説明可能性の欠如：同じ質問でも異なる回答を生成し、生成された内容の根拠も不明なおそれ
-                    </li>
-                  </ul>
-                </dd>
-              </div>
-              <div>
-                <dt className='mb-2 font-bold'>対応アクション：</dt>
-                <dd className='ml-0'>
-                  <ul>
-                    <li>
-                      常に出力内容を批判的に評価し、利用者自身で正確性・妥当性等を判断してください
-                    </li>
-                    <li>機密性３情報や業務目的以外の私的利用の情報の入力は避けてください</li>
-                    <li>必ず他の信頼できる情報源を確認してください</li>
-                  </ul>
-                </dd>
-              </div>
-            </dl>
-          </div>
-        </Disclosure>
-        <h3>入力例</h3>
-        <p>
-          文章の元になる情報のところに生成したい文章のキーワード等と、例を参考に文章の形式に入力された情報を自然言語で入力してください。
-        </p>
-        <h2>操作方法</h2>
-        <p>
-          必要な情報を入力し、実行ボタンを押します。AIモデルのプルダウンより利用するAIモデルを選択してください。利用するAIモデルによって、生成結果が変わることがあります。
-          <br />
-          なお、情報が多すぎる場合は処理が著しく重くなる場合がありますので、その場合は情報を減らして入力してください。
-        </p>
-        <Disclosure className='my-4'>
-          <DisclosureSummary>仕組み</DisclosureSummary>
-          <div className='pl-7'>
+      <ManagedAppHeader
+        teamId={COMMON_EXAPPS_TEAM_ID}
+        exAppId='generate'
+        fallbackTitle='文章を生成'
+        fallbackDescription='手元の情報をもとに文章を作成'
+        fallbackHowTo={
+          <div className='prose prose-sm mt-3 max-w-full'>
+            <h2>想定用途</h2>
             <p>
-              上部で選択した生成AIモデルを使い、文章の元になる情報および文章の形式に入力された情報をもとに文章を生成するよう指示し、生成された文章を返しています。特別な文書は読み込ませていません。利用するモデルは管理者の設定により切り替えられます。
+              ビジネスメールや記事などの文章をAIが代行して作成することができます。文書のドラフティングに役立ちます。
             </p>
+            <h3>アプリ個別の留意点</h3>
+            <p>本アプリは生成AIを使用しています。以下のリスクと対応をご理解ください：</p>
+            <Disclosure className='my-4'>
+              <DisclosureSummary>リスクの例と対応アクション</DisclosureSummary>
+              <div className='pl-7'>
+                <dl>
+                  <div>
+                    <dt className='mb-2 font-bold'>リスクの例：</dt>
+                    <dd className='ml-0'>
+                      <ul>
+                        <li>ハルシネーション（でたらめ）：事実と異なる不正確な情報を生成するおそれ</li>
+                        <li>最新性の欠如：古い情報に基づく回答を生成するおそれ</li>
+                        <li>バイアス：偏った見解や政府の公式見解と異なる判断を生成するおそれ</li>
+                        <li>著作権侵害：保護された著作物を不適切に生成するおそれ</li>
+                        <li>倫理的問題：道徳的に問題のある判断や提案を生成するおそれ</li>
+                        <li>
+                          再現性や説明可能性の欠如：同じ質問でも異なる回答を生成し、生成された内容の根拠も不明なおそれ
+                        </li>
+                      </ul>
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className='mb-2 font-bold'>対応アクション：</dt>
+                    <dd className='ml-0'>
+                      <ul>
+                        <li>
+                          常に出力内容を批判的に評価し、利用者自身で正確性・妥当性等を判断してください
+                        </li>
+                        <li>機密性３情報や業務目的以外の私的利用の情報の入力は避けてください</li>
+                        <li>必ず他の信頼できる情報源を確認してください</li>
+                      </ul>
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+            </Disclosure>
+            <h3>入力例</h3>
+            <p>
+              文章の元になる情報のところに生成したい文章のキーワード等と、例を参考に文章の形式に入力された情報を自然言語で入力してください。
+            </p>
+            <h2>操作方法</h2>
+            <p>
+              必要な情報を入力し、実行ボタンを押します。AIモデルのプルダウンより利用するAIモデルを選択してください。利用するAIモデルによって、生成結果が変わることがあります。
+              <br />
+              なお、情報が多すぎる場合は処理が著しく重くなる場合がありますので、その場合は情報を減らして入力してください。
+            </p>
+            <Disclosure className='my-4'>
+              <DisclosureSummary>仕組み</DisclosureSummary>
+              <div className='pl-7'>
+                <p>
+                  上部で選択した生成AIモデルを使い、文章の元になる情報および文章の形式に入力された情報をもとに文章を生成するよう指示し、生成された文章を返しています。特別な文書は読み込ませていません。利用するモデルは管理者の設定により切り替えられます。
+                </p>
+              </div>
+            </Disclosure>
           </div>
-        </Disclosure>
-        </div>
-      </Disclosure>
+        }
+      >
+        <ModelSelector />
+      </ManagedAppHeader>
     </div>
   );
 };

--- a/genai-web/packages/web/src/features/team-apps/components/TeamAppList.tsx
+++ b/genai-web/packages/web/src/features/team-apps/components/TeamAppList.tsx
@@ -11,6 +11,7 @@ import {
 import { MoreVertIcon } from '@/components/ui/icons/MoreVertIcon';
 import { LoadingButton } from '@/components/ui/LoadingButton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
+import { builtinRouteOf, isBuiltinExApp } from '@/features/exapps/utils/builtinExApp';
 import { useFocusNewItemOnLoadMore } from '@/hooks/useFocusNewItemOnLoadMore';
 import { download } from '@/utils/createDownloadLink';
 import { formatDateTime } from '@/utils/formatDateTime';
@@ -52,6 +53,8 @@ export const TeamAppList = (props: Props) => {
       <ul ref={listRef} className='flex w-full flex-col'>
         {apps.map((app) => {
           const lastUpdated = app.updatedDate || app.createdDate;
+          const builtin = isBuiltinExApp(app);
+          const href = builtinRouteOf(app.config) || `/apps/${app.teamId}/${app.exAppId}`;
           return (
             <li
               className='relative grid w-full grid-cols-[1fr_auto] items-center border-b border-solid border-solid-gray-420'
@@ -59,7 +62,7 @@ export const TeamAppList = (props: Props) => {
             >
               <div className='flex flex-col items-start gap-4 px-4 py-4 text-dns-16N-130 leading-tight!'>
                 <Link
-                  to={`/apps/${app.teamId}/${app.exAppId}`}
+                  to={href}
                   className={`${linkDefaultStyle} ${linkHoverStyle} ${linkFocusStyle} ${linkActiveStyle}`}
                 >
                   {app.exAppName}
@@ -143,6 +146,7 @@ export const TeamAppList = (props: Props) => {
                         </button>
                       )}
                     </MenuItem>
+                    {!builtin && (
                     <MenuItem>
                       {({ focus }) => (
                         <button
@@ -155,6 +159,7 @@ export const TeamAppList = (props: Props) => {
                         </button>
                       )}
                     </MenuItem>
+                    )}
                   </MenuItems>
                 </Menu>
               </div>

--- a/genai-web/packages/web/src/features/team-apps/edit/components/TeamAppEditForm.tsx
+++ b/genai-web/packages/web/src/features/team-apps/edit/components/TeamAppEditForm.tsx
@@ -20,6 +20,7 @@ import { EXAPP_STATUS_OPTIONS, MARKDOWN_EXAMPLE } from '@/constants';
 import { isApiError } from '@/lib/fetcher';
 import { escapeNewlinesInJsonFields } from '@/utils/escapeNewlinesInJsonFields';
 import { focus } from '@/utils/focus';
+import { isBuiltinExApp } from '@/features/exapps/utils/builtinExApp';
 import { useUpdateTeamApp } from '../hooks/useUpdateTeamApp';
 import { teamAppEditSchema } from '../schema';
 
@@ -29,6 +30,7 @@ type Props = {
 
 export const TeamAppEditForm = (props: Props) => {
   const { app } = props;
+  const builtin = isBuiltinExApp(app);
 
   const navigate = useNavigate();
 
@@ -113,7 +115,7 @@ export const TeamAppEditForm = (props: Props) => {
           <RequirementBadge>※必須</RequirementBadge>
         </Label>
         <SupportText id={`team-app-description-support`}>
-          一覧に表示する簡単な説明（30文字程度）
+          おすすめ・アプリ一覧に表示する簡単な説明（30文字程度）
         </SupportText>
         <Input
           id={`team-app-description`}
@@ -167,6 +169,8 @@ export const TeamAppEditForm = (props: Props) => {
         </Disclosure>
       </div>
 
+      {!builtin && (
+        <>
       <Divider className='my-6' />
 
       <div className='flex flex-col gap-1.5'>
@@ -297,6 +301,8 @@ export const TeamAppEditForm = (props: Props) => {
           </ErrorText>
         )}
       </div>
+        </>
+      )}
 
       <Divider className='my-6' />
 
@@ -306,7 +312,7 @@ export const TeamAppEditForm = (props: Props) => {
           <RequirementBadge>※必須</RequirementBadge>
         </Label>
         <SupportText id={`team-app-status-support`}>
-          下書きの場合、一覧には表示されません
+          下書きにすると、おすすめ・すべてのAIアプリ・ピン留め対象から消えます
         </SupportText>
         <Select
           id={`team-app-status`}
@@ -330,6 +336,8 @@ export const TeamAppEditForm = (props: Props) => {
         )}
       </div>
 
+      {!builtin && (
+        <>
       <Divider className='my-6' />
 
       <fieldset>
@@ -338,6 +346,8 @@ export const TeamAppEditForm = (props: Props) => {
         </Legend>
         <Checkbox {...register('copyable')}>このAIアプリをコピー可能にする</Checkbox>
       </fieldset>
+        </>
+      )}
 
       {error && (
         <section className='my-4'>

--- a/genai-web/packages/web/src/features/translate/TranslatePage.tsx
+++ b/genai-web/packages/web/src/features/translate/TranslatePage.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect } from 'react';
 import { PageTitle } from '@/components/PageTitle';
 import { Divider } from '@/components/ui/dads/Divider';
 import { Switch } from '@/components/ui/Switch';
-import { APP_TITLE } from '@/constants';
+import { useRegisteredAppMeta } from '@/features/exapp/hooks/useRegisteredAppMeta';
+import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
 import { TranslateForm } from '@/features/translate/components/TranslateForm';
 import { TranslateHeader } from '@/features/translate/components/TranslateHeader';
 import { useReset } from '@/features/translate/hooks/useReset';
@@ -18,6 +19,7 @@ import { LayoutBody } from '@/layout/LayoutBody';
 import { debounce } from '@/utils/debounce';
 
 export const TranslatePage = () => {
+  const { documentTitle } = useRegisteredAppMeta(COMMON_EXAPPS_TEAM_ID, 'translate', '翻訳');
   const { sentence, additionalContext, language } = useTranslateStore();
 
   const { usecase, chatId } = useUsecasePath();
@@ -86,7 +88,7 @@ export const TranslatePage = () => {
 
   return (
     <LayoutBody>
-      <PageTitle title={`翻訳${APP_TITLE ? ` | ${APP_TITLE}` : ''}`} />
+      <PageTitle title={documentTitle} />
       <div className='mx-auto p-6 max-w-(--page-width) lg:p-8'>
         <TranslateHeader />
         <Divider className='my-6' />

--- a/genai-web/packages/web/src/features/translate/components/TranslateHeader.tsx
+++ b/genai-web/packages/web/src/features/translate/components/TranslateHeader.tsx
@@ -1,56 +1,49 @@
-import { PiBookOpenBold } from 'react-icons/pi';
-import { BreadcrumbsNav } from '@/components/ui/BreadcrumbsNav';
 import { Disclosure, DisclosureSummary } from '@/components/ui/dads/Disclosure';
+import { ManagedAppHeader } from '@/features/exapp/components/ManagedAppHeader';
+import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
 import { ModelSelector } from './ModelSelector';
 
 export const TranslateHeader = () => {
   return (
     <div className='mb-6 flex flex-col gap-4'>
-      <BreadcrumbsNav
-        items={[
-          { label: 'ホーム', to: '/' },
-          { label: 'AIアプリ', to: '/apps' },
-          { label: '翻訳' },
-        ]}
-      />
-      <h1 className='flex justify-start text-std-20B-160 lg:text-std-24B-150'>翻訳</h1>
-      <ModelSelector />
-      <Disclosure className='rounded-8 border border-solid-gray-420 bg-solid-gray-50 px-4 py-3'>
-        <DisclosureSummary>
-          <span className='flex items-center text-std-16B-150'>
-            <PiBookOpenBold className='mr-2 size-5 flex-none' />
-            使い方（クリックで開閉）
-          </span>
-        </DisclosureSummary>
-        <div className='prose prose-sm mt-3 max-w-full'>
-          <h2>想定用途</h2>
-        <p>
-          生成AI（上部で選択中のモデル）を使って、翻訳サービスを提供するものです。
-          文章を英語/日本語/中国語/韓国語/フランス語/スペイン語/ドイツ語のいずれかに翻訳することができます。
-          カジュアルな文章がほしいなどのコンテキストを追加することもできます。
-        </p>
-        <h3>アプリ個別の留意点</h3>
-        <p>
-          長文を入力する場合は処理が著しく重くなる場合がありますので、その場合は、分割して入力してください。翻訳の正確性の確認は利用者側の責任です。翻訳後の文章を再翻訳して大意が変わってないことを確認する等の工夫をお願いします。
-        </p>
-        <h3>入力例</h3>
-        <p>翻訳したい文章のみを入力してください。</p>
-        <h2>操作方法</h2>
-        <p>
-          テキストの箇所に翻訳したいテキストを入力します。翻訳する言語は、プルダウンから選択してください。翻訳して、といったAIへの指示は不要です。
-          <br />
-          AIモデルのプルダウンより利用するAIモデルを選択してください。利用するAIモデルによって、翻訳結果が変わることがあります。
-        </p>
-        <Disclosure className='my-4'>
-          <DisclosureSummary>仕組み</DisclosureSummary>
-          <div className='pl-7'>
+      <ManagedAppHeader
+        teamId={COMMON_EXAPPS_TEAM_ID}
+        exAppId='translate'
+        fallbackTitle='翻訳'
+        fallbackDescription='手元の文章を他の言語に翻訳'
+        fallbackHowTo={
+          <div className='prose prose-sm mt-3 max-w-full'>
+            <h2>想定用途</h2>
             <p>
-              生成AIの機能を活用し、翻訳するよう入力プロンプトに指示して翻訳文を返答させています。特別な文書は読み込ませていません。利用するモデルは管理者の設定により切り替えられます。
+              生成AI（上部で選択中のモデル）を使って、翻訳サービスを提供するものです。
+              文章を英語/日本語/中国語/韓国語/フランス語/スペイン語/ドイツ語のいずれかに翻訳することができます。
+              カジュアルな文章がほしいなどのコンテキストを追加することもできます。
             </p>
+            <h3>アプリ個別の留意点</h3>
+            <p>
+              長文を入力する場合は処理が著しく重くなる場合がありますので、その場合は、分割して入力してください。翻訳の正確性の確認は利用者側の責任です。翻訳後の文章を再翻訳して大意が変わってないことを確認する等の工夫をお願いします。
+            </p>
+            <h3>入力例</h3>
+            <p>翻訳したい文章のみを入力してください。</p>
+            <h2>操作方法</h2>
+            <p>
+              テキストの箇所に翻訳したいテキストを入力します。翻訳する言語は、プルダウンから選択してください。翻訳して、といったAIへの指示は不要です。
+              <br />
+              AIモデルのプルダウンより利用するAIモデルを選択してください。利用するAIモデルによって、翻訳結果が変わることがあります。
+            </p>
+            <Disclosure className='my-4'>
+              <DisclosureSummary>仕組み</DisclosureSummary>
+              <div className='pl-7'>
+                <p>
+                  生成AIの機能を活用し、翻訳するよう入力プロンプトに指示して翻訳文を返答させています。特別な文書は読み込ませていません。利用するモデルは管理者の設定により切り替えられます。
+                </p>
+              </div>
+            </Disclosure>
           </div>
-        </Disclosure>
-        </div>
-      </Disclosure>
+        }
+      >
+        <ModelSelector />
+      </ManagedAppHeader>
     </div>
   );
 };

--- a/genai-web/packages/web/src/layout/navItems.ts
+++ b/genai-web/packages/web/src/layout/navItems.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
-import { useExAppStore } from '@/features/exapps/stores/useExAppStore';
+import { useExAppCatalog } from '@/features/exapps/hooks/useExAppCatalog';
+import { isCatalogListed } from '@/features/exapps/utils/builtinExApp';
 import type { PinnedAppItem } from '@/open-genai/app-pins/types';
 import { useImageAvailable } from '@/open-genai/image-health/useImageAvailable';
 import {
@@ -114,7 +115,7 @@ export const useRecommendedNavItems = (): NavLinkItem[] => {
   const procuretechHearingAvailable = useProcuretechHearingAvailable();
   // 登録済み exApp の表示名・説明は「AIアプリの編集」（レジストリ）の内容に追従させる。
   // 取得前や未登録アプリ（GenU 組み込み・ナレッジ管理）はハードコードの既定値にフォールバック。
-  const registryApps = useExAppStore((s) => s.exApps);
+  const { apps: registryApps, loaded: catalogLoaded } = useExAppCatalog();
 
   return useMemo(() => {
     const metaById = new Map<string, { name: string; description: string }>();
@@ -128,67 +129,76 @@ export const useRecommendedNavItems = (): NavLinkItem[] => {
     }
     const nameOf = (id: string, fallback: string) => metaById.get(id)?.name || fallback;
     const descOf = (id: string, fallback: string) => metaById.get(id)?.description || fallback;
+    const listed = (id: string) => isCatalogListed(id, registryApps, catalogLoaded);
 
-    const items: NavLinkItem[] = [
-      {
-        label: 'チャット',
+    const items: NavLinkItem[] = [];
+
+    if (listed('chat')) {
+      items.push({
+        label: nameOf('chat', 'チャット'),
         to: '/chat',
         state: { shouldReset: true },
-        description: '着想や整理のための壁打ち',
-      },
-    ];
+        description: descOf('chat', '着想や整理のための壁打ち'),
+      });
+    }
 
-    if (isUseCaseEnabled('generate')) {
+    if (isUseCaseEnabled('generate') && listed('generate')) {
       items.push({
-        label: '文章を生成',
+        label: nameOf('generate', '文章を生成'),
         to: '/generate',
-        description: '手元の情報をもとに文章を作成',
+        description: descOf('generate', '手元の情報をもとに文章を作成'),
       });
     }
-    if (isUseCaseEnabled('translate')) {
+    if (isUseCaseEnabled('translate') && listed('translate')) {
       items.push({
-        label: '翻訳',
+        label: nameOf('translate', '翻訳'),
         to: '/translate',
-        description: '手元の文章を他の言語に翻訳',
+        description: descOf('translate', '手元の文章を他の言語に翻訳'),
       });
     }
-    if (isUseCaseEnabled('image') && imageAvailable) {
+    if (isUseCaseEnabled('image') && imageAvailable && listed('image')) {
       items.push({
-        label: '画像を生成',
+        label: nameOf('image', '画像を生成'),
         to: '/image',
-        description: 'プロンプトから資料用の挿絵やイメージ案を作成',
+        description: descOf('image', 'プロンプトから資料用の挿絵やイメージ案を作成'),
       });
     }
-    if (isUseCaseEnabled('diagram')) {
+    if (isUseCaseEnabled('diagram') && listed('diagram')) {
       items.push({
-        label: 'ダイアグラムを生成',
+        label: nameOf('diagram', 'ダイアグラムを生成'),
         to: '/diagram',
-        description: 'テキストからフローチャートやマインドマップを作成',
+        description: descOf('diagram', 'テキストからフローチャートやマインドマップを作成'),
       });
     }
 
-    items.push({
-      label: nameOf('whisper', '文字起こし'),
-      to: WHISPER_EXAPP_PATH,
-      description: descOf('whisper', '音声ファイルから文字起こし'),
-    });
+    if (listed('whisper')) {
+      items.push({
+        label: nameOf('whisper', '文字起こし'),
+        to: WHISPER_EXAPP_PATH,
+        description: descOf('whisper', '音声ファイルから文字起こし'),
+      });
+    }
 
-    items.push({
-      label: nameOf(PROMPT_EXAPP_ID, 'プロンプトテンプレート'),
-      to: PROMPT_TEMPLATES_PATH,
-      description: descOf(PROMPT_EXAPP_ID, '標準／共有テンプレートを選んでチャットへ'),
-    });
+    if (listed(PROMPT_EXAPP_ID)) {
+      items.push({
+        label: nameOf(PROMPT_EXAPP_ID, 'プロンプトテンプレート'),
+        to: PROMPT_TEMPLATES_PATH,
+        description: descOf(PROMPT_EXAPP_ID, '標準／共有テンプレートを選んでチャットへ'),
+      });
+    }
 
-    items.push({
-      label: nameOf(CHOSEI_EXAPP_ID, '日程調整'),
-      to: CHOSEI_PATH,
-      description: descOf(
-        CHOSEI_EXAPP_ID,
-        '庁内・外部参加者向けの日程調整。専用画面で作成・回答・集計できます。',
-      ),
-    });
+    if (listed(CHOSEI_EXAPP_ID)) {
+      items.push({
+        label: nameOf(CHOSEI_EXAPP_ID, '日程調整'),
+        to: CHOSEI_PATH,
+        description: descOf(
+          CHOSEI_EXAPP_ID,
+          '庁内・外部参加者向けの日程調整。専用画面で作成・回答・集計できます。',
+        ),
+      });
+    }
 
-    if (doccheckAvailable) {
+    if (doccheckAvailable && listed(DOCCHECK_EXAPP_ID)) {
       items.push({
         label: nameOf(DOCCHECK_EXAPP_ID, '書類読取とチェック'),
         to: DOCCHECK_PATH,
@@ -199,7 +209,7 @@ export const useRecommendedNavItems = (): NavLinkItem[] => {
       });
     }
 
-    if (patchformAvailable) {
+    if (patchformAvailable && listed(PATCHFORM_EXAPP_ID)) {
       items.push({
         label: nameOf(PATCHFORM_EXAPP_ID, 'フォーム'),
         to: PATCHFORM_PATH,
@@ -210,7 +220,7 @@ export const useRecommendedNavItems = (): NavLinkItem[] => {
       });
     }
 
-    if (procuretechAvailable) {
+    if (procuretechAvailable && listed(PROCURETECH_EXAPP_ID)) {
       items.push({
         label: nameOf(PROCURETECH_EXAPP_ID, '情報化企画書ナビ'),
         to: PROCURETECH_PATH,
@@ -221,7 +231,7 @@ export const useRecommendedNavItems = (): NavLinkItem[] => {
       });
     }
 
-    if (procuretechEditorAvailable) {
+    if (procuretechEditorAvailable && listed(PROCURETECH_EDITOR_EXAPP_ID)) {
       items.push({
         label: nameOf(PROCURETECH_EDITOR_EXAPP_ID, 'Markdown エディタ'),
         to: PROCURETECH_EDITOR_PATH,
@@ -232,7 +242,7 @@ export const useRecommendedNavItems = (): NavLinkItem[] => {
       });
     }
 
-    if (procuretechHearingAvailable) {
+    if (procuretechHearingAvailable && listed(PROCURETECH_HEARING_EXAPP_ID)) {
       items.push({
         label: nameOf(PROCURETECH_HEARING_EXAPP_ID, 'ヒアリングシート'),
         to: PROCURETECH_HEARING_PATH,
@@ -243,11 +253,16 @@ export const useRecommendedNavItems = (): NavLinkItem[] => {
       });
     }
 
-    items.push({
-      label: 'ナレッジ管理',
-      to: KNOWLEDGE_PATH,
-      description: '共有・所属チームの資料を登録／管理（検索は「ナレッジ検索」）',
-    });
+    if (listed('knowledge')) {
+      items.push({
+        label: nameOf('knowledge', 'ナレッジ管理'),
+        to: KNOWLEDGE_PATH,
+        description: descOf(
+          'knowledge',
+          '共有・所属チームの資料を登録／管理（検索は「ナレッジ検索」）',
+        ),
+      });
+    }
 
     return items;
   }, [
@@ -258,6 +273,7 @@ export const useRecommendedNavItems = (): NavLinkItem[] => {
     procuretechEditorAvailable,
     procuretechHearingAvailable,
     registryApps,
+    catalogLoaded,
   ]);
 };
 

--- a/genai-web/packages/web/src/open-genai/chosei/ChoseiPage.tsx
+++ b/genai-web/packages/web/src/open-genai/chosei/ChoseiPage.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/dads/Button';
 import { Label } from '@/components/ui/dads/Label';
 import { PageTitle } from '@/components/PageTitle';
 import { ManagedAppHeader } from '@/features/exapp/components/ManagedAppHeader';
+import { useRegisteredAppMeta } from '@/features/exapp/hooks/useRegisteredAppMeta';
 import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
 import { LayoutBody } from '@/layout/LayoutBody';
 import { CHOSEI_EXAPP_ID } from '@/layout/navItems';
@@ -32,6 +33,11 @@ const newRow = (): DateRow => ({
  * Compose profiles: ["chosei"] 未起動時は有効化手順を案内する。
  */
 export const ChoseiPage = () => {
+  const { documentTitle } = useRegisteredAppMeta(
+    COMMON_EXAPPS_TEAM_ID,
+    CHOSEI_EXAPP_ID,
+    '日程調整',
+  );
   const navigate = useNavigate();
   const { config, isLoading: configLoading, unavailable } = useChoseiConfig();
   const { events, isLoading, loadError, mutate } = useChoseiEvents();
@@ -80,7 +86,7 @@ export const ChoseiPage = () => {
 
   return (
     <LayoutBody>
-      <PageTitle title='日程調整' />
+      <PageTitle title={documentTitle} />
       <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-6 p-6 lg:p-8'>
         <ManagedAppHeader
           teamId={COMMON_EXAPPS_TEAM_ID}

--- a/genai-web/packages/web/src/open-genai/doccheck/DoccheckPage.tsx
+++ b/genai-web/packages/web/src/open-genai/doccheck/DoccheckPage.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/dads/Button';
 import { Label } from '@/components/ui/dads/Label';
 import { PageTitle } from '@/components/PageTitle';
 import { ManagedAppHeader } from '@/features/exapp/components/ManagedAppHeader';
+import { useRegisteredAppMeta } from '@/features/exapp/hooks/useRegisteredAppMeta';
 import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
 import { LayoutBody } from '@/layout/LayoutBody';
 import { DOCCHECK_EXAPP_ID } from '@/layout/navItems';
@@ -86,6 +87,11 @@ type TabItem = {
  * Compose profiles: ["doccheck"] 未起動時は有効化手順を案内する。
  */
 export const DoccheckPage = () => {
+  const { documentTitle } = useRegisteredAppMeta(
+    COMMON_EXAPPS_TEAM_ID,
+    DOCCHECK_EXAPP_ID,
+    '書類読取とチェック',
+  );
   const { config, isLoading: configLoading, unavailable, mutate: mutateConfig } =
     useDoccheckConfig();
   const canArbitrate = config?.can_arbitrate === true;
@@ -495,7 +501,7 @@ export const DoccheckPage = () => {
 
   return (
     <LayoutBody>
-      <PageTitle title='書類読取とチェック' />
+      <PageTitle title={documentTitle} />
       <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-6 p-6 lg:p-8'>
         <ManagedAppHeader
           teamId={COMMON_EXAPPS_TEAM_ID}

--- a/genai-web/packages/web/src/open-genai/knowledge/KnowledgePage.tsx
+++ b/genai-web/packages/web/src/open-genai/knowledge/KnowledgePage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import { PageTitle } from '@/components/PageTitle';
-import { BreadcrumbsNav } from '@/components/ui/BreadcrumbsNav';
 import { Label } from '@/components/ui/dads/Label';
 import { Select } from '@/components/ui/dads/Select';
-import { APP_TITLE } from '@/constants';
+import { ManagedAppHeader } from '@/features/exapp/components/ManagedAppHeader';
+import { useRegisteredAppMeta } from '@/features/exapp/hooks/useRegisteredAppMeta';
+import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
 import { LayoutBody } from '@/layout/LayoutBody';
 import { DocsSection } from './DocsSection';
 import { RegisterSection } from './RegisterSection';
@@ -19,6 +20,11 @@ const TABS: Array<{ id: Tab; label: string }> = [
 ];
 
 export const KnowledgePage = () => {
+  const { documentTitle } = useRegisteredAppMeta(
+    COMMON_EXAPPS_TEAM_ID,
+    'knowledge',
+    'ナレッジ管理',
+  );
   const { scopes, isSystemAdmin, isLoading: scopesLoading } = useScopes();
   const [scope, setScope] = useState('');
   const [tab, setTab] = useState<Tab>('docs');
@@ -38,16 +44,17 @@ export const KnowledgePage = () => {
 
   return (
     <LayoutBody>
-      <PageTitle title={`ナレッジ管理${APP_TITLE ? ` | ${APP_TITLE}` : ''}`} />
+      <PageTitle title={documentTitle} />
       <div className='mx-auto p-6 max-w-(--page-width) lg:p-8'>
-        <BreadcrumbsNav
-          items={[{ label: 'ホーム', to: '/' }, { label: 'ナレッジ管理' }]}
-          className='mb-4'
-        />
-        <h1 className='mb-2 text-std-20B-160 lg:text-std-24B-150'>ナレッジ管理</h1>
-        <p className='mb-6 text-solid-gray-600'>
-          共有ナレッジや所属チームの資料を登録・管理します。検索は「AIアプリ」のナレッジ検索から行えます。
-        </p>
+        <div className='mb-6'>
+          <ManagedAppHeader
+            teamId={COMMON_EXAPPS_TEAM_ID}
+            exAppId='knowledge'
+            fallbackTitle='ナレッジ管理'
+            fallbackDescription='共有ナレッジや所属チームの資料を登録・管理します。検索は「ナレッジ検索」から行えます。'
+            breadcrumbItems={[{ label: 'ホーム', to: '/' }, { label: 'ナレッジ管理' }]}
+          />
+        </div>
 
         {/* スコープセレクタ */}
         <div className='mb-6 flex flex-col gap-1.5'>

--- a/genai-web/packages/web/src/open-genai/procuretech-hearing/ProcuretechHearingPage.tsx
+++ b/genai-web/packages/web/src/open-genai/procuretech-hearing/ProcuretechHearingPage.tsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/dads/Label';
 import { Textarea } from '@/components/ui/dads/Textarea';
 import { PageTitle } from '@/components/PageTitle';
 import { ManagedAppHeader } from '@/features/exapp/components/ManagedAppHeader';
+import { useRegisteredAppMeta } from '@/features/exapp/hooks/useRegisteredAppMeta';
 import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
 import { LayoutBody } from '@/layout/LayoutBody';
 import { PROCURETECH_HEARING_EXAPP_ID } from '@/layout/navItems';
@@ -45,6 +46,11 @@ const UnavailableNotice = ({ message }: { message?: string }) => (
 );
 
 export const ProcuretechHearingPage = () => {
+  const { documentTitle } = useRegisteredAppMeta(
+    COMMON_EXAPPS_TEAM_ID,
+    PROCURETECH_HEARING_EXAPP_ID,
+    'ヒアリングシート',
+  );
   const { config, isLoading: configLoading, unavailable } = useHearingConfig();
   const { sessions, mutate: mutateSessions } = useHearingSessions();
   const [sessionId, setSessionId] = useState<string | null>(null);
@@ -188,7 +194,7 @@ export const ProcuretechHearingPage = () => {
 
   return (
     <LayoutBody>
-      <PageTitle title='ヒアリングシート' />
+      <PageTitle title={documentTitle} />
       <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-4 p-6 lg:p-8'>
         <ManagedAppHeader
           teamId={COMMON_EXAPPS_TEAM_ID}

--- a/genai-web/packages/web/src/open-genai/procuretech/ProcuretechPage.tsx
+++ b/genai-web/packages/web/src/open-genai/procuretech/ProcuretechPage.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/dads/Button';
 import { Label } from '@/components/ui/dads/Label';
 import { PageTitle } from '@/components/PageTitle';
 import { ManagedAppHeader } from '@/features/exapp/components/ManagedAppHeader';
+import { useRegisteredAppMeta } from '@/features/exapp/hooks/useRegisteredAppMeta';
 import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
 import { LayoutBody } from '@/layout/LayoutBody';
 import { PROCURETECH_EXAPP_ID } from '@/layout/navItems';
@@ -330,6 +331,11 @@ const ExportPanel = ({
 };
 
 export const ProcuretechPage = () => {
+  const { documentTitle } = useRegisteredAppMeta(
+    COMMON_EXAPPS_TEAM_ID,
+    PROCURETECH_EXAPP_ID,
+    '情報化企画書ナビ',
+  );
   const { config, isLoading: configLoading, unavailable } = useProcuretechConfig();
   const { sessions, mutate: mutateSessions } = useProcuretechSessions();
   const { createSession, deleteSession, submitting, error, setError } = useProcuretechActions();
@@ -418,7 +424,7 @@ export const ProcuretechPage = () => {
 
   return (
     <LayoutBody>
-      <PageTitle title='情報化企画書ナビ' />
+      <PageTitle title={documentTitle} />
       <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-4 p-6 lg:p-8'>
         <ManagedAppHeader
           teamId={COMMON_EXAPPS_TEAM_ID}

--- a/genai-web/packages/web/src/open-genai/prompt-templates/PromptTemplatesPage.tsx
+++ b/genai-web/packages/web/src/open-genai/prompt-templates/PromptTemplatesPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { PageTitle } from '@/components/PageTitle';
 import { ManagedAppHeader } from '@/features/exapp/components/ManagedAppHeader';
+import { useRegisteredAppMeta } from '@/features/exapp/hooks/useRegisteredAppMeta';
 import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
 import { LayoutBody } from '@/layout/LayoutBody';
 import { PROMPT_EXAPP_ID } from '@/layout/navItems';
@@ -23,6 +24,11 @@ const MODES: { id: Mode; label: string }[] = [
  * プレビュー→チャットへ、というカタログ型 UI を専用ページとして提供する。
  */
 export const PromptTemplatesPage = () => {
+  const { documentTitle } = useRegisteredAppMeta(
+    COMMON_EXAPPS_TEAM_ID,
+    PROMPT_EXAPP_ID,
+    'プロンプトテンプレート',
+  );
   const [mode, setMode] = useState<Mode>('use');
   const { templates, teams, canCreateStandard, isLoading, loadError, mutate } =
     usePromptTemplates();
@@ -35,7 +41,7 @@ export const PromptTemplatesPage = () => {
 
   return (
     <LayoutBody>
-      <PageTitle title='プロンプトテンプレート' />
+      <PageTitle title={documentTitle} />
       <div className='mx-auto flex w-full max-w-(--page-width) flex-col gap-6 p-6 lg:p-8'>
         <ManagedAppHeader
           teamId={COMMON_EXAPPS_TEAM_ID}

--- a/genai-web/packages/web/tests/features/exapps/utils/builtinExApp.test.ts
+++ b/genai-web/packages/web/tests/features/exapps/utils/builtinExApp.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  builtinRouteOf,
+  isBuiltinConfig,
+  isCatalogListed,
+} from '@/features/exapps/utils/builtinExApp';
+
+describe('builtinExApp', () => {
+  it('parses builtin config', () => {
+    expect(isBuiltinConfig('{"builtin":true,"route":"/chat"}')).toBe(true);
+    expect(isBuiltinConfig('{"dynamic_schema":true}')).toBe(false);
+    expect(isBuiltinConfig('')).toBe(false);
+  });
+
+  it('reads builtin route', () => {
+    expect(builtinRouteOf('{"builtin":true,"route":"/diagram"}')).toBe('/diagram');
+    expect(builtinRouteOf('{"builtin":true,"route":"diagram"}')).toBeNull();
+  });
+
+  it('hides draft catalog apps after load', () => {
+    const apps = [{ exAppId: 'diagram', status: 'draft' as const }];
+    expect(isCatalogListed('diagram', apps, true)).toBe(false);
+    expect(isCatalogListed('chat', apps, true)).toBe(true);
+    expect(isCatalogListed('prompt', apps, true)).toBe(false);
+  });
+
+  it('shows defaults before catalog is loaded', () => {
+    expect(isCatalogListed('diagram', [], false)).toBe(true);
+    expect(isCatalogListed('prompt', [], false)).toBe(true);
+  });
+
+  it('shows published catalog apps', () => {
+    const apps = [
+      { exAppId: 'diagram', status: 'published' as const },
+      { exAppId: 'prompt', status: 'published' as const },
+    ];
+    expect(isCatalogListed('diagram', apps, true)).toBe(true);
+    expect(isCatalogListed('prompt', apps, true)).toBe(true);
+  });
+});

--- a/genai-web/packages/web/tests/features/team-apps/edit/components/TeamAppEditForm.test.tsx
+++ b/genai-web/packages/web/tests/features/team-apps/edit/components/TeamAppEditForm.test.tsx
@@ -623,7 +623,7 @@ describe('TeamAppEditForm', () => {
     it('has support text for description field', () => {
       renderWithRouter();
 
-      const supportText = screen.getByText(/一覧に表示する簡単な説明/);
+      const supportText = screen.getByText(/アプリ一覧に表示する簡単な説明/);
       expect(supportText).toBeDefined();
     });
 

--- a/tests/test_app_pins.py
+++ b/tests/test_app_pins.py
@@ -39,6 +39,104 @@ def _make_team_with_app(store, team_name="テストチーム", admin="admin@exam
     return team, app
 
 
+def test_seed_preserves_edited_status(teams_store) -> None:
+    teams_store.upsert_seed_exapp(
+        {
+            "exAppId": "diagram",
+            "teamId": teams_store.COMMON_TEAM_ID,
+            "exAppName": "ダイアグラムを生成",
+            "endpoint": "http://127.0.0.1/builtin/diagram",
+            "config": '{"builtin": true, "route": "/diagram"}',
+            "description": "説明",
+            "howToUse": "使い方",
+            "status": "published",
+        }
+    )
+    teams_store.update_exapp(
+        teams_store.COMMON_TEAM_ID, "diagram", {"status": "draft"}
+    )
+    teams_store.upsert_seed_exapp(
+        {
+            "exAppId": "diagram",
+            "teamId": teams_store.COMMON_TEAM_ID,
+            "exAppName": "ダイアグラムを生成",
+            "endpoint": "http://127.0.0.1/builtin/diagram",
+            "config": '{"builtin": true, "route": "/diagram"}',
+            "description": "説明",
+            "howToUse": "使い方",
+            "status": "published",
+        }
+    )
+    app = teams_store.get_exapp(teams_store.COMMON_TEAM_ID, "diagram")
+    assert app["status"] == "draft"
+
+
+def test_builtin_update_keeps_endpoint(teams_store) -> None:
+    teams_store.upsert_seed_exapp(
+        {
+            "exAppId": "chat",
+            "teamId": teams_store.COMMON_TEAM_ID,
+            "exAppName": "チャット",
+            "endpoint": "http://127.0.0.1/builtin/chat",
+            "config": '{"builtin": true, "route": "/chat"}',
+            "description": "着想や整理のための壁打ち",
+            "howToUse": "使い方",
+            "status": "published",
+        }
+    )
+    teams_store.update_exapp(
+        teams_store.COMMON_TEAM_ID,
+        "chat",
+        {
+            "exAppName": "AIに質問",
+            "description": "アイディア出しや思考整理など",
+            "endpoint": "http://evil.example/invoke",
+            "status": "published",
+        },
+    )
+    app = teams_store.get_exapp(teams_store.COMMON_TEAM_ID, "chat")
+    assert app["exAppName"] == "AIに質問"
+    assert app["description"] == "アイディア出しや思考整理など"
+    assert app["endpoint"] == "http://127.0.0.1/builtin/chat"
+
+
+def test_cannot_delete_builtin(teams_store) -> None:
+    teams_store.upsert_seed_exapp(
+        {
+            "exAppId": "chat",
+            "teamId": teams_store.COMMON_TEAM_ID,
+            "exAppName": "チャット",
+            "endpoint": "http://127.0.0.1/builtin/chat",
+            "config": '{"builtin": true, "route": "/chat"}',
+            "description": "d",
+            "howToUse": "h",
+            "status": "published",
+        }
+    )
+    assert teams_store.delete_exapp(teams_store.COMMON_TEAM_ID, "chat") is False
+    assert teams_store.get_exapp(teams_store.COMMON_TEAM_ID, "chat") is not None
+
+
+def test_pin_rejects_draft_builtin(teams_store) -> None:
+    teams_store.upsert_seed_exapp(
+        {
+            "exAppId": "diagram",
+            "teamId": teams_store.COMMON_TEAM_ID,
+            "exAppName": "ダイアグラムを生成",
+            "endpoint": "http://127.0.0.1/builtin/diagram",
+            "config": '{"builtin": true, "route": "/diagram"}',
+            "description": "d",
+            "howToUse": "h",
+            "status": "draft",
+        }
+    )
+    pins, error = teams_store.add_user_app_pin(
+        "user@example.com", teams_store.COMMON_TEAM_ID, "diagram", False
+    )
+    assert pins is None
+    assert error is not None
+
+
 def test_seed_preserves_edited_description_and_howto(teams_store) -> None:
     teams_store.upsert_seed_exapp(
         {


### PR DESCRIPTION
## Summary
- 組み込みアプリ（チャット・文章生成・翻訳・画像・ダイアグラム・ナレッジ）を共通アプリとして登録し、チーム管理の編集画面で名前・概要・使い方・公開ステータスを変えられるようにした。
- 下書きのアプリはおすすめ・アプリ一覧・ピン留めから外し、専用ページの見出しと履歴ラベルはレジストリの名前に揃える。
- 組み込みアプリはエンドポイント変更・削除不可。シード再実行でも公開ステータスと既存の紹介文は上書きしない。

## Test plan
- [ ] チーム管理 → 共通アプリで、チャット等の「AIアプリの編集」から名前・概要・使い方を保存し、サイドバー・専用ページ見出し・新規チャット説明が反映されること
- [ ] ダイアグラム等を下書きにすると、おすすめ・`/apps`・ピン留め候補から消えること（専用URLは残る）
- [ ] 公開に戻すと再びおすすめに出ること
- [ ] 組み込みアプリの削除ボタンが出ないこと、エンドポイントを変えようとしても保存されないこと
- [ ] 画像生成はコンテナ停止時にメニューから消える既存の健康チェックが維持されること


Made with [Cursor](https://cursor.com)