### PR TITLE
feat(web): プロンプト送信キーをアカウント設定で選べるようにする

### DIFF
--- a/genai-web/packages/web/src/features/chat/components/ChatHints.tsx
+++ b/genai-web/packages/web/src/features/chat/components/ChatHints.tsx
@@ -1,7 +1,9 @@
 import { PiBookOpenBold } from 'react-icons/pi';
 import { Disclosure, DisclosureSummary } from '@/components/ui/dads/Disclosure';
+import { useSubmitKey } from '@/hooks/useSubmitKey';
 
 export const ChatHints = () => {
+  const { hint } = useSubmitKey();
   return (
     <div className='w-full rounded-8 border border-solid-gray-420 bg-solid-gray-50 px-4 py-3 text-solid-gray-800'>
       <Disclosure>
@@ -15,9 +17,8 @@ export const ChatHints = () => {
           <div>
           <dt className='mb-2 text-std-18B-160'>チャットの使い方</dt>
           <dd>
-            下部の入力欄にメッセージを入力して送信すると、AIから回答が返ってきます。Enter
-            で送信、Shift+Enter
-            で改行できます。質問・依頼・相談など、業務に関することを自由に送ってみてください。一度の質問で完結しなくても大丈夫です。回答後もそのまま会話を続けることで、タスクをより深く進められます。
+            下部の入力欄にメッセージを入力して送信すると、AIから回答が返ってきます。{hint}
+            です。質問・依頼・相談など、業務に関することを自由に送ってみてください。一度の質問で完結しなくても大丈夫です。回答後もそのまま会話を続けることで、タスクをより深く進められます。
           </dd>
         </div>
         <div>

--- a/genai-web/packages/web/src/features/chat/components/ChatInput.tsx
+++ b/genai-web/packages/web/src/features/chat/components/ChatInput.tsx
@@ -24,7 +24,8 @@ import { useChatStore } from '@/features/chat/stores/useChatStore';
 import { useChat } from '@/hooks/useChat';
 import { useFiles } from '@/hooks/useFiles';
 import { useUsecasePath } from '@/hooks/useUsecasePath';
-import { requestSubmitOnEnter, submitKeyHint } from '@/utils/keyboard';
+import { useSubmitKey } from '@/hooks/useSubmitKey';
+import { requestSubmitOnEnter } from '@/utils/keyboard';
 import { FILE_LIMIT } from '../constants';
 import { ChatFormSchema, chatFormSchema } from '../schema';
 
@@ -36,6 +37,7 @@ type Props = {
 
 export const ChatInput = (props: Props) => {
   const { onSend, fileUpload, accept } = props;
+  const { hint } = useSubmitKey();
 
   const { usecase, chatId } = useUsecasePath();
   const { content, setContent, hasSent, setHasSent } = useChatStore();
@@ -153,7 +155,7 @@ export const ChatInput = (props: Props) => {
             : '追加で質問や不明点などあれば返答してみましょう'}
         </h2>
         <SupportText id='chat-input-submit-hint' className='mb-1'>
-          {submitKeyHint}
+          {hint}
         </SupportText>
         <div className='relative flex items-end bg-white'>
           <div className='flex w-full flex-col gap-2'>

--- a/genai-web/packages/web/src/features/exapp/components/ExAppChat.tsx
+++ b/genai-web/packages/web/src/features/exapp/components/ExAppChat.tsx
@@ -4,10 +4,12 @@ import { Markdown } from '@/components/Markdown';
 import { ButtonCopy } from '@/components/ui/ButtonCopy';
 import { Button } from '@/components/ui/dads/Button';
 import { ProgressIndicator } from '@/components/ui/dads/ProgressIndicator';
+import { SupportText } from '@/components/ui/dads/SupportText';
 import { Textarea } from '@/components/ui/dads/Textarea';
 import { LoadingButton } from '@/components/ui/LoadingButton';
+import { useSubmitKey } from '@/hooks/useSubmitKey';
 import { isApiError } from '@/lib/fetcher';
-import { submitKeyHint, isSubmitKey } from '@/utils/keyboard';
+import { isSubmitKey } from '@/utils/keyboard';
 import { newId } from '@/utils/uuid';
 import { ExAppConversation, useExAppConversations } from '../hooks/useExAppConversations';
 import { useInvokeExApp } from '../hooks/useInvokeExApp';
@@ -61,6 +63,7 @@ const extractFileNames = (inputs: Record<string, unknown>): string[] | undefined
 };
 
 export const ExAppChat = ({ exApp, fileAttachEnabled = false }: Props) => {
+  const { hint } = useSubmitKey();
   const { invokeExAppStream } = useInvokeExApp();
   const { conversations, mutate: mutateConversations } = useExAppConversations(
     exApp.teamId,
@@ -356,6 +359,7 @@ export const ExAppChat = ({ exApp, fileAttachEnabled = false }: Props) => {
           </div>
         )}
 
+        <SupportText id='exapp-chat-submit-hint'>{hint}</SupportText>
         <Textarea
           value={input}
           onChange={(e) => setInput(e.target.value)}
@@ -363,7 +367,8 @@ export const ExAppChat = ({ exApp, fileAttachEnabled = false }: Props) => {
           onCompositionStart={() => (isComposing.current = true)}
           onCompositionEnd={() => (isComposing.current = false)}
           rows={2}
-          placeholder={`メッセージを入力（${submitKeyHint}）`}
+          placeholder='メッセージを入力'
+          aria-describedby='exapp-chat-submit-hint'
           className='w-full'
         />
 

--- a/genai-web/packages/web/src/features/exapp/components/ExAppForm.tsx
+++ b/genai-web/packages/web/src/features/exapp/components/ExAppForm.tsx
@@ -14,7 +14,7 @@ import { Disclosure, DisclosureSummary } from '@/components/ui/dads/Disclosure';
 import { ErrorText } from '@/components/ui/dads/ErrorText';
 import { SupportText } from '@/components/ui/dads/SupportText';
 import { isJSON } from '@/utils/isJSON';
-import { submitKeyHint } from '@/utils/keyboard';
+import { ENTER_SUBMIT_HINT } from '@/utils/keyboard';
 import { newId } from '@/utils/uuid';
 import { useExAppInvokeState } from '../hooks/useExAppInvokeState';
 import { getExAppHistoriesKey } from '../hooks/useFetchInvokedExAppHistories';
@@ -303,7 +303,7 @@ ${parsedHistory.outputs}
         {validationError && <ErrorText>＊{validationError}</ErrorText>}
 
         <div className='flex flex-col items-center gap-3'>
-          <SupportText id='exapp-submit-hint'>{submitKeyHint}</SupportText>
+          <SupportText id='exapp-submit-hint'>{ENTER_SUBMIT_HINT}</SupportText>
           <Button
             aria-disabled={requestLoading ? true : undefined}
             variant='solid-fill'

--- a/genai-web/packages/web/src/features/exapp/components/SystemPrompt.tsx
+++ b/genai-web/packages/web/src/features/exapp/components/SystemPrompt.tsx
@@ -3,7 +3,7 @@ import { FieldErrors, FieldValues, UseFormRegister } from 'react-hook-form';
 import { AutoResizeTextarea } from '@/components/ui/AutoResizeTextarea';
 import { Disclosure, DisclosureSummary } from '@/components/ui/dads/Disclosure';
 import { ErrorText } from '@/components/ui/dads/ErrorText';
-import { requestSubmitOnEnter } from '@/utils/keyboard';
+import { requestEnterSubmit } from '@/utils/keyboard';
 
 type Props = {
   exApp: ExApp;
@@ -27,7 +27,7 @@ export const SystemPrompt = (props: Props) => {
         aria-labelledby='system-prompt-input-label'
         aria-describedby='exapp-submit-hint'
         defaultValue={exApp.systemPrompt}
-        onKeyDown={requestSubmitOnEnter}
+        onKeyDown={requestEnterSubmit}
         {...register(key, {
           required: true,
         })}

--- a/genai-web/packages/web/src/features/exapp/components/form/ExAppTextarea.tsx
+++ b/genai-web/packages/web/src/features/exapp/components/form/ExAppTextarea.tsx
@@ -4,7 +4,7 @@ import { Label } from '@/components/ui/dads/Label';
 import { RequirementBadge } from '@/components/ui/dads/RequirementBadge';
 import { SupportText } from '@/components/ui/dads/SupportText';
 import { Textarea } from '@/components/ui/dads/Textarea';
-import { requestSubmitOnEnter } from '@/utils/keyboard';
+import { requestEnterSubmit } from '@/utils/keyboard';
 import { GovAIFormUITextarea } from '../../types';
 
 type Props = {
@@ -41,7 +41,7 @@ export const ExAppTextarea = (props: Props) => {
             .filter(Boolean)
             .join(' ') || undefined
         }
-        onKeyDown={requestSubmitOnEnter}
+        onKeyDown={requestEnterSubmit}
         {...register(id, {
           required: uiConfig.required ?? false,
           minLength: uiConfig.min_length ?? undefined,

--- a/genai-web/packages/web/src/features/generate-diagram/components/DiagramGenerateForm.tsx
+++ b/genai-web/packages/web/src/features/generate-diagram/components/DiagramGenerateForm.tsx
@@ -17,7 +17,8 @@ import { SupportText } from '@/components/ui/dads/SupportText';
 import { useDiagram } from '@/features/generate-diagram/hooks/useDiagram';
 import { useDiagramStore } from '@/features/generate-diagram/stores/useDiagramStore';
 import { useUsecasePath } from '@/hooks/useUsecasePath';
-import { requestSubmitOnEnter, submitKeyHint } from '@/utils/keyboard';
+import { useSubmitKey } from '@/hooks/useSubmitKey';
+import { requestSubmitOnEnter } from '@/utils/keyboard';
 import { DIAGRAM_DATA } from '../constants';
 import { DiagramFormSchema, diagramFormSchema } from '../schema';
 import { DiagramTypeButton } from './DiagramTypeButton';
@@ -31,6 +32,7 @@ const otherTypeOptions = Object.values(DIAGRAM_DATA).filter(
 );
 
 export const DiagramGenerateForm = () => {
+  const { hint } = useSubmitKey();
   const { content, setContent, selectedType, setSelectedType, setDiagramGenerationError } =
     useDiagramStore();
 
@@ -149,7 +151,7 @@ export const DiagramGenerateForm = () => {
         </div>
 
         <SupportText id='generate-diagram-submit-hint' className='mb-3 text-center'>
-          {submitKeyHint}
+          {hint}
         </SupportText>
 
         <div className='flex justify-center'>

--- a/genai-web/packages/web/src/features/generate-image/components/GenerateImageInput.tsx
+++ b/genai-web/packages/web/src/features/generate-image/components/GenerateImageInput.tsx
@@ -7,7 +7,8 @@ import { SendIcon } from '@/components/ui/icons/SendIcon';
 import { LoadingButton } from '@/components/ui/LoadingButton';
 import { useChat } from '@/hooks/useChat';
 import { useUsecasePath } from '@/hooks/useUsecasePath';
-import { requestSubmitOnEnter, submitKeyHint } from '@/utils/keyboard';
+import { useSubmitKey } from '@/hooks/useSubmitKey';
+import { requestSubmitOnEnter } from '@/utils/keyboard';
 import { type GenerateImageChatFormSchema, generateImageChatFormSchema } from '../schema';
 
 type Props = {
@@ -20,6 +21,7 @@ type Props = {
 
 export const GenerateImageInput = (props: Props) => {
   const { textareaId, content, onChangeContent, onSend } = props;
+  const { hint } = useSubmitKey();
 
   const { usecase, chatId } = useUsecasePath();
   const { loading: chatLoading } = useChat(usecase, chatId);
@@ -51,7 +53,7 @@ export const GenerateImageInput = (props: Props) => {
         生成したい画像の内容を入力してみましょう
       </h2>
       <SupportText id={`${textareaId}-submit-hint`} className='mb-1'>
-        {submitKeyHint}
+        {hint}
       </SupportText>
       <div className='flex w-full flex-col gap-2'>
         <AutoResizeTextarea

--- a/genai-web/packages/web/src/features/generate-image/components/ImageGeneratorForm.tsx
+++ b/genai-web/packages/web/src/features/generate-image/components/ImageGeneratorForm.tsx
@@ -20,7 +20,8 @@ import {
   useGenerateImageStore,
 } from '@/features/generate-image/stores/useGenerateImageStore';
 import { findModelDisplayNameByModelId, MODELS } from '@/models';
-import { isSubmitKey, submitKeyHint } from '@/utils/keyboard';
+import { useSubmitKey } from '@/hooks/useSubmitKey';
+import { isSubmitKey } from '@/utils/keyboard';
 import {
   AMAZON_ADVANCED_GENERATION_MODE,
   AMAZON_MODELS,
@@ -44,6 +45,7 @@ type Props = {
 };
 
 export const ImageGeneratorForm = (props: Props) => {
+  const { hint } = useSubmitKey();
   const {
     generating,
     loadingChat,
@@ -600,7 +602,7 @@ export const ImageGeneratorForm = (props: Props) => {
       </div>
 
       <SupportText id='generate-image-submit-hint' className='mt-4 mb-2 text-center text-dns-14N-130!'>
-        {submitKeyHint}
+        {hint}
       </SupportText>
 
       <div className='flex flex-row-reverse items-center justify-center gap-x-5'>

--- a/genai-web/packages/web/src/features/generate-text/components/GenerateTextForm.tsx
+++ b/genai-web/packages/web/src/features/generate-text/components/GenerateTextForm.tsx
@@ -9,7 +9,8 @@ import { SupportText } from '@/components/ui/dads/SupportText';
 import { useGenerateTextStore } from '@/features/generate-text/stores/useGenerateTextStore';
 import { useChat } from '@/hooks/useChat';
 import { useUsecasePath } from '@/hooks/useUsecasePath';
-import { requestSubmitOnEnter, submitKeyHint } from '@/utils/keyboard';
+import { useSubmitKey } from '@/hooks/useSubmitKey';
+import { requestSubmitOnEnter } from '@/utils/keyboard';
 import { GenerateTextFormSchema, generateTextFormSchema } from '../schema';
 
 type Props = {
@@ -18,6 +19,7 @@ type Props = {
 };
 
 export const GenerateTextForm = (props: Props) => {
+  const { hint } = useSubmitKey();
   const { setFollowing, getGeneratedText } = props;
 
   const { information, setInformation, context, setContext } = useGenerateTextStore();
@@ -96,7 +98,7 @@ export const GenerateTextForm = (props: Props) => {
         </div>
 
         <SupportText id='generate-text-submit-hint' className='mt-4 text-center'>
-          {submitKeyHint}
+          {hint}
         </SupportText>
 
         <div className='mt-3 flex justify-center'>

--- a/genai-web/packages/web/src/features/landing/components/LandingForm.tsx
+++ b/genai-web/packages/web/src/features/landing/components/LandingForm.tsx
@@ -12,9 +12,11 @@ import { ChatNotificationDialogButton } from '@/features/chat/components/ChatNot
 import { ModelSelector } from '@/features/landing/components/ModelSelector';
 import { TOP_CHAT_SYSTEM_PROMPT, TOP_CHAT_SYSTEM_PROMPT_TITLE } from '@/features/landing/constants';
 import { LandingChatFormSchema, landingChatFormSchema } from '@/features/landing/schema';
-import { requestSubmitOnEnter, submitKeyHint } from '@/utils/keyboard';
+import { useSubmitKey } from '@/hooks/useSubmitKey';
+import { requestSubmitOnEnter } from '@/utils/keyboard';
 
 export const LandingForm = () => {
+  const { hint } = useSubmitKey();
   const navigate = useNavigate();
   const [isNotificationDialogOpen, setIsNotificationDialogOpen] = useState(false);
 
@@ -66,7 +68,7 @@ export const LandingForm = () => {
             onKeyDown={requestSubmitOnEnter}
             {...register('chatInput')}
           />
-          <SupportText id='chat-input-submit-hint'>{submitKeyHint}</SupportText>
+          <SupportText id='chat-input-submit-hint'>{hint}</SupportText>
           <div className='flex justify-end'>
             {errors.chatInput && (
               <ErrorText className='mr-auto -mt-1' id='chat-input-error'>

--- a/genai-web/packages/web/src/features/translate/components/TranslateForm.tsx
+++ b/genai-web/packages/web/src/features/translate/components/TranslateForm.tsx
@@ -9,7 +9,8 @@ import { SupportText } from '@/components/ui/dads/SupportText';
 import { useTranslateStore } from '@/features/translate/stores/useTranslateStore';
 import { useChat } from '@/hooks/useChat';
 import { useUsecasePath } from '@/hooks/useUsecasePath';
-import { requestSubmitOnEnter, submitKeyHint } from '@/utils/keyboard';
+import { useSubmitKey } from '@/hooks/useSubmitKey';
+import { requestSubmitOnEnter } from '@/utils/keyboard';
 import { TranslateFormSchema, translateFormSchema } from '../schema';
 import { TranslatedResult } from './TranslatedResult';
 
@@ -21,6 +22,7 @@ type Props = {
 
 export const TranslateForm = (props: Props) => {
   const { typingTextOutput, translatedSentence, getTranslation } = props;
+  const { hint } = useSubmitKey();
 
   const { sentence, setSentence, additionalContext, setAdditionalContext, language } =
     useTranslateStore();
@@ -114,7 +116,7 @@ export const TranslateForm = (props: Props) => {
         </div>
 
         <SupportText id='translate-submit-hint' className='mt-4 text-center'>
-          {submitKeyHint}
+          {hint}
         </SupportText>
 
         <div className='mt-3 flex justify-center'>

--- a/genai-web/packages/web/src/hooks/useSubmitKey.ts
+++ b/genai-web/packages/web/src/hooks/useSubmitKey.ts
@@ -1,0 +1,18 @@
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import {
+  DEFAULT_SUBMIT_KEY,
+  parseSubmitKey,
+  SUBMIT_KEY_STORAGE,
+  submitKeyHint,
+  type SubmitKey,
+} from '@/utils/keyboard';
+
+export const useSubmitKey = () => {
+  const [raw, setRaw] = useLocalStorage(SUBMIT_KEY_STORAGE, DEFAULT_SUBMIT_KEY);
+  const key = parseSubmitKey(raw);
+  return {
+    key,
+    setKey: (next: SubmitKey) => setRaw(next),
+    hint: submitKeyHint(key),
+  };
+};

--- a/genai-web/packages/web/src/open-genai/procuretech/ProcuretechPage.tsx
+++ b/genai-web/packages/web/src/open-genai/procuretech/ProcuretechPage.tsx
@@ -9,11 +9,14 @@ import {
 import { PiDownloadSimpleBold } from 'react-icons/pi';
 import { Button } from '@/components/ui/dads/Button';
 import { Label } from '@/components/ui/dads/Label';
+import { SupportText } from '@/components/ui/dads/SupportText';
 import { PageTitle } from '@/components/PageTitle';
 import { ManagedAppHeader } from '@/features/exapp/components/ManagedAppHeader';
 import { useRegisteredAppMeta } from '@/features/exapp/hooks/useRegisteredAppMeta';
 import { COMMON_EXAPPS_TEAM_ID } from '@/features/exapps/constants';
+import { useSubmitKey } from '@/hooks/useSubmitKey';
 import { LayoutBody } from '@/layout/LayoutBody';
+import { isSubmitKey } from '@/utils/keyboard';
 import { PROCURETECH_EXAPP_ID } from '@/layout/navItems';
 import { ApiError } from '@/lib/fetcher';
 import type { ProcuretechSection, ProcuretechSessionDetail } from './types';
@@ -66,6 +69,7 @@ const SectionChat = ({
   sessionId: string;
   onChanged: () => void | Promise<void>;
 }) => {
+  const { hint } = useSubmitKey();
   const { finalize, clearSection, submitting, error, setError } = useProcuretechActions();
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
@@ -112,8 +116,7 @@ const SectionChat = ({
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    // Enter で送信 / Shift+Enter で改行。日本語入力の変換確定 Enter は送信しない。
-    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+    if (isSubmitKey(e)) {
       e.preventDefault();
       void submit();
     }
@@ -220,8 +223,9 @@ const SectionChat = ({
 
       <form onSubmit={onSubmit} className='flex flex-col gap-2'>
         <Label htmlFor={`pt-input-${section.key}`} size='sm'>
-          メッセージ（Enter で送信 / Shift+Enter で改行）
+          メッセージ
         </Label>
+        <SupportText id={`pt-input-${section.key}-submit-hint`}>{hint}</SupportText>
         <textarea
           id={`pt-input-${section.key}`}
           className='w-full rounded-4 border border-solid-gray-420 px-3 py-2 text-std-16N-170'
@@ -229,6 +233,7 @@ const SectionChat = ({
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={onKeyDown}
+          aria-describedby={`pt-input-${section.key}-submit-hint`}
           placeholder={section.chat_placeholder}
         />
         <div className='flex flex-wrap items-center gap-2'>

--- a/genai-web/packages/web/src/open-genai/settings/SettingsPage.tsx
+++ b/genai-web/packages/web/src/open-genai/settings/SettingsPage.tsx
@@ -3,6 +3,7 @@ import { ProgressIndicator } from '@/components/ui/dads/ProgressIndicator';
 import { LayoutBody } from '@/layout/LayoutBody';
 import { PasswordForm } from './components/PasswordForm';
 import { ProfileForm } from './components/ProfileForm';
+import { SubmitKeySettings } from './components/SubmitKeySettings';
 import { useMyProfile } from './useMyProfile';
 
 export const SettingsPage = () => {
@@ -15,7 +16,7 @@ export const SettingsPage = () => {
         <div className='flex flex-col gap-1'>
           <h1 className='text-std-22B-150 text-solid-gray-900'>アカウント設定</h1>
           <p className='text-dns-16N-170 text-solid-gray-700'>
-            表示名（姓名）とパスワードを変更できます。
+            表示名（姓名）とパスワード、プロンプト入力の送信キーを変更できます。
           </p>
         </div>
 
@@ -60,6 +61,16 @@ export const SettingsPage = () => {
             </section>
           </>
         )}
+
+        <section className='flex flex-col gap-4 rounded-8 border border-solid-gray-300 bg-white p-5'>
+          <div className='flex flex-col gap-1'>
+            <h2 className='text-std-18B-160 text-solid-gray-900'>入力</h2>
+            <p className='text-dns-14N-130 text-solid-gray-600'>
+              チャットや文章生成など、プロンプトを送るときのキーです。この端末に保存されます。
+            </p>
+          </div>
+          <SubmitKeySettings />
+        </section>
       </div>
     </LayoutBody>
   );

--- a/genai-web/packages/web/src/open-genai/settings/SettingsPage.tsx
+++ b/genai-web/packages/web/src/open-genai/settings/SettingsPage.tsx
@@ -7,7 +7,7 @@ import { SubmitKeySettings } from './components/SubmitKeySettings';
 import { useMyProfile } from './useMyProfile';
 
 export const SettingsPage = () => {
-  const { profile, error, isLoading, mutate } = useMyProfile();
+  const { profile, isLoading, mutate } = useMyProfile();
 
   return (
     <LayoutBody>
@@ -16,19 +16,15 @@ export const SettingsPage = () => {
         <div className='flex flex-col gap-1'>
           <h1 className='text-std-22B-150 text-solid-gray-900'>アカウント設定</h1>
           <p className='text-dns-16N-170 text-solid-gray-700'>
-            表示名（姓名）とパスワード、プロンプト入力の送信キーを変更できます。
+            {profile
+              ? '表示名（姓名）とパスワード、プロンプト入力の送信キーを変更できます。'
+              : 'プロンプト入力の送信キーを変更できます。'}
           </p>
         </div>
 
         {isLoading && (
           <div className='py-6'>
             <ProgressIndicator label='設定を読み込み中...' />
-          </div>
-        )}
-
-        {!isLoading && error && (
-          <div className='rounded-8 border border-amber-300 bg-amber-50 px-4 py-3 text-dns-14N-130 text-solid-gray-800'>
-            設定情報を取得できませんでした。時間をおいて再度お試しください。
           </div>
         )}
 

--- a/genai-web/packages/web/src/open-genai/settings/components/SubmitKeySettings.tsx
+++ b/genai-web/packages/web/src/open-genai/settings/components/SubmitKeySettings.tsx
@@ -1,0 +1,28 @@
+import { Radio } from '@/components/ui/dads/Radio';
+import { useSubmitKey } from '@/hooks/useSubmitKey';
+import { SUBMIT_KEY_OPTIONS, type SubmitKey } from '@/utils/keyboard';
+
+export const SubmitKeySettings = () => {
+  const { key, setKey } = useSubmitKey();
+
+  return (
+    <fieldset className='flex flex-col gap-1 border-0 p-0 m-0'>
+      <legend className='sr-only'>送信キー</legend>
+      {SUBMIT_KEY_OPTIONS.map((opt) => (
+        <Radio
+          key={opt.value}
+          name='submitKey'
+          value={opt.value}
+          size='md'
+          checked={key === opt.value}
+          onChange={() => setKey(opt.value as SubmitKey)}
+        >
+          <span className='flex flex-col gap-0.5'>
+            <span>{opt.label}</span>
+            <span className='text-dns-14N-130 text-solid-gray-600'>{opt.description}</span>
+          </span>
+        </Radio>
+      ))}
+    </fieldset>
+  );
+};

--- a/genai-web/packages/web/src/utils/keyboard.ts
+++ b/genai-web/packages/web/src/utils/keyboard.ts
@@ -1,4 +1,32 @@
-type SubmitKeyEvent = Pick<KeyboardEvent, 'key' | 'shiftKey'> & {
+export const SUBMIT_KEY_STORAGE = 'submitKey';
+
+export type SubmitKey = 'enter' | 'shiftEnter' | 'ctrlEnter';
+
+export const DEFAULT_SUBMIT_KEY: SubmitKey = 'enter';
+
+export const SUBMIT_KEY_OPTIONS: {
+  value: SubmitKey;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: 'enter',
+    label: 'Enter で送信',
+    description: 'Shift+Enter で改行',
+  },
+  {
+    value: 'shiftEnter',
+    label: 'Shift+Enter で送信',
+    description: 'Enter で改行',
+  },
+  {
+    value: 'ctrlEnter',
+    label: 'Ctrl+Enter で送信（Mac は ⌘+Enter）',
+    description: 'Enter で改行',
+  },
+];
+
+type SubmitKeyEvent = Pick<KeyboardEvent, 'key' | 'shiftKey' | 'ctrlKey' | 'metaKey'> & {
   isComposing?: boolean;
   nativeEvent?: { isComposing?: boolean };
 };
@@ -8,20 +36,74 @@ type SubmitKeyDownEvent = SubmitKeyEvent & {
   currentTarget: { form?: HTMLFormElement | null };
 };
 
-/** 入力欄のショートカット案内文 */
-export const submitKeyHint = 'Enter で送信 / Shift+Enter で改行';
-
-/** Enter で送信（IME 変換確定中・Shift+Enter の改行は除外） */
-export const isSubmitKey = (e: SubmitKeyEvent): boolean => {
-  const isComposing = e.isComposing ?? e.nativeEvent?.isComposing ?? false;
-  return e.key === 'Enter' && !e.shiftKey && !isComposing;
+export const parseSubmitKey = (raw: string | null | undefined): SubmitKey => {
+  if (raw === 'shiftEnter' || raw === 'ctrlEnter' || raw === 'enter') {
+    return raw;
+  }
+  return DEFAULT_SUBMIT_KEY;
 };
 
-/** Enter で所属フォームを送信する（Shift+Enter・IME 変換中は何もしない） */
-export const requestSubmitOnEnter = (e: SubmitKeyDownEvent): void => {
-  if (!isSubmitKey(e)) {
+export const readSubmitKey = (): SubmitKey => {
+  try {
+    return parseSubmitKey(globalThis.localStorage?.getItem(SUBMIT_KEY_STORAGE));
+  } catch {
+    return DEFAULT_SUBMIT_KEY;
+  }
+};
+
+/** 入力欄のショートカット案内文 */
+export const submitKeyHint = (key: SubmitKey = readSubmitKey()): string => {
+  switch (key) {
+    case 'shiftEnter':
+      return 'Shift+Enter で送信 / Enter で改行';
+    case 'ctrlEnter':
+      return 'Ctrl（⌘）+ Enter で送信 / Enter で改行';
+    default:
+      return 'Enter で送信 / Shift+Enter で改行';
+  }
+};
+
+/** フォーム欄用。設定に依らず現行どおり */
+export const ENTER_SUBMIT_HINT = submitKeyHint('enter');
+
+const isComposingEvent = (e: SubmitKeyEvent): boolean =>
+  e.isComposing ?? e.nativeEvent?.isComposing ?? false;
+
+/** 指定した送信キーか（IME 変換確定中は常に false） */
+export const isSubmitKey = (e: SubmitKeyEvent, key: SubmitKey = readSubmitKey()): boolean => {
+  if (e.key !== 'Enter' || isComposingEvent(e)) {
+    return false;
+  }
+  const shift = Boolean(e.shiftKey);
+  const ctrl = Boolean(e.ctrlKey);
+  const meta = Boolean(e.metaKey);
+  switch (key) {
+    case 'shiftEnter':
+      return shift && !ctrl && !meta;
+    case 'ctrlEnter':
+      return (ctrl || meta) && !shift;
+    default:
+      return !shift && !ctrl && !meta;
+  }
+};
+
+/** フォーム固定。Enter で送信（IME・Shift+Enter は除外） */
+export const isEnterSubmitKey = (e: SubmitKeyEvent): boolean => isSubmitKey(e, 'enter');
+
+const requestSubmitOn = (e: SubmitKeyDownEvent, key: SubmitKey): void => {
+  if (!isSubmitKey(e, key)) {
     return;
   }
   e.preventDefault();
   e.currentTarget.form?.requestSubmit();
+};
+
+/** プロンプト入力。アカウント設定の送信キーに従う */
+export const requestSubmitOnEnter = (e: SubmitKeyDownEvent): void => {
+  requestSubmitOn(e, readSubmitKey());
+};
+
+/** フォーム欄。設定に依らず Enter で送信 */
+export const requestEnterSubmit = (e: SubmitKeyDownEvent): void => {
+  requestSubmitOn(e, 'enter');
 };

--- a/genai-web/packages/web/tests/features/chat/ChatInput.test.tsx
+++ b/genai-web/packages/web/tests/features/chat/ChatInput.test.tsx
@@ -93,10 +93,18 @@ vi.mock('@/components/ui/icons/SendIcon', () => ({
   SendIcon: () => <span />,
 }));
 
+vi.mock('@/hooks/useSubmitKey', () => ({
+  useSubmitKey: () => ({
+    key: 'enter',
+    setKey: () => {},
+    hint: 'Enter で送信 / Shift+Enter で改行',
+  }),
+}));
+
 vi.mock('@/utils/keyboard', () => ({
   isSubmitKey: () => false,
   requestSubmitOnEnter: () => {},
-  submitKeyHint: 'Enter で送信 / Shift+Enter で改行',
+  submitKeyHint: () => 'Enter で送信 / Shift+Enter で改行',
 }));
 
 const defaultProps = {

--- a/genai-web/packages/web/tests/utils/keyboard.test.ts
+++ b/genai-web/packages/web/tests/utils/keyboard.test.ts
@@ -4,44 +4,79 @@ const createKeyEvent = (
   overrides: Partial<{
     key: string;
     shiftKey: boolean;
+    ctrlKey: boolean;
+    metaKey: boolean;
     isComposing: boolean;
     nativeEvent: { isComposing?: boolean };
   }> = {},
 ) => ({
   key: 'Enter',
   shiftKey: false,
+  ctrlKey: false,
+  metaKey: false,
   ...overrides,
 });
 
 describe('keyboard utils', () => {
   beforeEach(() => {
     vi.resetModules();
+    localStorage.clear();
   });
 
-  it('submitKeyHint はショートカット案内を返す', async () => {
-    const { submitKeyHint } = await import('../../src/utils/keyboard');
-    expect(submitKeyHint).toBe('Enter で送信 / Shift+Enter で改行');
+  it('submitKeyHint の既定は現行の Enter 送信', async () => {
+    const { submitKeyHint, ENTER_SUBMIT_HINT } = await import('../../src/utils/keyboard');
+    expect(submitKeyHint()).toBe('Enter で送信 / Shift+Enter で改行');
+    expect(ENTER_SUBMIT_HINT).toBe('Enter で送信 / Shift+Enter で改行');
+    expect(submitKeyHint('shiftEnter')).toBe('Shift+Enter で送信 / Enter で改行');
+    expect(submitKeyHint('ctrlEnter')).toBe('Ctrl（⌘）+ Enter で送信 / Enter で改行');
   });
 
-  it('Enter のみで isSubmitKey が true を返す', async () => {
+  it('未設定では Enter のみで isSubmitKey が true', async () => {
     const { isSubmitKey } = await import('../../src/utils/keyboard');
     expect(isSubmitKey(createKeyEvent())).toBe(true);
   });
 
-  it('Shift+Enter で isSubmitKey が false を返す', async () => {
+  it('未設定では Shift+Enter で isSubmitKey が false', async () => {
     const { isSubmitKey } = await import('../../src/utils/keyboard');
     expect(isSubmitKey(createKeyEvent({ shiftKey: true }))).toBe(false);
   });
 
-  it('IME 変換中（isComposing）は isSubmitKey が false を返す', async () => {
+  it('shiftEnter では Shift+Enter だけ送信', async () => {
+    const { isSubmitKey } = await import('../../src/utils/keyboard');
+    expect(isSubmitKey(createKeyEvent(), 'shiftEnter')).toBe(false);
+    expect(isSubmitKey(createKeyEvent({ shiftKey: true }), 'shiftEnter')).toBe(true);
+    expect(isSubmitKey(createKeyEvent({ ctrlKey: true }), 'shiftEnter')).toBe(false);
+  });
+
+  it('ctrlEnter では Ctrl または ⌘ + Enter だけ送信', async () => {
+    const { isSubmitKey } = await import('../../src/utils/keyboard');
+    expect(isSubmitKey(createKeyEvent(), 'ctrlEnter')).toBe(false);
+    expect(isSubmitKey(createKeyEvent({ ctrlKey: true }), 'ctrlEnter')).toBe(true);
+    expect(isSubmitKey(createKeyEvent({ metaKey: true }), 'ctrlEnter')).toBe(true);
+    expect(isSubmitKey(createKeyEvent({ ctrlKey: true, shiftKey: true }), 'ctrlEnter')).toBe(false);
+  });
+
+  it('IME 変換中はどのモードでも isSubmitKey が false', async () => {
     const { isSubmitKey } = await import('../../src/utils/keyboard');
     expect(isSubmitKey(createKeyEvent({ isComposing: true }))).toBe(false);
-    expect(isSubmitKey(createKeyEvent({ nativeEvent: { isComposing: true } }))).toBe(false);
+    expect(isSubmitKey(createKeyEvent({ nativeEvent: { isComposing: true } }), 'shiftEnter')).toBe(
+      false,
+    );
+    expect(isSubmitKey(createKeyEvent({ ctrlKey: true, isComposing: true }), 'ctrlEnter')).toBe(
+      false,
+    );
   });
 
   it('Enter 以外のキーで isSubmitKey が false を返す', async () => {
     const { isSubmitKey } = await import('../../src/utils/keyboard');
     expect(isSubmitKey(createKeyEvent({ key: 'a' }))).toBe(false);
+  });
+
+  it('isEnterSubmitKey は設定に依らず Enter 送信', async () => {
+    const { isEnterSubmitKey, SUBMIT_KEY_STORAGE } = await import('../../src/utils/keyboard');
+    localStorage.setItem(SUBMIT_KEY_STORAGE, 'ctrlEnter');
+    expect(isEnterSubmitKey(createKeyEvent())).toBe(true);
+    expect(isEnterSubmitKey(createKeyEvent({ ctrlKey: true }))).toBe(false);
   });
 
   it('requestSubmitOnEnter は Enter で preventDefault と requestSubmit を呼ぶ', async () => {
@@ -68,5 +103,19 @@ describe('keyboard utils', () => {
     });
     expect(preventDefault).not.toHaveBeenCalled();
     expect(requestSubmit).not.toHaveBeenCalled();
+  });
+
+  it('requestEnterSubmit は localStorage が ctrlEnter でも Enter で送信する', async () => {
+    const { requestEnterSubmit, SUBMIT_KEY_STORAGE } = await import('../../src/utils/keyboard');
+    localStorage.setItem(SUBMIT_KEY_STORAGE, 'ctrlEnter');
+    const preventDefault = vi.fn();
+    const requestSubmit = vi.fn();
+    requestEnterSubmit({
+      ...createKeyEvent(),
+      preventDefault,
+      currentTarget: { form: { requestSubmit } as unknown as HTMLFormElement },
+    });
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(requestSubmit).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- プロンプト送信キーを Enter / Shift+Enter / Ctrl+Enter（Mac は ⌘+Enter）から選べる
- 既定は現行の Enter 送信。選んだ組み合わせは入力欄に常時表示する
- 適用はチャット・文章生成・翻訳・画像・ダイアグラム・exApp 会話。フォーム欄とシステムプロンプトは Enter 送信のまま
- 運用者（Keycloak にいない）でもアカウント設定の「入力」だけ見え、プロフィール失敗の帯は出さない

## Test plan
- [ ] 未設定では Enter で送信、Shift+Enter で改行のまま
- [ ] アカウント設定で送信キーを変えると、チャット等の入力欄の案内が追従する
- [ ] 運用者ログインでアカウント設定を開くと黄色い帯は出ず、送信キーだけ選べる
- [ ] Keycloak 利用者では姓名・パスワードと送信キーの両方が見える
- [ ] IME 変換確定の Enter では送信しない
- [ ] exApp フォーム／システムプロンプトは設定に依らず Enter 送信


Made with [Cursor](https://cursor.com)