### PR TITLE
fix(auth): 作業中の突然ログアウトを防ぐサイレントJWT再発行

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -264,6 +264,9 @@ DIFY_APP_URL=http://dify-app:8004/invoke
 # --- SAML 認証（backend = SAML SP / Keycloak = SAML IdP）---
 # アプリ JWT 署名鍵（本番では十分長いランダム値に変更すること）
 APP_JWT_SECRET=change-me-open-genai-secret
+# アプリ JWT の有効期限（秒）。既定 43200=12時間。フロントは期限前に静かに再発行する。
+# 併せて Keycloak realm の SSO Session Idle/Max も同程度にしておくと再ログインが減る。
+APP_JWT_TTL=43200
 # Keycloak 管理者（proxy 経由 http://localhost/kc/ の admin console 用）
 # ※ 利用者一括管理(usermgmt-app) はこの管理者資格情報で Keycloak Admin API を呼ぶ
 KEYCLOAK_ADMIN=admin

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -40,6 +40,9 @@ VITE_APP_IMAGE_DEFAULT_CFG=7
 # === 認証・鍵（本番では必ず変更。未変更のままだと backend 起動時に警告が出ます）===
 # 生成例: openssl rand -hex 32
 APP_JWT_SECRET=please-change-to-a-long-random-secret
+# アプリ JWT の有効期限（秒）。既定 43200=12時間。フロントは期限前に静かに再発行する。
+# Keycloak realm の SSO Session Idle/Max も同程度に設定しておくと再ログインが減る。
+APP_JWT_TTL=43200
 KEYCLOAK_ADMIN=admin
 KEYCLOAK_ADMIN_PASSWORD=please-change-me
 # backend↔exApp 間の署名鍵（x-user-* 偽装対策）。必須・十分長い乱数（例: openssl rand -hex 32）

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -19,7 +19,12 @@ from onelogin.saml2.settings import OneLogin_Saml2_Settings
 
 APP_JWT_SECRET = os.environ.get("APP_JWT_SECRET", "change-me-open-genai-secret")
 JWT_ALG = "HS256"
-JWT_TTL_SECONDS = int(os.environ.get("APP_JWT_TTL", "28800"))  # 8 時間
+JWT_TTL_SECONDS = int(os.environ.get("APP_JWT_TTL", "43200"))  # 12 時間
+# 時計ずれで作業中に 401 にならないよう、検証時に許す猶予（秒）。
+JWT_LEEWAY_SECONDS = int(os.environ.get("APP_JWT_LEEWAY", "60"))
+# 期限切れ直後でも同一 claims で再発行を許す猶予（秒）。
+# （タブがスリープ等で keep-alive が一瞬止まっても復帰できるようにする）
+JWT_REFRESH_GRACE_SECONDS = int(os.environ.get("APP_JWT_REFRESH_GRACE", "300"))
 
 SP_ENTITY_ID = os.environ.get(
     "SAML_SP_ENTITY_ID", "http://localhost:8000/auth/saml/metadata"
@@ -154,4 +159,40 @@ def mint_token(
 
 
 def verify_token(token: str) -> dict[str, Any]:
-    return jwt.decode(token, APP_JWT_SECRET, algorithms=[JWT_ALG])
+    return jwt.decode(
+        token,
+        APP_JWT_SECRET,
+        algorithms=[JWT_ALG],
+        leeway=JWT_LEEWAY_SECONDS,
+    )
+
+
+def refresh_token(token: str) -> str:
+    """有効な（または期限切れ直後・猶予内の）JWT から同一 claims で新 JWT を発行する。
+
+    Keycloak への再認証は行わない。作業中の突然ログアウトを避けるための延長用。
+    - 通常検証を通れば、そのまま再発行。
+    - 期限切れのときだけ、署名を検証しつつ `exp` を無視して読み、`JWT_REFRESH_GRACE_SECONDS`
+      以内なら再発行する。それ以上経過・署名不正は例外を送出（呼び出し側で 401）。
+    """
+    try:
+        claims = verify_token(token)
+    except jwt.ExpiredSignatureError:
+        claims = jwt.decode(
+            token,
+            APP_JWT_SECRET,
+            algorithms=[JWT_ALG],
+            options={"verify_exp": False},
+        )
+        exp = claims.get("exp")
+        if not isinstance(exp, (int, float)):
+            raise
+        if int(time.time()) - int(exp) > JWT_REFRESH_GRACE_SECONDS:
+            raise
+    return mint_token(
+        sub=claims.get("sub", ""),
+        email=claims.get("email", ""),
+        name=claims.get("name", ""),
+        groups=list(claims.get("groups") or []),
+        session_index=claims.get("sidx"),
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1563,6 +1563,24 @@ async def auth_me(authorization: str | None = Header(default=None)) -> JSONRespo
     return JSONResponse(content=claims)
 
 
+@app.post("/auth/refresh")
+async def auth_refresh(
+    authorization: str | None = Header(default=None),
+) -> JSONResponse:
+    """作業中のアプリ JWT を同一 claims で再発行する（Keycloak 再認証なし）。
+
+    有効な、または期限切れ直後（猶予内）の JWT を Bearer で受け取り、新しい JWT を返す。
+    それ以外は 401（フロントはログイン画面へ誘導する）。
+    """
+    if not authorization or not authorization.startswith("Bearer "):
+        return JSONResponse(status_code=401, content={"error": "unauthorized"})
+    try:
+        token = auth.refresh_token(authorization[7:])
+    except Exception:  # noqa: BLE001 - トークン不正/猶予超過は 401 に集約
+        return JSONResponse(status_code=401, content={"error": "unauthorized"})
+    return JSONResponse(content={"token": token})
+
+
 @app.get("/auth/logout")
 async def auth_logout(
     request: Request, token: str | None = Query(default=None)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -148,6 +148,8 @@ services:
       - PUBLIC_BASE_URL=${PUBLIC_URL}/api
       - FRONTEND_URL=${PUBLIC_URL}
       - APP_JWT_SECRET=${APP_JWT_SECRET:?APP_JWT_SECRET を .env.prod に設定してください}
+      # アプリ JWT の有効期限（秒）。既定 43200=12時間。フロントが期限前に静かに再発行する。
+      - APP_JWT_TTL=${APP_JWT_TTL:-43200}
       # 起動時の既定パスワード警告用（Keycloak 本体の認証とは別。backend が検知して案内する）
       - KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD:?KEYCLOAK_ADMIN_PASSWORD を設定してください}
       - FILES_URL_SECRET=${FILES_URL_SECRET:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,8 @@ services:
       - SD_FASTSD_OPENVINO_MODEL_ID=${SD_FASTSD_OPENVINO_MODEL_ID:-}
       # --- SAML 認証 (backend = SAML SP) ---
       - APP_JWT_SECRET=${APP_JWT_SECRET:-change-me-open-genai-secret}
+      # アプリ JWT の有効期限（秒）。既定 43200=12時間。フロントが期限前に静かに再発行する。
+      - APP_JWT_TTL=${APP_JWT_TTL:-43200}
       # 起動時の既定パスワード警告用（未変更なら stderr にガイドを出す）
       - KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD:-admin}
       - FILES_URL_SECRET=${FILES_URL_SECRET:-}

--- a/genai-web/packages/web/src/lib/chatApi.ts
+++ b/genai-web/packages/web/src/lib/chatApi.ts
@@ -10,7 +10,7 @@ import {
   UpdateTitleResponse,
 } from 'genai-web';
 import { genUApi } from '@/lib/fetcher';
-import { getIdToken } from '@/local/localAuth';
+import { getIdToken, refreshSession } from '@/local/localAuth';
 import { decomposeId } from '@/utils/decomposeId';
 
 export type SaveImageResultRequest = {
@@ -74,16 +74,24 @@ export const predict = async (req: PredictRequest): Promise<string> => {
  * yield して呼び出し側 (useChat) の JSON.parse が壊れないようにする。
  */
 export async function* predictStream(req: PredictRequest) {
-  const token = await getIdToken();
+  const callOnce = async (): Promise<Response> => {
+    const token = await getIdToken();
+    return fetch(`${import.meta.env.VITE_APP_API_ENDPOINT}/predict/stream`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(req),
+    });
+  };
 
-  const res = await fetch(`${import.meta.env.VITE_APP_API_ENDPOINT}/predict/stream`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify(req),
-  });
+  let res = await callOnce();
+
+  // 401 のときはまず JWT のサイレント再発行を 1 回試し、成功したら再実行する。
+  if (res.status === 401 && (await refreshSession())) {
+    res = await callOnce();
+  }
 
   if (!res.ok || !res.body) {
     throw new Error(`ストリーム取得に失敗しました (status: ${res.status})`);

--- a/genai-web/packages/web/src/lib/fetcher.ts
+++ b/genai-web/packages/web/src/lib/fetcher.ts
@@ -1,4 +1,4 @@
-import { clearToken, getIdToken, getToken, login } from '@/local/localAuth';
+import { clearToken, getIdToken, getToken, login, refreshSession } from '@/local/localAuth';
 
 // 401（認証切れ/不正トークン）を受けたら、壊れたトークンを破棄して
 // 素直にログイン画面へ戻す。多重リダイレクトを避けるためのガード付き。
@@ -89,6 +89,7 @@ const createApiClient = (baseURL: string) => {
     path: string,
     body?: unknown,
     options?: RequestOptions,
+    retried = false,
   ): Promise<ApiResponse<T>> => {
     const url = buildUrl(baseURL, path, options?.params);
     const authHeaders = await getAuthHeaders(body !== undefined);
@@ -101,6 +102,11 @@ const createApiClient = (baseURL: string) => {
 
     if (!res.ok) {
       if (res.status === 401) {
+        // すぐログアウトせず、まず JWT のサイレント再発行を 1 回だけ試す。
+        // 成功したら同じリクエストを新トークンで再実行する。
+        if (!retried && (await refreshSession())) {
+          return request<T>(method, path, body, options, true);
+        }
         handleUnauthorized();
       }
       const errorData = await parseResponseBody<unknown>(res);
@@ -114,6 +120,7 @@ const createApiClient = (baseURL: string) => {
   const getBlob = async (
     path: string,
     options?: RequestOptions,
+    retried = false,
   ): Promise<{ blob: Blob; disposition: string | null; status: number }> => {
     const url = buildUrl(baseURL, path, options?.params);
     const authHeaders = await getAuthHeaders(false);
@@ -125,6 +132,9 @@ const createApiClient = (baseURL: string) => {
 
     if (!res.ok) {
       if (res.status === 401) {
+        if (!retried && (await refreshSession())) {
+          return getBlob(path, options, true);
+        }
         handleUnauthorized();
       }
       const errorData = await parseResponseBody<unknown>(res);

--- a/genai-web/packages/web/src/local/localAuth.ts
+++ b/genai-web/packages/web/src/local/localAuth.ts
@@ -54,21 +54,110 @@ export const captureTokenFromUrl = (): void => {
 
 export const getToken = (): string | null => localStorage.getItem(TOKEN_KEY);
 
+/** localStorage に JWT を保存する（再発行時に差し替える） */
+export const setToken = (token: string): void => {
+  localStorage.setItem(TOKEN_KEY, token);
+};
+
 /** localStorage の JWT を破棄する（認証エラー時に壊れたセッションを残さない） */
 export const clearToken = (): void => {
   localStorage.removeItem(TOKEN_KEY);
 };
 
-export const isAuthenticated = (): boolean => {
+/** JWT の有効期限（ミリ秒 epoch）。取得できなければ null */
+export const getTokenExpMs = (): number | null => {
   const token = getToken();
   if (!token) {
-    return false;
+    return null;
   }
   const payload = decodeJwt(token);
   if (!payload?.exp) {
+    return null;
+  }
+  return payload.exp * 1000;
+};
+
+export const isAuthenticated = (): boolean => {
+  const exp = getTokenExpMs();
+  if (exp === null) {
     return false;
   }
-  return payload.exp * 1000 > Date.now();
+  return exp > Date.now();
+};
+
+/**
+ * アプリ JWT をサイレント再発行する（Keycloak には戻らない）。
+ * 成功で新トークンを localStorage に保存して true。失敗（401 等）は false。
+ * 期限切れ直後でも backend 側の猶予内なら成功する。
+ */
+let refreshInFlight: Promise<boolean> | null = null;
+export const refreshSession = (): Promise<boolean> => {
+  if (refreshInFlight) {
+    return refreshInFlight;
+  }
+  const token = getToken();
+  if (!token) {
+    return Promise.resolve(false);
+  }
+  refreshInFlight = (async () => {
+    try {
+      const res = await fetch(`${API_ENDPOINT}/auth/refresh`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        return false;
+      }
+      const data = (await res.json()) as { token?: string };
+      if (!data?.token) {
+        return false;
+      }
+      setToken(data.token);
+      return true;
+    } catch {
+      return false;
+    } finally {
+      refreshInFlight = null;
+    }
+  })();
+  return refreshInFlight;
+};
+
+// 残寿命がこの値を切ったら再発行する（既定 1 時間）
+const REFRESH_THRESHOLD_MS = 60 * 60 * 1000;
+// keep-alive のポーリング間隔（1 分）
+const KEEPALIVE_INTERVAL_MS = 60 * 1000;
+let keepAliveTimer: ReturnType<typeof setInterval> | null = null;
+
+const maybeRefresh = (): void => {
+  const exp = getTokenExpMs();
+  if (exp === null) {
+    return;
+  }
+  const remaining = exp - Date.now();
+  // 期限切れは keep-alive では扱わない（API の 401 リトライ／ログインゲートに委ねる）
+  if (remaining > 0 && remaining < REFRESH_THRESHOLD_MS) {
+    void refreshSession();
+  }
+};
+
+/**
+ * 作業中にセッションが切れないよう、期限前に静かに JWT を延長する。
+ * - 1 分ごとに残寿命を確認し、残り 1 時間を切ったら再発行
+ * - タブが前面へ復帰したときにも確認（スリープ明け対策）
+ * - トークンは毎回 localStorage から読むため、他タブでの再発行も自動で共有される
+ */
+export const startSessionKeepAlive = (): void => {
+  if (typeof window === 'undefined' || keepAliveTimer !== null) {
+    return;
+  }
+  maybeRefresh();
+  keepAliveTimer = setInterval(maybeRefresh, KEEPALIVE_INTERVAL_MS);
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') {
+      maybeRefresh();
+    }
+  });
 };
 
 /** backend の SAML ログインへリダイレクト（戻り先は現在のオリジン） */

--- a/genai-web/packages/web/src/main.tsx
+++ b/genai-web/packages/web/src/main.tsx
@@ -6,7 +6,13 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { BrowserRouter } from 'react-router';
 import { OnlineStatusProvider } from '@/components/OnlineStatusProvider';
 import { GlobalErrorFallback } from '@/components/ui/GlobalErrorFallback';
-import { captureTokenFromUrl, clearToken, isAuthenticated, login } from '@/local/localAuth';
+import {
+  captureTokenFromUrl,
+  clearToken,
+  isAuthenticated,
+  login,
+  startSessionKeepAlive,
+} from '@/local/localAuth';
 
 // ACS からのリダイレクトで付与された #token= を取り込む（描画前に実行）
 captureTokenFromUrl();
@@ -27,6 +33,8 @@ const AuthGate = ({ children }: { children: ReactNode }) => {
     login();
     return null;
   }
+  // 認証済みの間は、期限前にサイレント再発行してセッションを維持する
+  startSessionKeepAlive();
   return <>{children}</>;
 };
 

--- a/keycloak/import/realm-open-genai.json
+++ b/keycloak/import/realm-open-genai.json
@@ -5,6 +5,8 @@
   "loginTheme": "keycloak",
   "sslRequired": "none",
   "registrationAllowed": false,
+  "ssoSessionIdleTimeout": 43200,
+  "ssoSessionMaxLifespan": 43200,
   "groups": [
     { "name": "SystemAdminGroup" },
     { "name": "TeamAdminGroup" },

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@ httpx==0.28.1
 pypdf==6.16.2
 bcrypt==4.2.1
 openpyxl==3.1.5
+PyJWT==2.13.0

--- a/tests/test_auth_refresh.py
+++ b/tests/test_auth_refresh.py
@@ -1,0 +1,136 @@
+"""アプリ JWT の再発行（サイレントセッション延長）のテスト。
+
+`backend/app/auth.py` は onelogin(python3-saml) を import するが、ここで検証するのは
+JWT の発行・検証・再発行のみ。テスト依存を軽くするため、onelogin 未導入時は
+ダミーモジュールを差し込んでから import する。
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+import types
+
+import jwt
+import pytest
+
+
+def _install_onelogin_stubs() -> None:
+    try:
+        import onelogin  # noqa: F401
+
+        return
+    except ModuleNotFoundError:
+        pass
+    onelogin_mod = types.ModuleType("onelogin")
+    saml2 = types.ModuleType("onelogin.saml2")
+    auth_mod = types.ModuleType("onelogin.saml2.auth")
+    idp_mod = types.ModuleType("onelogin.saml2.idp_metadata_parser")
+    settings_mod = types.ModuleType("onelogin.saml2.settings")
+    auth_mod.OneLogin_Saml2_Auth = object
+    idp_mod.OneLogin_Saml2_IdPMetadataParser = object
+    settings_mod.OneLogin_Saml2_Settings = object
+    onelogin_mod.saml2 = saml2
+    saml2.auth = auth_mod
+    saml2.idp_metadata_parser = idp_mod
+    saml2.settings = settings_mod
+    sys.modules.update(
+        {
+            "onelogin": onelogin_mod,
+            "onelogin.saml2": saml2,
+            "onelogin.saml2.auth": auth_mod,
+            "onelogin.saml2.idp_metadata_parser": idp_mod,
+            "onelogin.saml2.settings": settings_mod,
+        }
+    )
+
+
+_install_onelogin_stubs()
+
+from app import auth  # noqa: E402
+
+_SECRET = "unit-test-app-jwt-secret-0123456789"
+
+
+@pytest.fixture(autouse=True)
+def _stable_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth, "APP_JWT_SECRET", _SECRET)
+    monkeypatch.setattr(auth, "JWT_LEEWAY_SECONDS", 60)
+    monkeypatch.setattr(auth, "JWT_REFRESH_GRACE_SECONDS", 300)
+
+
+def _make_token(exp_offset: int, **overrides: object) -> str:
+    now = int(time.time())
+    payload: dict[str, object] = {
+        "sub": "user@example.com",
+        "email": "user@example.com",
+        "name": "テスト利用者",
+        "groups": ["UserGroup"],
+        "sidx": "session-index-1",
+        "iat": now,
+        "exp": now + exp_offset,
+    }
+    payload.update(overrides)
+    return jwt.encode(payload, _SECRET, algorithm=auth.JWT_ALG)
+
+
+def test_default_ttl_is_12_hours() -> None:
+    assert auth.JWT_TTL_SECONDS == 43200
+
+
+def test_mint_and_verify_roundtrip() -> None:
+    token = auth.mint_token(
+        sub="a@example.com",
+        email="a@example.com",
+        name="A",
+        groups=["UserGroup", "TeamAdminGroup"],
+        session_index="idx-9",
+    )
+    claims = auth.verify_token(token)
+    assert claims["sub"] == "a@example.com"
+    assert claims["groups"] == ["UserGroup", "TeamAdminGroup"]
+    assert claims["sidx"] == "idx-9"
+
+
+def test_refresh_valid_token_preserves_claims_and_extends_exp() -> None:
+    old = _make_token(3600)
+    old_claims = auth.verify_token(old)
+
+    new = auth.refresh_token(old)
+    new_claims = auth.verify_token(new)
+
+    assert new_claims["sub"] == old_claims["sub"]
+    assert new_claims["email"] == old_claims["email"]
+    assert new_claims["name"] == old_claims["name"]
+    assert new_claims["groups"] == old_claims["groups"]
+    assert new_claims["sidx"] == old_claims["sidx"]
+    # 再発行後は有効期限が（既定 12 時間先に）延びている
+    assert new_claims["exp"] > old_claims["exp"]
+
+
+def test_refresh_expired_within_grace_succeeds() -> None:
+    # leeway(60s) は超えるが grace(300s) 以内 → 再発行を許可する
+    token = _make_token(-120)
+    new = auth.refresh_token(token)
+    claims = auth.verify_token(new)
+    assert claims["sub"] == "user@example.com"
+    assert claims["exp"] > int(time.time())
+
+
+def test_refresh_expired_beyond_grace_raises() -> None:
+    token = _make_token(-400)
+    with pytest.raises(jwt.ExpiredSignatureError):
+        auth.refresh_token(token)
+
+
+def test_refresh_tampered_signature_raises() -> None:
+    token = _make_token(3600) + "tampered"
+    with pytest.raises(jwt.InvalidTokenError):
+        auth.refresh_token(token)
+
+
+def test_verify_allows_small_clock_skew() -> None:
+    # 期限を 30 秒だけ過ぎたトークンは leeway(60s) 内なので有効扱い
+    token = _make_token(-30)
+    claims = auth.verify_token(token)
+    assert claims["sub"] == "user@example.com"


### PR DESCRIPTION
## 背景 / 症状
「Keycloakでログインしても、作業中にアプリが突然ログイン画面に戻る」という報告への対策です。

原因は Keycloak SSO ではなく、backend が発行するアプリ JWT（更新なし・既定8時間）でした。期限切れ後の API が 401 になると、フロントが即 `clearToken()` → `/auth/login` へ飛ばすため、作業中に突然ログインになっていました。

## 変更内容
Keycloak には戻さず、JWT だけを期限前・期限直後に静かに再発行してセッションを維持します。

### Backend
- `APP_JWT_TTL` 既定を 8h → **12h**（`43200`）
- `verify_token` に `leeway`（既定60秒）を追加し、時計ずれでの誤 401 を緩和
- `refresh_token()` を追加：有効な、または期限切れ直後（既定300秒の猶予内）の JWT から同一 claims（`sub/email/name/groups/sidx`）で再発行
- `POST /auth/refresh` を追加（`/auth/` 公開パス配下、ハンドラ内で Bearer 検証。成功 `{ "token": ... }` / 失敗 401）

### Frontend
- `localAuth` に `setToken` / `getTokenExpMs` / `refreshSession()` / `startSessionKeepAlive()`（残り1時間で再発行、1分間隔 + `visibilitychange`）を追加
- `fetcher` と `predictStream` は 401 時にまず `refreshSession()` を1回試して同一リクエストを再実行し、失敗時のみ従来のログアウト

### 設定 / Keycloak
- `.env.example` / `.env.prod.example` と両 compose に `APP_JWT_TTL=43200` を追加
- realm に `ssoSessionIdleTimeout` / `ssoSessionMaxLifespan` を 12 時間で明示

## テスト
- `tests/test_auth_refresh.py` を新規追加（再発行で exp 延長・claims 保持、猶予内成功、猶予超過で例外、署名改ざんで例外、leeway 確認）。`tests/requirements.txt` に `PyJWT` を追加
- backend pytest スイート全合格
- フロントは当環境に Node ランタイムが無く vitest/型チェック未実行（IDE の TS 診断のみ）。Node を用意でき次第 web テストを追加・実行予定

## 注意（運用）
- 稼働中の Keycloak realm は import 上書きされないため、**既存環境は管理コンソールで SSO Session Idle/Max を手動延長**してください（開発 compose の `OVERWRITE_EXISTING` は再起動で反映）
